### PR TITLE
housekeeping: Added Error Interactions to Sextant Sample

### DIFF
--- a/Sample/SextantSample/Interactions.cs
+++ b/Sample/SextantSample/Interactions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using ReactiveUI;
+
+namespace SextantSample
+{
+    public static class Interactions
+    {
+        public static Interaction<Exception, bool> ErrorMessage = new Interaction<Exception, bool>();
+    }
+}

--- a/Sample/SextantSample/ViewModels/FirstModalViewModel.cs
+++ b/Sample/SextantSample/ViewModels/FirstModalViewModel.cs
@@ -36,7 +36,7 @@ namespace SextantSample.ViewModels
 
 			OpenModal.Subscribe(x => Debug.WriteLine("PagePushed"));
 			PopModal.Subscribe(x => Debug.WriteLine("PagePoped"));
-
-		}
+		    PopModal.ThrownExceptions.Subscribe(error => Interactions.ErrorMessage.Handle(error).Subscribe());
+        }
 	}
 }

--- a/Sample/SextantSample/ViewModels/HomeViewModel.cs
+++ b/Sample/SextantSample/ViewModels/HomeViewModel.cs
@@ -38,6 +38,9 @@ namespace SextantSample.ViewModels
                     outputScheduler: RxApp.MainThreadScheduler);
 
             OpenModal.Subscribe(x => Debug.WriteLine("PagePushed"));
+
+            PushPage.ThrownExceptions.Subscribe(error => Interactions.ErrorMessage.Handle(error).Subscribe());
+            OpenModal.ThrownExceptions.Subscribe(error => Interactions.ErrorMessage.Handle(error).Subscribe());
         }
     }
 }

--- a/Sample/SextantSample/ViewModels/RedViewModel.cs
+++ b/Sample/SextantSample/ViewModels/RedViewModel.cs
@@ -42,6 +42,10 @@ namespace SextantSample.ViewModels
 		            outputScheduler: RxApp.MainThreadScheduler);
 
             PopModal.Subscribe(x => Debug.WriteLine("PagePushed"));
-		}
+		    PopModal.ThrownExceptions.Subscribe(error => Interactions.ErrorMessage.Handle(error).Subscribe());
+		    PopPage.ThrownExceptions.Subscribe(error => Interactions.ErrorMessage.Handle(error).Subscribe());
+		    PushPage.ThrownExceptions.Subscribe(error => Interactions.ErrorMessage.Handle(error).Subscribe());
+		    PopToRoot.ThrownExceptions.Subscribe(error => Interactions.ErrorMessage.Handle(error).Subscribe());
+        }
 	}
 }

--- a/Sample/SextantSample/ViewModels/SecondModalViewModel.cs
+++ b/Sample/SextantSample/ViewModels/SecondModalViewModel.cs
@@ -3,6 +3,7 @@ using ReactiveUI;
 using System;
 using System.Diagnostics;
 using Sextant;
+using System.Reactive.Linq;
 
 namespace SextantSample.ViewModels
 {
@@ -37,6 +38,8 @@ namespace SextantSample.ViewModels
             PushPage.Subscribe(x => Debug.WriteLine("PagePushed"));
 			PopModal.Subscribe(x => Debug.WriteLine("PagePoped"));
 
-		}
+		    PushPage.ThrownExceptions.Subscribe(error => Interactions.ErrorMessage.Handle(error).Subscribe());
+		    PopModal.ThrownExceptions.Subscribe(error => Interactions.ErrorMessage.Handle(error).Subscribe());
+        }
 	}
 }

--- a/Sample/SextantSample/Views/FirstModalView.xaml.cs
+++ b/Sample/SextantSample/Views/FirstModalView.xaml.cs
@@ -13,6 +13,14 @@ namespace SextantSample.Views
 			InitializeComponent();
 			this.BindCommand(ViewModel, x => x.OpenModal, x => x.OpenSecondModal);
 			this.BindCommand(ViewModel, x => x.PopModal, x => x.PopModal);
+
+            Interactions
+                .ErrorMessage
+                .RegisterHandler(async x =>
+                {
+                    await DisplayAlert("Error", x.Input.Message, "Done");
+                    x.SetOutput(true);
+                });
         }
     }
 }

--- a/Sample/SextantSample/Views/HomeView.xaml.cs
+++ b/Sample/SextantSample/Views/HomeView.xaml.cs
@@ -17,6 +17,14 @@ namespace SextantSample.Views
 				this.BindCommand(ViewModel, x => x.OpenModal, x => x.FirstModalButton).DisposeWith(disposables);
                 this.BindCommand(ViewModel, x => x.PushPage, x => x.PushPage);
             });
+
+            Interactions
+                .ErrorMessage
+                .RegisterHandler(async x =>
+                {
+                    await DisplayAlert("Error", x.Input.Message, "Done");
+                    x.SetOutput(true);
+                });
         }
     }
 }

--- a/Sample/SextantSample/Views/RedView.xaml.cs
+++ b/Sample/SextantSample/Views/RedView.xaml.cs
@@ -14,6 +14,14 @@ namespace SextantSample.Views
             this.BindCommand(ViewModel, x => x.PushPage, x => x.PushPage);
             this.BindCommand(ViewModel, x => x.PopPage, x => x.PopPage);
             this.BindCommand(ViewModel, x => x.PopToRoot, x => x.PopToRoot);
+
+            Interactions
+                .ErrorMessage
+                .RegisterHandler(async x =>
+                {
+                    await DisplayAlert("Error", x.Input.Message, "Done");
+                    x.SetOutput(true);
+                });
         }
     }
 }

--- a/Sample/SextantSample/Views/SecondModalView.xaml.cs
+++ b/Sample/SextantSample/Views/SecondModalView.xaml.cs
@@ -12,6 +12,14 @@ namespace SextantSample.Views
             InitializeComponent();
 			this.BindCommand(ViewModel, x => x.PushPage, x => x.PushPage);
             this.BindCommand(ViewModel, x => x.PopModal, x => x.PopModal);
+
+            Interactions
+                .ErrorMessage
+                .RegisterHandler(async x =>
+                {
+                    await DisplayAlert("Error", x.Input.Message, "Done");
+                    x.SetOutput(true);
+                });
         }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Adds interactions to display error messages.  Just a nicety to show off **a** use for Interactions from the ReactiveUI framework.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->
The sample will crash if you hit an unexpected error.


**What is the new behavior?**
<!-- If this is a feature change -->

The sample will display the `Message` portion of an Exception thrown from a ReactiveCommand


**What might this PR break?**

Samples

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

