### PR TITLE
housekeeping: Source logo from styleguide repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
         <img src="https://img.shields.io/badge/chat-slack-blue.svg">
 </a>
 
-<p align="left"><img src="logo/vertical.png" alt="Sextant" height="180px"></p>
+<p align="left"><img src="https://github.com/reactiveui/styleguide/blob/master/logo_sextant/vertical.png?raw=true" alt="Sextant" height="180px"></p>
 
 ## A ReactiveUI navigation library for Xamarin.Forms
 

--- a/logo/horizontal.png
+++ b/logo/horizontal.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07fcb6972728328c0ddc0f5616e877e30fe4dcf35ad586e8429bbf066af00ad1
-size 172880

--- a/logo/logo.png
+++ b/logo/logo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cadba957141d8f6ab828637c9cca7b50e6f35817cc8e712e35256e0873e80ede
-size 76657

--- a/logo/vertical.png
+++ b/logo/vertical.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04ea8e44cf7c3c5cef63a9d50ba53833b7f2d8c90b5c141b3d8c60061dd92da5
-size 111558

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -3,7 +3,7 @@
     <Copyright>Copyright (c) .NET Foundation and Contributors</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/reactiveui/sextant/</PackageProjectUrl>
-    <PackageIconUrl>https://github.com/reactiveui/Sextant/blob/master/logo/logo.png?raw=true</PackageIconUrl>
+    <PackageIconUrl>https://github.com/reactiveui/styleguide/blob/master/logo_sextant/logo.png?raw=true</PackageIconUrl>
     <Authors>.NET Foundation and Contributors</Authors>
     <Owners>xpaulbettsx;ghuntley</Owners>
     <PackageTags>mvvm;reactiveui;Rx;Reactive Extensions;Observable;xamarin;xamarin ios;xamarin mac;android;monodroid;uwp;net461</PackageTags>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Sourcing images for Sextant from the styleguide repository.

**What is the current behavior?**
Logos exist in the Sextant repository.



**What is the new behavior?**
Sextant logos exist in the styleguide repository.



**What might this PR break?**
 Images on NuGet packages.

