### PR TITLE
fix: IParameterViewStackService extends IViewStackService

### DIFF
--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
@@ -28,7 +28,7 @@ namespace Sextant
     public interface INavigationParameter : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable { }
     [System.ObsoleteAttribute("Please use the IViewModel interface.")]
     public interface IPageViewModel : Sextant.IViewModel { }
-    public interface IParameterViewStackService
+    public interface IParameterViewStackService : Sextant.IViewStackService
     {
         System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = True);
         System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable modal, Sextant.INavigationParameter parameter, string contract = null);
@@ -65,7 +65,7 @@ namespace Sextant
     {
         public NavigationParameter() { }
     }
-    public sealed class ParameterViewStackService : Sextant.ViewStackServiceBase, Sextant.IParameterViewStackService
+    public sealed class ParameterViewStackService : Sextant.ViewStackServiceBase, Sextant.IParameterViewStackService, Sextant.IViewStackService
     {
         public ParameterViewStackService(Sextant.IView view) { }
         public System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = True) { }

--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
@@ -28,7 +28,7 @@ namespace Sextant
     public interface INavigationParameter : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable { }
     [System.ObsoleteAttribute("Please use the IViewModel interface.")]
     public interface IPageViewModel : Sextant.IViewModel { }
-    public interface IParameterViewStackService
+    public interface IParameterViewStackService : Sextant.IViewStackService
     {
         System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = True);
         System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable modal, Sextant.INavigationParameter parameter, string contract = null);
@@ -65,7 +65,7 @@ namespace Sextant
     {
         public NavigationParameter() { }
     }
-    public sealed class ParameterViewStackService : Sextant.ViewStackServiceBase, Sextant.IParameterViewStackService
+    public sealed class ParameterViewStackService : Sextant.ViewStackServiceBase, Sextant.IParameterViewStackService, Sextant.IViewStackService
     {
         public ParameterViewStackService(Sextant.IView view) { }
         public System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = True) { }

--- a/src/Sextant/Abstractions/IParameterViewStackService.cs
+++ b/src/Sextant/Abstractions/IParameterViewStackService.cs
@@ -11,7 +11,7 @@ namespace Sextant
     /// <summary>
     /// Interface that defines methods for passing parameters on navigation.
     /// </summary>
-    public interface IParameterViewStackService
+    public interface IParameterViewStackService : IViewStackService
     {
         /// <summary>
         /// Pushes the <see cref="INavigable" /> onto the stack.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Extend IParameterViewStackService from IViewStackService

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

It doesn't extend and you cannot use `IViewStackService` methods from the interface.

**What is the new behavior?**
<!-- If this is a feature change -->

You can access `IViewStackService` methods from `IParameterViewStackService`

**What might this PR break?**

Nothing

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

