### PR TITLE
housekeeping: Added dotnet sdk version to global.json

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -1,4 +1,7 @@
 {
+    "sdk": {
+        "version": "3.0.100-preview"
+      },
     "msbuild-sdks": {
         "MSBuild.Sdk.Extras": "1.6.68"
     }

--- a/src/global.json
+++ b/src/global.json
@@ -3,6 +3,6 @@
         "version": "3.0.100-preview"
       },
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.68"
+        "MSBuild.Sdk.Extras": "2.0.31"
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds dotnet sdk version to the global.json as outlined in the [MsBuild.Sdk.Extras documentation](https://github.com/onovotny/MSBuildSdkExtras#getting-started-vs-156).

**What is the current behavior?**
The build is broken

**What is the new behavior?**
The build is working.


**What might this PR break?**
Nothing the build is already broke.
