### PR TITLE
fix: PagePopped observable

### DIFF
--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Text;

--- a/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
+++ b/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using NSubstitute;

--- a/src/Sextant.iOS.Runner/AppDelegate.cs
+++ b/src/Sextant.iOS.Runner/AppDelegate.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Foundation;
+using UIKit;
+using Xunit.Runner;
+using Xunit.Sdk;
+
+namespace Sextant.IOS.Runner
+{
+    /// <summary>
+    /// The xunit AppDelegate.
+    /// </summary>
+    /// <seealso cref="Xunit.Runner.RunnerAppDelegate" />
+    [Register("AppDelegate")]
+    public partial class AppDelegate : RunnerAppDelegate
+    {
+        // This method is invoked when the application has loaded and is ready to run. In this
+        // method you should instantiate the window, load the UI into it and then make the window
+        // visible.
+        //
+        // You have 17 seconds to return from this method, or iOS will terminate your application.
+        //
+
+        /// <inheritdoc />
+        public override bool FinishedLaunching(UIApplication app, NSDictionary options)
+        {
+            // We need this to ensure the execution assembly is part of the app bundle
+            AddExecutionAssembly(typeof(ExtensibilityPointFactory).Assembly);
+
+            // tests can be inside the main assembly
+            AddTestAssembly(Assembly.GetExecutingAssembly());
+
+#if false
+// you can use the default or set your own custom writer (e.g. save to web site and tweet it ;-)
+			Writer = new TcpTextWriter ("10.0.1.2", 16384);
+			// start running the test suites as soon as the application is loaded
+			AutoStart = true;
+			// crash the application (to ensure it's ended) and return to springboard
+			TerminateAfterExecution = true;
+#endif
+            return base.FinishedLaunching(app, options);
+        }
+    }
+}

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,117 @@
+{
+  "images": [
+    {
+      "scale": "2x",
+      "size": "20x20",
+      "idiom": "iphone",
+      "filename": "Icon40.png"
+    },
+    {
+      "scale": "3x",
+      "size": "20x20",
+      "idiom": "iphone",
+      "filename": "Icon60.png"
+    },
+    {
+      "scale": "2x",
+      "size": "29x29",
+      "idiom": "iphone",
+      "filename": "Icon58.png"
+    },
+    {
+      "scale": "3x",
+      "size": "29x29",
+      "idiom": "iphone",
+      "filename": "Icon87.png"
+    },
+    {
+      "scale": "2x",
+      "size": "40x40",
+      "idiom": "iphone",
+      "filename": "Icon80.png"
+    },
+    {
+      "scale": "3x",
+      "size": "40x40",
+      "idiom": "iphone",
+      "filename": "Icon120.png"
+    },
+    {
+      "scale": "2x",
+      "size": "60x60",
+      "idiom": "iphone",
+      "filename": "Icon120.png"
+    },
+    {
+      "scale": "3x",
+      "size": "60x60",
+      "idiom": "iphone",
+      "filename": "Icon180.png"
+    },
+    {
+      "scale": "1x",
+      "size": "20x20",
+      "idiom": "ipad",
+      "filename": "Icon20.png"
+    },
+    {
+      "scale": "2x",
+      "size": "20x20",
+      "idiom": "ipad",
+      "filename": "Icon40.png"
+    },
+    {
+      "scale": "1x",
+      "size": "29x29",
+      "idiom": "ipad",
+      "filename": "Icon29.png"
+    },
+    {
+      "scale": "2x",
+      "size": "29x29",
+      "idiom": "ipad",
+      "filename": "Icon58.png"
+    },
+    {
+      "scale": "1x",
+      "size": "40x40",
+      "idiom": "ipad",
+      "filename": "Icon40.png"
+    },
+    {
+      "scale": "2x",
+      "size": "40x40",
+      "idiom": "ipad",
+      "filename": "Icon80.png"
+    },
+    {
+      "scale": "1x",
+      "size": "76x76",
+      "idiom": "ipad",
+      "filename": "Icon76.png"
+    },
+    {
+      "scale": "2x",
+      "size": "76x76",
+      "idiom": "ipad",
+      "filename": "Icon152.png"
+    },
+    {
+      "scale": "2x",
+      "size": "83.5x83.5",
+      "idiom": "ipad",
+      "filename": "Icon167.png"
+    },
+    {
+      "scale": "1x",
+      "size": "1024x1024",
+      "idiom": "ios-marketing",
+      "filename": "Icon1024.png"
+    }
+  ],
+  "properties": {},
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon1024.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon1024.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc7f7cb40a3d7b2d7639e2a15b62bc3404d779a56c8863ae492218fb3519452e
+size 70429

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon120.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon120.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:faf908f37fa0eb73f531d8c46ef422df52252b9bca73cd726ec299bf92852fb6
+size 3773

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon152.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon152.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b98982a7dd52bbaea5515ce0681e7b1180eaddf85589cc6a261c5b1c98336d9
+size 4750

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon167.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon167.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed32a51128101cd81f0569f209f415ca21315591fc46b1db5533f254d4db6c69
+size 4692

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon180.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon180.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d11de68c36358cccbb16a82ba7645c3ab6c7568b4cd5f29f7b7879f38a99495e
+size 5192

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon20.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon20.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de96a3ba670c8163ba94ef578bb897b951b14c475ac1fecab06b297af967bd6f
+size 1313

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon29.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon29.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:653a3d75c42c01ce4dd60c0aa0b59f6de548a016a2d70cc9aaa3a5e9664e78c9
+size 845

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon40.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon40.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09242c80c04a97fc083bca554f5c992f4ae090ffaa858af7a92613b5cdb07354
+size 1101

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon58.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon58.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04cfee2b3a4feb32a77bb953c8453a0bb416f48906a9448b5edc355c0d68da86
+size 1761

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon60.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon60.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf145cb811bd1095bd94aadd17e3ed38b489dde1e8ce58ad5e9de090bb3556f8
+size 2537

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon76.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon76.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:170b1b2119e0fff597104534ab50b7c31b930eb76b24bfc9bd7508e1b489bc30
+size 2332

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon80.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon80.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:538ba04ed28b7eec3917fa1a3226e4b023ffc263bb762891a2a25e2c95f9f394
+size 2454

--- a/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon87.png
+++ b/src/Sextant.iOS.Runner/Assets.xcassets/AppIcon.appiconset/Icon87.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5bf0830dc6cffbf5685ee16b11c9e04b08466cce1ddd4c9598f9ad8e7952c6f
+size 2758

--- a/src/Sextant.iOS.Runner/Entitlements.plist
+++ b/src/Sextant.iOS.Runner/Entitlements.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+    </dict>
+</plist>

--- a/src/Sextant.iOS.Runner/Info.plist
+++ b/src/Sextant.iOS.Runner/Info.plist
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>Sextant.iOS.Runner</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.companyname.Sextant.iOS.Runner</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>MinimumOSVersion</key>
+        <string>12.1</string>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+    </array>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>armv7</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>XSAppIconAssets</key>
+    <string>Assets.xcassets/AppIcon.appiconset</string>
+</dict>
+</plist>

--- a/src/Sextant.iOS.Runner/LaunchScreen.storyboard
+++ b/src/Sextant.iOS.Runner/LaunchScreen.storyboard
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="222" launchScreen="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="221">
+            <objects>
+                <viewController id="222" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="219"/>
+                        <viewControllerLayoutGuide type="bottom" id="220"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="223">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="224" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-200" y="-388"/>
+        </scene>
+    </scenes>
+</document>

--- a/src/Sextant.iOS.Runner/Main.cs
+++ b/src/Sextant.iOS.Runner/Main.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using UIKit;
+
+namespace Sextant.IOS.Runner
+{
+#pragma warning disable SA1649 // File name should match first type name
+    /// <summary>
+    /// The iOS application.
+    /// </summary>
+    public class Application
+    {
+        // This is the main entry point of the application.
+
+        /// <summary>
+        /// Defines the entry point of the application.
+        /// </summary>
+        /// <param name="args">The arguments.</param>
+        private static void Main(string[] args)
+        {
+            // if you want to use a different Application Delegate class from "AppDelegate"
+            // you can specify it here.
+            UIApplication.Main(args, null, "AppDelegate");
+        }
+    }
+}
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/Sextant.iOS.Runner/NavigationViewControllerFixture.cs
+++ b/src/Sextant.iOS.Runner/NavigationViewControllerFixture.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Reactive.Testing;
+using ReactiveUI;
+using Sextant;
+
+namespace Sextant.IOS.Runner
+{
+    /// <summary>
+    /// Navigation view controller fixture.
+    /// </summary>
+    public class NavigationViewControllerFixture
+    {
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="NavigationViewControllerFixture"/> to <see cref="NavigationViewController"/>.
+        /// </summary>
+        /// <param name="fixture">The fixture.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        public static implicit operator NavigationViewController(NavigationViewControllerFixture fixture) =>
+            fixture.Build();
+
+        private NavigationViewController Build() => 
+            new NavigationViewController(new TestScheduler(), new TestScheduler(), new TestViewLocator());
+    }
+}

--- a/src/Sextant.iOS.Runner/NavigationViewControllerFixture.cs
+++ b/src/Sextant.iOS.Runner/NavigationViewControllerFixture.cs
@@ -25,7 +25,7 @@ namespace Sextant.IOS.Runner
         public static implicit operator NavigationViewController(NavigationViewControllerFixture fixture) =>
             fixture.Build();
 
-        private NavigationViewController Build() => 
+        private NavigationViewController Build() =>
             new NavigationViewController(new TestScheduler(), new TestScheduler(), new TestViewLocator());
     }
 }

--- a/src/Sextant.iOS.Runner/NavigationViewControllerTests.cs
+++ b/src/Sextant.iOS.Runner/NavigationViewControllerTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Foundation;
+using Sextant;
+using Shouldly;
+using UIKit;
+using Xunit;
+
+namespace Sextant.IOS.Runner
+{
+    /// <summary>
+    /// Navigation view controller tests.
+    /// </summary>
+    public class NavigationViewControllerTests
+    {
+        /// <summary>
+        /// Test that verifies view controller pops.
+        /// </summary>
+        [Fact]
+        public void Should_Pop_View_Controller()
+        {
+            // Given
+            var actual = false;
+            NavigationViewController sut = new NavigationViewControllerFixture();
+            sut.PagePopped.Subscribe(_ => { actual = true; });
+
+            // When
+            sut.PopPage();
+
+            // Then
+            actual.ShouldBeTrue();
+        }
+    }
+}

--- a/src/Sextant.iOS.Runner/PageUiViewController.cs
+++ b/src/Sextant.iOS.Runner/PageUiViewController.cs
@@ -1,0 +1,15 @@
+﻿using ReactiveUI;
+
+namespace Sextant.IOS.Runner
+{
+    internal class PageUiViewController : IViewFor<PageViewModelMock>
+    {
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (PageViewModelMock) value;
+        }
+
+        public PageViewModelMock ViewModel { get; set; } = new PageViewModelMock();
+    }
+}

--- a/src/Sextant.iOS.Runner/PageViewModelMock.cs
+++ b/src/Sextant.iOS.Runner/PageViewModelMock.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Sextant;
+
+namespace Sextant.IOS.Runner
+{
+    /// <summary>
+    /// A mock of a page view model.
+    /// </summary>
+    internal class PageViewModelMock : IPageViewModel
+    {
+        private readonly string _id;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PageViewModelMock"/> class.
+        /// </summary>
+        /// <param name="id">The id of the page.</param>
+        public PageViewModelMock(string id = null)
+        {
+            _id = id;
+        }
+
+        /// <summary>
+        /// Gets the ID of the page.
+        /// </summary>
+        public string Id => _id ?? nameof(PageViewModelMock);
+    }
+}

--- a/src/Sextant.iOS.Runner/Properties/AssemblyInfo.cs
+++ b/src/Sextant.iOS.Runner/Properties/AssemblyInfo.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Sextant.iOS.Runner")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Sextant.iOS.Runner")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("50c7b8c9-e664-45af-b88e-0c9b8b9c1be1")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Sextant.iOS.Runner/Resources/LaunchScreen.xib
+++ b/src/Sextant.iOS.Runner/Resources/LaunchScreen.xib
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207" />
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1" />
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" />
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder" />
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480" />
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2017 " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines"
+                    minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21" />
+                    <fontDescription key="fontDescription" type="system" pointSize="17" />
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor" />
+                    <nil key="highlightedColor" />
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sextant.iOS.Runner" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines"
+                    minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43" />
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36" />
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor" />
+                    <nil key="highlightedColor" />
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite" />
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC" />
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk" />
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l" />
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0" />
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9" />
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g" />
+            </constraints>
+            <nil key="simulatedStatusBarMetrics" />
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics" />
+            <point key="canvasLocation" x="548" y="455" />
+        </view>
+    </objects>
+</document>

--- a/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
+++ b/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
@@ -1,0 +1,152 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectGuid>{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TemplateGuid>{440aa056-593a-4519-8708-27081dee632f}</TemplateGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Blank</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>Blank</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchLink>None</MtouchLink>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARM64</MtouchArch>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <None Include="Info.plist" />
+    <Compile Include="NavigationViewControllerFixture.cs" />
+    <Compile Include="NavigationViewControllerTests.cs" />
+    <Compile Include="TestViewLocator.cs" />
+    <Compile Include="PageUiViewController.cs" />
+    <Compile Include="PageViewModelMock.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Content Include="Entitlements.plist" />
+    <InterfaceDefinition Include="LaunchScreen.storyboard" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon1024.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon167.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon120.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon152.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon180.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon29.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon40.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon58.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon76.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon80.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon87.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon20.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon60.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Reactive.Testing">
+      <Version>4.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Reactive">
+      <Version>4.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.4.1</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.devices">
+      <Version>2.5.25</Version>
+    </PackageReference>
+    <PackageReference Include="Shouldly" Version=" 3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sextant\Sextant.csproj">
+      <Project>{d6b84899-4afc-4e6c-9c3f-005f21df5a52}</Project>
+      <Name>Sextant</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>

--- a/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
+++ b/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
@@ -128,10 +128,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Reactive.Testing">
-      <Version>4.0.0</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="System.Reactive">
-      <Version>4.0.0</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>
@@ -141,7 +141,6 @@
     </PackageReference>
     <PackageReference Include="Shouldly" Version=" 3.0.2" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Sextant\Sextant.csproj">
       <Project>{d6b84899-4afc-4e6c-9c3f-005f21df5a52}</Project>

--- a/src/Sextant.iOS.Runner/TestViewLocator.cs
+++ b/src/Sextant.iOS.Runner/TestViewLocator.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Foundation;
+using ReactiveUI;
+using UIKit;
+
+namespace Sextant.IOS.Runner
+{
+    internal class TestViewLocator
+        : IViewLocator
+    {
+        public IViewFor ResolveView<T>(T viewModel, string contract = null)
+            where T : class
+        {
+            return new PageUiViewController();
+        }
+    }
+}

--- a/src/Sextant.sln
+++ b/src/Sextant.sln
@@ -31,6 +31,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sextant.XamForms.Tests", "S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sextant.Mocks", "Sextant.Mocks\Sextant.Mocks.csproj", "{07C90E5B-858E-4EB2-948B-8D0A698F439B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{42173B56-0F72-4E8E-828F-4289222C8BB4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sextant.iOS.Runner", "Sextant.iOS.Runner\Sextant.iOS.Runner.csproj", "{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Ad-Hoc|Any CPU = Ad-Hoc|Any CPU
@@ -290,6 +294,34 @@ Global
 		{07C90E5B-858E-4EB2-948B-8D0A698F439B}.Sample Release|iPhone.Build.0 = Release|Any CPU
 		{07C90E5B-858E-4EB2-948B-8D0A698F439B}.Sample Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{07C90E5B-858E-4EB2-948B-8D0A698F439B}.Sample Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Ad-Hoc|Any CPU.ActiveCfg = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Ad-Hoc|Any CPU.Build.0 = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Ad-Hoc|iPhone.ActiveCfg = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Ad-Hoc|iPhone.Build.0 = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Ad-Hoc|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.AppStore|Any CPU.ActiveCfg = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.AppStore|Any CPU.Build.0 = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.AppStore|iPhone.ActiveCfg = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.AppStore|iPhone.Build.0 = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.AppStore|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.AppStore|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Debug|Any CPU.ActiveCfg = Debug|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Debug|iPhone.Build.0 = Debug|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Release|Any CPU.ActiveCfg = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Release|iPhone.ActiveCfg = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Release|iPhone.Build.0 = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Sample Release|Any CPU.ActiveCfg = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Sample Release|Any CPU.Build.0 = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Sample Release|iPhone.ActiveCfg = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Sample Release|iPhone.Build.0 = Release|iPhone
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Sample Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60}.Sample Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -298,6 +330,7 @@ Global
 		{44FA03FD-7A52-41AD-9332-1B34FFDEE67B} = {BEB94547-F374-4211-BBE6-3DA7CAB972BB}
 		{A5BBADB1-F348-49CD-8264-59B5BE8E9F17} = {BEB94547-F374-4211-BBE6-3DA7CAB972BB}
 		{4A684BB2-2CB4-4B04-8541-FF0FA677DD49} = {BEB94547-F374-4211-BBE6-3DA7CAB972BB}
+		{80A96B52-6758-4BDB-B0B4-CEA4CA155C60} = {42173B56-0F72-4E8E-828F-4289222C8BB4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5DD8FF23-E55B-4675-A15F-2E0DB2E10CC3}

--- a/src/Sextant/Platforms/uikit-common/NavigationViewController.cs
+++ b/src/Sextant/Platforms/uikit-common/NavigationViewController.cs
@@ -45,8 +45,6 @@ namespace Sextant
             _mainScheduler = mainScheduler ?? RxApp.MainThreadScheduler;
             _backgroundScheduler = backgroundScheduler ?? RxApp.TaskpoolScheduler;
             _viewLocator = viewLocator ?? ViewLocator.Current;
-            _navigationPages = new Stack<UIViewController>();
-            _navigationPages.Push(this);
         }
 
         /// <inheritdoc />
@@ -119,7 +117,6 @@ namespace Sextant
                     {
                         var page = LocatePageFor(pageViewModel, contract);
                         SetPageTitle(page, pageViewModel.Id);
-                        _navigationPages.Push(page);
                         viewController = page;
                         return page;
                     },
@@ -156,13 +153,15 @@ namespace Sextant
                 });
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override UIViewController PopViewController(bool animated)
         {
-            var popped = _navigationPages.Pop();
-            var view = popped as IViewFor;
-            _pagePopped.OnNext(view?.ViewModel as IViewModel);
-            return base.PopViewController(animated);
+            var poppedController = base.PopViewController(animated);
+
+            var view = poppedController as IViewFor;
+            _pagePopped.OnNext(view?.ViewModel as IPageViewModel);
+
+            return poppedController;
         }
 
         private UIViewController LocatePageFor(object viewModel, string contract)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fixes the iOS `IView` implementation so that the pages being popped are from the platform navigation stack.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

There is an internal navigation stack that is not in sync with the platform stack.

**What is the new behavior?**
<!-- If this is a feature change -->

We will pull the popped page from the navigation stack.

**What might this PR break?**

Sextant on the iOS platform

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

