### PR TITLE
fix: PopToRoot doesn't clear PageStack

### DIFF
--- a/Sample/SextantSample/ViewModels/RedViewModel.cs
+++ b/Sample/SextantSample/ViewModels/RedViewModel.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Windows.Input;
 using ReactiveUI;
 using Sextant;
 
@@ -9,27 +10,17 @@ namespace SextantSample.ViewModels
 {
 	public class RedViewModel : ViewModelBase, IPageViewModel
 	{
-		public ReactiveCommand<Unit, Unit> PopModal
-		{
-			get;
-			set;
-		}
+	    public ReactiveCommand<Unit, Unit> PopModal { get; set; }
 
-        public ReactiveCommand<Unit, Unit> PushPage
-        {
-            get;
-            set;
-        }
+	    public ReactiveCommand<Unit, Unit> PushPage { get; set; }
 
-        public ReactiveCommand<Unit, Unit> PopPage
-        {
-            get;
-            set;
-        }
+	    public ReactiveCommand<Unit, Unit> PopPage { get; set; }
 
-		public string Id => nameof(RedViewModel);
+	    public ReactiveCommand<Unit, Unit> PopToRoot { get; set; }
 
-		public RedViewModel(IViewStackService viewStackService) : base(viewStackService)
+        public string Id => nameof(RedViewModel);
+
+	    public RedViewModel(IViewStackService viewStackService) : base(viewStackService)
 		{
 			PopModal = ReactiveCommand
 				.CreateFromObservable(() =>
@@ -45,8 +36,12 @@ namespace SextantSample.ViewModels
                 .CreateFromObservable(() =>
                     this.ViewStackService.PushPage(new RedViewModel(ViewStackService)),
                     outputScheduler: RxApp.MainThreadScheduler);
+		    PopToRoot = ReactiveCommand
+                .CreateFromObservable(() => 
+                    this.ViewStackService.PopToRootPage(),
+		            outputScheduler: RxApp.MainThreadScheduler);
 
-			PopModal.Subscribe(x => Debug.WriteLine("PagePushed"));
+            PopModal.Subscribe(x => Debug.WriteLine("PagePushed"));
 		}
 	}
 }

--- a/Sample/SextantSample/Views/RedView.xaml
+++ b/Sample/SextantSample/Views/RedView.xaml
@@ -11,6 +11,7 @@
             <Button x:Name="PopModal" Text="Pop Modal" TextColor="White"/>
             <Button x:Name="PushPage" Text="Push Another Red Page" TextColor="White"/>
             <Button x:Name="PopPage" Text="Pop Page" TextColor="White"/>
+            <Button x:Name="PopToRoot" Text="Pop To Root" TextColor="White"/>
         </StackLayout>
     </ContentPage.Content>
 </rxui:ReactiveContentPage>

--- a/Sample/SextantSample/Views/RedView.xaml.cs
+++ b/Sample/SextantSample/Views/RedView.xaml.cs
@@ -13,6 +13,7 @@ namespace SextantSample.Views
 			this.BindCommand(ViewModel, x => x.PopModal, x => x.PopModal);
             this.BindCommand(ViewModel, x => x.PushPage, x => x.PushPage);
             this.BindCommand(ViewModel, x => x.PopPage, x => x.PopPage);
+            this.BindCommand(ViewModel, x => x.PopToRoot, x => x.PopToRoot);
         }
     }
 }

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -32,6 +32,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="0.3.18" />
     <PackageReference Include="Shouldly" Version=" 3.0.2" />
+    <PackageReference Include="ReactiveUI.Testing" Version="9.14.1" />
     <PackageReference Include="PublicApiGenerator" Version="8.1.0" />
     <PackageReference Include="NSubstitute" Version="4.0.0" />
   </ItemGroup>

--- a/src/Sextant.Tests/Mocks/PageViewModelMock.cs
+++ b/src/Sextant.Tests/Mocks/PageViewModelMock.cs
@@ -22,6 +22,11 @@ namespace Sextant.Tests
         }
 
         /// <summary>
+        /// Gets the mock.
+        /// </summary>
+        public static PageViewModelMock Mock { get; } = new PageViewModelMock();
+
+        /// <summary>
         /// Gets the ID of the page.
         /// </summary>
         public string Id => _id ?? nameof(PageViewModelMock);

--- a/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
@@ -6,32 +6,30 @@
 using System.Reactive;
 using System.Reactive.Linq;
 using NSubstitute;
+using ReactiveUI.Testing;
 
 namespace Sextant.Tests.Navigation
 {
     /// <summary>
     /// A fixture for the view stack.
     /// </summary>
-    internal sealed class ViewStackServiceFixture
+    internal sealed class ViewStackServiceFixture : IBuilder
     {
+        private IView _view;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewStackServiceFixture"/> class.
         /// </summary>
         public ViewStackServiceFixture()
         {
-            View = Substitute.For<IView>();
-            View.PushPage(Arg.Any<IPageViewModel>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>()).Returns(Observable.Return(Unit.Default));
-            ViewStackService = new ViewStackService(View);
+            _view = Substitute.For<IView>();
+            _view.PushPage(Arg.Any<IPageViewModel>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>()).Returns(Observable.Return(Unit.Default));
         }
 
-        /// <summary>
-        /// Gets the view.
-        /// </summary>
-        public IView View { get; }
+        public static implicit operator ViewStackService(ViewStackServiceFixture fixture) => fixture.Build();
 
-        /// <summary>
-        /// Gets the view stack service.
-        /// </summary>
-        public IViewStackService ViewStackService { get; }
+        public ViewStackServiceFixture WithView(IView view) => this.With(ref _view, view);
+
+        private ViewStackService Build() => new ViewStackService(_view);
     }
 }

--- a/src/Sextant.Tests/Navigation/ViewStackServiceFixtureExtensions.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceFixtureExtensions.cs
@@ -14,41 +14,41 @@ namespace Sextant.Tests.Navigation
     /// </summary>
     internal static class ViewStackServiceFixtureExtensions
     {
-        public static IObservable<Unit> PopModal(this ViewStackServiceFixture viewStackServiceFixture, int pages = 1)
+        public static IObservable<Unit> PopModal(this ViewStackService viewStackService, int pages = 1)
         {
             for (var i = 0; i < pages; i++)
             {
-                viewStackServiceFixture.ViewStackService.PopModal().Subscribe();
+                viewStackService.PopModal().Subscribe();
             }
 
             return Observable.Return(Unit.Default);
         }
 
-        public static IObservable<Unit> PopPage(this ViewStackServiceFixture viewStackServiceFixture, int pages = 1)
+        public static IObservable<Unit> PopPage(this ViewStackService viewStackService, int pages = 1)
         {
             for (var i = 0; i < pages; i++)
             {
-                viewStackServiceFixture.ViewStackService.PopPage().Subscribe();
+                viewStackService.PopPage().Subscribe();
             }
 
             return Observable.Return(Unit.Default);
         }
 
-        public static IObservable<Unit> PushModal(this ViewStackServiceFixture viewStackServiceFixture, IPageViewModel viewModel, string contract = null, int pages = 1)
+        public static IObservable<Unit> PushModal(this ViewStackService viewStackService, IPageViewModel viewModel, string contract = null, int pages = 1)
         {
             for (var i = 0; i < pages; i++)
             {
-                viewStackServiceFixture.ViewStackService.PushModal(viewModel, contract).Subscribe();
+                viewStackService.PushModal(viewModel, contract).Subscribe();
             }
 
             return Observable.Return(Unit.Default);
         }
 
-        public static IObservable<Unit> PushPage(this ViewStackServiceFixture viewStackServiceFixture, IPageViewModel viewModel, string contract = null, int pages = 1)
+        public static IObservable<Unit> PushPage(this ViewStackService viewStackService, IPageViewModel viewModel, string contract = null, int pages = 1)
         {
             for (var i = 0; i < pages; i++)
             {
-                viewStackServiceFixture.ViewStackService.PushPage(viewModel, contract).Subscribe();
+                viewStackService.PushPage(viewModel, contract).Subscribe();
             }
 
             return Observable.Return(Unit.Default);

--- a/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
@@ -432,7 +432,7 @@ namespace Sextant.Tests.Navigation
                 var result = await Should.ThrowAsync<ArgumentNullException>(async () => await sut.PushPage(null)).ConfigureAwait(false);
 
                 // Then
-                result.Message.ShouldBe("Value cannot be null.\r\nParameter name: page");
+                result.ParamName.ShouldBe("page");
             }
 
             /// <summary>

--- a/src/Sextant/Sextant.csproj
+++ b/src/Sextant/Sextant.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;Xamarin.iOS10</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Sextant</AssemblyName>
     <RootNamespace>Sextant</RootNamespace>
     <PackageId>Sextant</PackageId>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Added some test coverage and fixed a few issues

- ViewStackService properties now properly return observables
- PopToRoot will now notify that it has popped an item from the stack
- PopToRoot will now clear the stack after it has completed

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Resolves: #57 

**What is the new behavior?**
<!-- If this is a feature change -->

`PopToRoot` clears the `ViewStackService.PageStack`

**What might this PR break?**

Nothing

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
