### PR TITLE
feature: Added default NavigationView constructor

### DIFF
--- a/src/Sextant.XamForms.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
+++ b/src/Sextant.XamForms.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
@@ -12,6 +12,7 @@ namespace Sextant.XamForms
     }
     public class NavigationView : Xamarin.Forms.NavigationPage, Sextant.IView, Splat.IEnableLogger
     {
+        public NavigationView() { }
         public NavigationView(System.Reactive.Concurrency.IScheduler mainScheduler, System.Reactive.Concurrency.IScheduler backgroundScheduler, ReactiveUI.IViewLocator viewLocator, Xamarin.Forms.Page rootPage) { }
         public NavigationView(System.Reactive.Concurrency.IScheduler mainScheduler, System.Reactive.Concurrency.IScheduler backgroundScheduler, ReactiveUI.IViewLocator viewLocator) { }
         public System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; }

--- a/src/Sextant.XamForms.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
+++ b/src/Sextant.XamForms.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
@@ -12,6 +12,7 @@ namespace Sextant.XamForms
     }
     public class NavigationView : Xamarin.Forms.NavigationPage, Sextant.IView, Splat.IEnableLogger
     {
+        public NavigationView() { }
         public NavigationView(System.Reactive.Concurrency.IScheduler mainScheduler, System.Reactive.Concurrency.IScheduler backgroundScheduler, ReactiveUI.IViewLocator viewLocator, Xamarin.Forms.Page rootPage) { }
         public NavigationView(System.Reactive.Concurrency.IScheduler mainScheduler, System.Reactive.Concurrency.IScheduler backgroundScheduler, ReactiveUI.IViewLocator viewLocator) { }
         public System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; }

--- a/src/Sextant.XamForms/NavigationView.cs
+++ b/src/Sextant.XamForms/NavigationView.cs
@@ -23,7 +23,15 @@ namespace Sextant.XamForms
         private readonly IScheduler _backgroundScheduler;
         private readonly IScheduler _mainScheduler;
         private readonly IViewLocator _viewLocator;
-        private IFullLogger _logger;
+        private readonly IFullLogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NavigationView"/> class.
+        /// </summary>
+        public NavigationView()
+            : this(RxApp.MainThreadScheduler, RxApp.TaskpoolScheduler, ViewLocator.Current)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NavigationView"/> class.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Adds a default `NavigationView()` constructor for the Xamarin Forms implementation.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

You currently have to provide `RxApp.MainThreadScheduler`, `RxApp.TaskpoolScheduler` and `ViewLocator.Current` any time you want to create an `NavigationView` instance.  The defaults are most likely what you will pass so we should provide a way to pass them.

**What is the new behavior?**
<!-- If this is a feature change -->

You can instantiate a `NavigationView` with a default constructor and no arguments `NavigationView()`

**What might this PR break?**

Itself.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

