### PR TITLE
fix: Passing parameters breaking ReactiveUI bindings

### DIFF
--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
@@ -36,6 +36,7 @@ namespace Sextant
     }
     public interface IView
     {
+        System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; }
         System.IObservable<Sextant.IViewModel> PagePopped { get; }
         System.IObservable<System.Reactive.Unit> PopModal();
         System.IObservable<System.Reactive.Unit> PopPage(bool animate = True);

--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
@@ -36,6 +36,7 @@ namespace Sextant
     }
     public interface IView
     {
+        System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; }
         System.IObservable<Sextant.IViewModel> PagePopped { get; }
         System.IObservable<System.Reactive.Unit> PopModal();
         System.IObservable<System.Reactive.Unit> PopPage(bool animate = True);

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -20,7 +20,7 @@ namespace Sextant.Tests
         public class ThePushPageWithParameterMethod
         {
             /// <summary>
-            /// Shoulds the throw if view model null.
+            /// Should the throw if view model null.
             /// </summary>
             /// <returns>A completion notification.</returns>
             [Fact]
@@ -41,7 +41,7 @@ namespace Sextant.Tests
             }
 
             /// <summary>
-            /// Shoulds the throw if view model null.
+            /// Should the throw if view model null.
             /// </summary>
             /// <returns>A completion notification.</returns>
             [Fact]
@@ -125,7 +125,7 @@ namespace Sextant.Tests
         public class ThePushModalWithParameterMethod
         {
             /// <summary>
-            /// Shoulds the throw if view model null.
+            /// Should the throw if view model null.
             /// </summary>
             /// <returns>A completion notification.</returns>
             [Fact]
@@ -146,7 +146,7 @@ namespace Sextant.Tests
             }
 
             /// <summary>
-            /// Shoulds the throw if view model null.
+            /// Should the throw if view model null.
             /// </summary>
             /// <returns>A completion notification.</returns>
             [Fact]
@@ -250,7 +250,7 @@ namespace Sextant.Tests
         public class ThePopPageWithParameterMethod
         {
             /// <summary>
-            /// Shoulds the throw if view model null.
+            /// Should the throw if view model null.
             /// </summary>
             /// <returns>A completion notification.</returns>
             [Fact]

--- a/src/Sextant.XamForms.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
+++ b/src/Sextant.XamForms.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
@@ -14,6 +14,7 @@ namespace Sextant.XamForms
     {
         public NavigationView(System.Reactive.Concurrency.IScheduler mainScheduler, System.Reactive.Concurrency.IScheduler backgroundScheduler, ReactiveUI.IViewLocator viewLocator, Xamarin.Forms.Page rootPage) { }
         public NavigationView(System.Reactive.Concurrency.IScheduler mainScheduler, System.Reactive.Concurrency.IScheduler backgroundScheduler, ReactiveUI.IViewLocator viewLocator) { }
+        public System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; }
         public System.IObservable<Sextant.IViewModel> PagePopped { get; }
         public System.IObservable<System.Reactive.Unit> PopModal() { }
         public System.IObservable<System.Reactive.Unit> PopPage(bool animate) { }

--- a/src/Sextant.XamForms.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
+++ b/src/Sextant.XamForms.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
@@ -14,6 +14,7 @@ namespace Sextant.XamForms
     {
         public NavigationView(System.Reactive.Concurrency.IScheduler mainScheduler, System.Reactive.Concurrency.IScheduler backgroundScheduler, ReactiveUI.IViewLocator viewLocator, Xamarin.Forms.Page rootPage) { }
         public NavigationView(System.Reactive.Concurrency.IScheduler mainScheduler, System.Reactive.Concurrency.IScheduler backgroundScheduler, ReactiveUI.IViewLocator viewLocator) { }
+        public System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; }
         public System.IObservable<Sextant.IViewModel> PagePopped { get; }
         public System.IObservable<System.Reactive.Unit> PopModal() { }
         public System.IObservable<System.Reactive.Unit> PopPage(bool animate) { }

--- a/src/Sextant.XamForms/NavigationView.cs
+++ b/src/Sextant.XamForms/NavigationView.cs
@@ -65,6 +65,9 @@ namespace Sextant.XamForms
         }
 
         /// <inheritdoc />
+        public IScheduler MainThreadScheduler => _mainScheduler;
+
+        /// <inheritdoc />
         public IObservable<IViewModel> PagePopped { get; }
 
         /// <inheritdoc />

--- a/src/Sextant/Abstractions/IView.cs
+++ b/src/Sextant/Abstractions/IView.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reactive;
+using System.Reactive.Concurrency;
 
 namespace Sextant
 {
@@ -13,6 +14,11 @@ namespace Sextant
     /// </summary>
     public interface IView
     {
+        /// <summary>
+        /// Gets the main thread scheduler for the <see cref="IView"/> instance.
+        /// </summary>
+        IScheduler MainThreadScheduler { get; }
+
         /// <summary>
         /// Gets an observable notifying that a page was popped from the navigation stack.
         /// </summary>

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Text;
+using ReactiveUI;
 
 namespace Sextant
 {
@@ -51,6 +52,7 @@ namespace Sextant
                 {
                     navigableViewModel
                         .WhenNavigatingTo(parameter)
+                        .ObserveOn(RxApp.MainThreadScheduler)
                         .Subscribe(navigating =>
                             Logger.Debug(
                                 $"Called `WhenNavigatingTo` on '{navigableViewModel.Id}' passing parameter {parameter}"));
@@ -60,6 +62,7 @@ namespace Sextant
 
                     navigableViewModel
                         .WhenNavigatedTo(parameter)
+                        .ObserveOn(RxApp.MainThreadScheduler)
                         .Subscribe(navigated =>
                             Logger.Debug(
                                 $"Called `WhenNavigatedTo` on '{navigableViewModel.Id}' passing parameter {parameter}"));
@@ -85,6 +88,7 @@ namespace Sextant
                 {
                     modal
                         .WhenNavigatingTo(parameter)
+                        .ObserveOn(RxApp.MainThreadScheduler)
                         .Subscribe(navigating =>
                             Logger.Debug($"Called `WhenNavigatingTo` on '{modal.Id}' passing parameter {parameter}"));
 
@@ -93,6 +97,7 @@ namespace Sextant
 
                     modal
                         .WhenNavigatedTo(parameter)
+                        .ObserveOn(RxApp.MainThreadScheduler)
                         .Subscribe(navigated =>
                             Logger.Debug($"Called `WhenNavigatedTo` on '{modal.Id}' passing parameter {parameter}"));
                 });
@@ -115,9 +120,9 @@ namespace Sextant
                     {
                         navigable
                             .WhenNavigatedFrom(parameter)
+                            .ObserveOn(RxApp.MainThreadScheduler)
                             .Subscribe(navigated =>
-                                Logger.Debug(
-                                    $"Called `WhenNavigatingTo` on '{navigable.Id}' passing parameter {parameter}"));
+                                Logger.Debug($"Called `WhenNavigatingTo` on '{navigable.Id}' passing parameter {parameter}"));
                     }
                 });
         }

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -52,7 +52,7 @@ namespace Sextant
                 {
                     navigableViewModel
                         .WhenNavigatingTo(parameter)
-                        .ObserveOn(RxApp.MainThreadScheduler)
+                        .ObserveOn(View.MainThreadScheduler)
                         .Subscribe(navigating =>
                             Logger.Debug(
                                 $"Called `WhenNavigatingTo` on '{navigableViewModel.Id}' passing parameter {parameter}"));
@@ -62,7 +62,7 @@ namespace Sextant
 
                     navigableViewModel
                         .WhenNavigatedTo(parameter)
-                        .ObserveOn(RxApp.MainThreadScheduler)
+                        .ObserveOn(View.MainThreadScheduler)
                         .Subscribe(navigated =>
                             Logger.Debug(
                                 $"Called `WhenNavigatedTo` on '{navigableViewModel.Id}' passing parameter {parameter}"));
@@ -88,7 +88,7 @@ namespace Sextant
                 {
                     modal
                         .WhenNavigatingTo(parameter)
-                        .ObserveOn(RxApp.MainThreadScheduler)
+                        .ObserveOn(View.MainThreadScheduler)
                         .Subscribe(navigating =>
                             Logger.Debug($"Called `WhenNavigatingTo` on '{modal.Id}' passing parameter {parameter}"));
 
@@ -97,7 +97,7 @@ namespace Sextant
 
                     modal
                         .WhenNavigatedTo(parameter)
-                        .ObserveOn(RxApp.MainThreadScheduler)
+                        .ObserveOn(View.MainThreadScheduler)
                         .Subscribe(navigated =>
                             Logger.Debug($"Called `WhenNavigatedTo` on '{modal.Id}' passing parameter {parameter}"));
                 });
@@ -120,9 +120,9 @@ namespace Sextant
                     {
                         navigable
                             .WhenNavigatedFrom(parameter)
-                            .ObserveOn(RxApp.MainThreadScheduler)
+                            .ObserveOn(View.MainThreadScheduler)
                             .Subscribe(navigated =>
-                                Logger.Debug($"Called `WhenNavigatingTo` on '{navigable.Id}' passing parameter {parameter}"));
+                                Logger.Debug($"Called `WhenNavigatedFrom` on '{navigable.Id}' passing parameter {parameter}"));
                     }
                 });
         }

--- a/src/Sextant/Platforms/uikit-common/NavigationViewController.cs
+++ b/src/Sextant/Platforms/uikit-common/NavigationViewController.cs
@@ -50,6 +50,9 @@ namespace Sextant
         }
 
         /// <inheritdoc />
+        public IScheduler MainThreadScheduler => _mainScheduler;
+
+        /// <inheritdoc />
         public IObservable<IViewModel> PagePopped => _pagePopped;
 
         /// <inheritdoc />


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

While creating a sample for navigation parameters, I found that ReactiveUI bindings are failing to update.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Bindings are failing.

**What is the new behavior?**
<!-- If this is a feature change -->

I made sure the `INavigable` functions happen on the UI thread.

**What might this PR break?**

Navigation Parameters

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
