### PR TITLE
fix: Changed Droid sample target framework to 9

### DIFF
--- a/Sample/SextantSample.Android/Properties/AndroidManifest.xml
+++ b/Sample/SextantSample.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.giusepe.SextantSample" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="27" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 	<application android:label="SextantSample.Android"></application>
 </manifest>

--- a/Sample/SextantSample.Android/Resources/Resource.designer.cs
+++ b/Sample/SextantSample.Android/Resources/Resource.designer.cs
@@ -36,6 +36,8 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_slide_in_top = global::SextantSample.Droid.Resource.Animation.abc_slide_in_top;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_slide_out_bottom = global::SextantSample.Droid.Resource.Animation.abc_slide_out_bottom;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_slide_out_top = global::SextantSample.Droid.Resource.Animation.abc_slide_out_top;
+			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_tooltip_enter = global::SextantSample.Droid.Resource.Animation.abc_tooltip_enter;
+			global::Xamarin.Forms.Platform.Android.Resource.Animation.abc_tooltip_exit = global::SextantSample.Droid.Resource.Animation.abc_tooltip_exit;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.design_bottom_sheet_slide_in = global::SextantSample.Droid.Resource.Animation.design_bottom_sheet_slide_in;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.design_bottom_sheet_slide_out = global::SextantSample.Droid.Resource.Animation.design_bottom_sheet_slide_out;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.design_snackbar_in = global::SextantSample.Droid.Resource.Animation.design_snackbar_in;
@@ -44,9 +46,16 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.EnterFromRight = global::SextantSample.Droid.Resource.Animation.EnterFromRight;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.ExitToLeft = global::SextantSample.Droid.Resource.Animation.ExitToLeft;
 			global::Xamarin.Forms.Platform.Android.Resource.Animation.ExitToRight = global::SextantSample.Droid.Resource.Animation.ExitToRight;
-			global::Xamarin.Forms.Platform.Android.Resource.Animation.tooltip_enter = global::SextantSample.Droid.Resource.Animation.tooltip_enter;
-			global::Xamarin.Forms.Platform.Android.Resource.Animation.tooltip_exit = global::SextantSample.Droid.Resource.Animation.tooltip_exit;
 			global::Xamarin.Forms.Platform.Android.Resource.Animator.design_appbar_state_list_animator = global::SextantSample.Droid.Resource.Animator.design_appbar_state_list_animator;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.design_fab_hide_motion_spec = global::SextantSample.Droid.Resource.Animator.design_fab_hide_motion_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.design_fab_show_motion_spec = global::SextantSample.Droid.Resource.Animator.design_fab_show_motion_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_btn_state_list_anim = global::SextantSample.Droid.Resource.Animator.mtrl_btn_state_list_anim;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_btn_unelevated_state_list_anim = global::SextantSample.Droid.Resource.Animator.mtrl_btn_unelevated_state_list_anim;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_chip_state_list_anim = global::SextantSample.Droid.Resource.Animator.mtrl_chip_state_list_anim;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_fab_hide_motion_spec = global::SextantSample.Droid.Resource.Animator.mtrl_fab_hide_motion_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_fab_show_motion_spec = global::SextantSample.Droid.Resource.Animator.mtrl_fab_show_motion_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_fab_transformation_sheet_collapse_spec = global::SextantSample.Droid.Resource.Animator.mtrl_fab_transformation_sheet_collapse_spec;
+			global::Xamarin.Forms.Platform.Android.Resource.Animator.mtrl_fab_transformation_sheet_expand_spec = global::SextantSample.Droid.Resource.Animator.mtrl_fab_transformation_sheet_expand_spec;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarDivider = global::SextantSample.Droid.Resource.Attribute.actionBarDivider;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarItemBackground = global::SextantSample.Droid.Resource.Attribute.actionBarItemBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarPopupTheme = global::SextantSample.Droid.Resource.Attribute.actionBarPopupTheme;
@@ -103,20 +112,33 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.backgroundTintMode = global::SextantSample.Droid.Resource.Attribute.backgroundTintMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.barLength = global::SextantSample.Droid.Resource.Attribute.barLength;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_autoHide = global::SextantSample.Droid.Resource.Attribute.behavior_autoHide;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_fitToContents = global::SextantSample.Droid.Resource.Attribute.behavior_fitToContents;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_hideable = global::SextantSample.Droid.Resource.Attribute.behavior_hideable;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_overlapTop = global::SextantSample.Droid.Resource.Attribute.behavior_overlapTop;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_peekHeight = global::SextantSample.Droid.Resource.Attribute.behavior_peekHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.behavior_skipCollapsed = global::SextantSample.Droid.Resource.Attribute.behavior_skipCollapsed;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.borderWidth = global::SextantSample.Droid.Resource.Attribute.borderWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.borderlessButtonStyle = global::SextantSample.Droid.Resource.Attribute.borderlessButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.bottomAppBarStyle = global::SextantSample.Droid.Resource.Attribute.bottomAppBarStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.bottomNavigationStyle = global::SextantSample.Droid.Resource.Attribute.bottomNavigationStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.bottomSheetDialogTheme = global::SextantSample.Droid.Resource.Attribute.bottomSheetDialogTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.bottomSheetStyle = global::SextantSample.Droid.Resource.Attribute.bottomSheetStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxBackgroundColor = global::SextantSample.Droid.Resource.Attribute.boxBackgroundColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxBackgroundMode = global::SextantSample.Droid.Resource.Attribute.boxBackgroundMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCollapsedPaddingTop = global::SextantSample.Droid.Resource.Attribute.boxCollapsedPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCornerRadiusBottomEnd = global::SextantSample.Droid.Resource.Attribute.boxCornerRadiusBottomEnd;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCornerRadiusBottomStart = global::SextantSample.Droid.Resource.Attribute.boxCornerRadiusBottomStart;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCornerRadiusTopEnd = global::SextantSample.Droid.Resource.Attribute.boxCornerRadiusTopEnd;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxCornerRadiusTopStart = global::SextantSample.Droid.Resource.Attribute.boxCornerRadiusTopStart;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxStrokeColor = global::SextantSample.Droid.Resource.Attribute.boxStrokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.boxStrokeWidth = global::SextantSample.Droid.Resource.Attribute.boxStrokeWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarButtonStyle = global::SextantSample.Droid.Resource.Attribute.buttonBarButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarNegativeButtonStyle = global::SextantSample.Droid.Resource.Attribute.buttonBarNegativeButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarNeutralButtonStyle = global::SextantSample.Droid.Resource.Attribute.buttonBarNeutralButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarPositiveButtonStyle = global::SextantSample.Droid.Resource.Attribute.buttonBarPositiveButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonBarStyle = global::SextantSample.Droid.Resource.Attribute.buttonBarStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonGravity = global::SextantSample.Droid.Resource.Attribute.buttonGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonIconDimen = global::SextantSample.Droid.Resource.Attribute.buttonIconDimen;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonPanelSideLayout = global::SextantSample.Droid.Resource.Attribute.buttonPanelSideLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonStyle = global::SextantSample.Droid.Resource.Attribute.buttonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.buttonStyleSmall = global::SextantSample.Droid.Resource.Attribute.buttonStyleSmall;
@@ -128,9 +150,38 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cardMaxElevation = global::SextantSample.Droid.Resource.Attribute.cardMaxElevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cardPreventCornerOverlap = global::SextantSample.Droid.Resource.Attribute.cardPreventCornerOverlap;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cardUseCompatPadding = global::SextantSample.Droid.Resource.Attribute.cardUseCompatPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cardViewStyle = global::SextantSample.Droid.Resource.Attribute.cardViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkboxStyle = global::SextantSample.Droid.Resource.Attribute.checkboxStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedChip = global::SextantSample.Droid.Resource.Attribute.checkedChip;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedIcon = global::SextantSample.Droid.Resource.Attribute.checkedIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedIconEnabled = global::SextantSample.Droid.Resource.Attribute.checkedIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedIconVisible = global::SextantSample.Droid.Resource.Attribute.checkedIconVisible;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.checkedTextViewStyle = global::SextantSample.Droid.Resource.Attribute.checkedTextViewStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipBackgroundColor = global::SextantSample.Droid.Resource.Attribute.chipBackgroundColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipCornerRadius = global::SextantSample.Droid.Resource.Attribute.chipCornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipEndPadding = global::SextantSample.Droid.Resource.Attribute.chipEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipGroupStyle = global::SextantSample.Droid.Resource.Attribute.chipGroupStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIcon = global::SextantSample.Droid.Resource.Attribute.chipIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIconEnabled = global::SextantSample.Droid.Resource.Attribute.chipIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIconSize = global::SextantSample.Droid.Resource.Attribute.chipIconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIconTint = global::SextantSample.Droid.Resource.Attribute.chipIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipIconVisible = global::SextantSample.Droid.Resource.Attribute.chipIconVisible;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipMinHeight = global::SextantSample.Droid.Resource.Attribute.chipMinHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipSpacing = global::SextantSample.Droid.Resource.Attribute.chipSpacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipSpacingHorizontal = global::SextantSample.Droid.Resource.Attribute.chipSpacingHorizontal;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipSpacingVertical = global::SextantSample.Droid.Resource.Attribute.chipSpacingVertical;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStandaloneStyle = global::SextantSample.Droid.Resource.Attribute.chipStandaloneStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStartPadding = global::SextantSample.Droid.Resource.Attribute.chipStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStrokeColor = global::SextantSample.Droid.Resource.Attribute.chipStrokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStrokeWidth = global::SextantSample.Droid.Resource.Attribute.chipStrokeWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.chipStyle = global::SextantSample.Droid.Resource.Attribute.chipStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIcon = global::SextantSample.Droid.Resource.Attribute.closeIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconEnabled = global::SextantSample.Droid.Resource.Attribute.closeIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconEndPadding = global::SextantSample.Droid.Resource.Attribute.closeIconEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconSize = global::SextantSample.Droid.Resource.Attribute.closeIconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconStartPadding = global::SextantSample.Droid.Resource.Attribute.closeIconStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconTint = global::SextantSample.Droid.Resource.Attribute.closeIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeIconVisible = global::SextantSample.Droid.Resource.Attribute.closeIconVisible;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.closeItemLayout = global::SextantSample.Droid.Resource.Attribute.closeItemLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.collapseContentDescription = global::SextantSample.Droid.Resource.Attribute.collapseContentDescription;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.collapseIcon = global::SextantSample.Droid.Resource.Attribute.collapseIcon;
@@ -146,6 +197,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorError = global::SextantSample.Droid.Resource.Attribute.colorError;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorPrimary = global::SextantSample.Droid.Resource.Attribute.colorPrimary;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorPrimaryDark = global::SextantSample.Droid.Resource.Attribute.colorPrimaryDark;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorSecondary = global::SextantSample.Droid.Resource.Attribute.colorSecondary;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorSwitchThumbNormal = global::SextantSample.Droid.Resource.Attribute.colorSwitchThumbNormal;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.commitIcon = global::SextantSample.Droid.Resource.Attribute.commitIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.contentDescription = global::SextantSample.Droid.Resource.Attribute.contentDescription;
@@ -162,12 +214,15 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.contentPaddingTop = global::SextantSample.Droid.Resource.Attribute.contentPaddingTop;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.contentScrim = global::SextantSample.Droid.Resource.Attribute.contentScrim;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.controlBackground = global::SextantSample.Droid.Resource.Attribute.controlBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.coordinatorLayoutStyle = global::SextantSample.Droid.Resource.Attribute.coordinatorLayoutStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.cornerRadius = global::SextantSample.Droid.Resource.Attribute.cornerRadius;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.counterEnabled = global::SextantSample.Droid.Resource.Attribute.counterEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.counterMaxLength = global::SextantSample.Droid.Resource.Attribute.counterMaxLength;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.counterOverflowTextAppearance = global::SextantSample.Droid.Resource.Attribute.counterOverflowTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.counterTextAppearance = global::SextantSample.Droid.Resource.Attribute.counterTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.customNavigationLayout = global::SextantSample.Droid.Resource.Attribute.customNavigationLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.defaultQueryHint = global::SextantSample.Droid.Resource.Attribute.defaultQueryHint;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.dialogCornerRadius = global::SextantSample.Droid.Resource.Attribute.dialogCornerRadius;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.dialogPreferredPadding = global::SextantSample.Droid.Resource.Attribute.dialogPreferredPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.dialogTheme = global::SextantSample.Droid.Resource.Attribute.dialogTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.displayOptions = global::SextantSample.Droid.Resource.Attribute.displayOptions;
@@ -183,6 +238,8 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.editTextColor = global::SextantSample.Droid.Resource.Attribute.editTextColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.editTextStyle = global::SextantSample.Droid.Resource.Attribute.editTextStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.elevation = global::SextantSample.Droid.Resource.Attribute.elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.enforceMaterialTheme = global::SextantSample.Droid.Resource.Attribute.enforceMaterialTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.enforceTextAppearance = global::SextantSample.Droid.Resource.Attribute.enforceTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.errorEnabled = global::SextantSample.Droid.Resource.Attribute.errorEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.errorTextAppearance = global::SextantSample.Droid.Resource.Attribute.errorTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.expandActivityOverflowButtonDrawable = global::SextantSample.Droid.Resource.Attribute.expandActivityOverflowButtonDrawable;
@@ -194,12 +251,19 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.expandedTitleMarginStart = global::SextantSample.Droid.Resource.Attribute.expandedTitleMarginStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.expandedTitleMarginTop = global::SextantSample.Droid.Resource.Attribute.expandedTitleMarginTop;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.expandedTitleTextAppearance = global::SextantSample.Droid.Resource.Attribute.expandedTitleTextAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabAlignmentMode = global::SextantSample.Droid.Resource.Attribute.fabAlignmentMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabCradleMargin = global::SextantSample.Droid.Resource.Attribute.fabCradleMargin;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabCradleRoundedCornerRadius = global::SextantSample.Droid.Resource.Attribute.fabCradleRoundedCornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabCradleVerticalOffset = global::SextantSample.Droid.Resource.Attribute.fabCradleVerticalOffset;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabCustomSize = global::SextantSample.Droid.Resource.Attribute.fabCustomSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fabSize = global::SextantSample.Droid.Resource.Attribute.fabSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollEnabled = global::SextantSample.Droid.Resource.Attribute.fastScrollEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollHorizontalThumbDrawable = global::SextantSample.Droid.Resource.Attribute.fastScrollHorizontalThumbDrawable;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollHorizontalTrackDrawable = global::SextantSample.Droid.Resource.Attribute.fastScrollHorizontalTrackDrawable;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollVerticalThumbDrawable = global::SextantSample.Droid.Resource.Attribute.fastScrollVerticalThumbDrawable;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fastScrollVerticalTrackDrawable = global::SextantSample.Droid.Resource.Attribute.fastScrollVerticalTrackDrawable;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.firstBaselineToTopHeight = global::SextantSample.Droid.Resource.Attribute.firstBaselineToTopHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.floatingActionButtonStyle = global::SextantSample.Droid.Resource.Attribute.floatingActionButtonStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.font = global::SextantSample.Droid.Resource.Attribute.font;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontFamily = global::SextantSample.Droid.Resource.Attribute.fontFamily;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontProviderAuthority = global::SextantSample.Droid.Resource.Attribute.fontProviderAuthority;
@@ -209,19 +273,31 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontProviderPackage = global::SextantSample.Droid.Resource.Attribute.fontProviderPackage;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontProviderQuery = global::SextantSample.Droid.Resource.Attribute.fontProviderQuery;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontStyle = global::SextantSample.Droid.Resource.Attribute.fontStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontVariationSettings = global::SextantSample.Droid.Resource.Attribute.fontVariationSettings;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.fontWeight = global::SextantSample.Droid.Resource.Attribute.fontWeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.foregroundInsidePadding = global::SextantSample.Droid.Resource.Attribute.foregroundInsidePadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.gapBetweenBars = global::SextantSample.Droid.Resource.Attribute.gapBetweenBars;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.goIcon = global::SextantSample.Droid.Resource.Attribute.goIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.headerLayout = global::SextantSample.Droid.Resource.Attribute.headerLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.height = global::SextantSample.Droid.Resource.Attribute.height;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.helperText = global::SextantSample.Droid.Resource.Attribute.helperText;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.helperTextEnabled = global::SextantSample.Droid.Resource.Attribute.helperTextEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.helperTextTextAppearance = global::SextantSample.Droid.Resource.Attribute.helperTextTextAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hideMotionSpec = global::SextantSample.Droid.Resource.Attribute.hideMotionSpec;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hideOnContentScroll = global::SextantSample.Droid.Resource.Attribute.hideOnContentScroll;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hideOnScroll = global::SextantSample.Droid.Resource.Attribute.hideOnScroll;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hintAnimationEnabled = global::SextantSample.Droid.Resource.Attribute.hintAnimationEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hintEnabled = global::SextantSample.Droid.Resource.Attribute.hintEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hintTextAppearance = global::SextantSample.Droid.Resource.Attribute.hintTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.homeAsUpIndicator = global::SextantSample.Droid.Resource.Attribute.homeAsUpIndicator;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.homeLayout = global::SextantSample.Droid.Resource.Attribute.homeLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.hoveredFocusedTranslationZ = global::SextantSample.Droid.Resource.Attribute.hoveredFocusedTranslationZ;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.icon = global::SextantSample.Droid.Resource.Attribute.icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconEndPadding = global::SextantSample.Droid.Resource.Attribute.iconEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconGravity = global::SextantSample.Droid.Resource.Attribute.iconGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconPadding = global::SextantSample.Droid.Resource.Attribute.iconPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconSize = global::SextantSample.Droid.Resource.Attribute.iconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconStartPadding = global::SextantSample.Droid.Resource.Attribute.iconStartPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconTint = global::SextantSample.Droid.Resource.Attribute.iconTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconTintMode = global::SextantSample.Droid.Resource.Attribute.iconTintMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.iconifiedByDefault = global::SextantSample.Droid.Resource.Attribute.iconifiedByDefault;
@@ -231,11 +307,20 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.insetForeground = global::SextantSample.Droid.Resource.Attribute.insetForeground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.isLightTheme = global::SextantSample.Droid.Resource.Attribute.isLightTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemBackground = global::SextantSample.Droid.Resource.Attribute.itemBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemHorizontalPadding = global::SextantSample.Droid.Resource.Attribute.itemHorizontalPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemHorizontalTranslationEnabled = global::SextantSample.Droid.Resource.Attribute.itemHorizontalTranslationEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemIconPadding = global::SextantSample.Droid.Resource.Attribute.itemIconPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemIconSize = global::SextantSample.Droid.Resource.Attribute.itemIconSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemIconTint = global::SextantSample.Droid.Resource.Attribute.itemIconTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemPadding = global::SextantSample.Droid.Resource.Attribute.itemPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemSpacing = global::SextantSample.Droid.Resource.Attribute.itemSpacing;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemTextAppearance = global::SextantSample.Droid.Resource.Attribute.itemTextAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemTextAppearanceActive = global::SextantSample.Droid.Resource.Attribute.itemTextAppearanceActive;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemTextAppearanceInactive = global::SextantSample.Droid.Resource.Attribute.itemTextAppearanceInactive;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.itemTextColor = global::SextantSample.Droid.Resource.Attribute.itemTextColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.keylines = global::SextantSample.Droid.Resource.Attribute.keylines;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.labelVisibilityMode = global::SextantSample.Droid.Resource.Attribute.labelVisibilityMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.lastBaselineToBottomHeight = global::SextantSample.Droid.Resource.Attribute.lastBaselineToBottomHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout = global::SextantSample.Droid.Resource.Attribute.layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layoutManager = global::SextantSample.Droid.Resource.Attribute.layoutManager;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout_anchor = global::SextantSample.Droid.Resource.Attribute.layout_anchor;
@@ -248,6 +333,9 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout_keyline = global::SextantSample.Droid.Resource.Attribute.layout_keyline;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout_scrollFlags = global::SextantSample.Droid.Resource.Attribute.layout_scrollFlags;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.layout_scrollInterpolator = global::SextantSample.Droid.Resource.Attribute.layout_scrollInterpolator;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.liftOnScroll = global::SextantSample.Droid.Resource.Attribute.liftOnScroll;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.lineHeight = global::SextantSample.Droid.Resource.Attribute.lineHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.lineSpacing = global::SextantSample.Droid.Resource.Attribute.lineSpacing;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.listChoiceBackgroundIndicator = global::SextantSample.Droid.Resource.Attribute.listChoiceBackgroundIndicator;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.listDividerAlertDialog = global::SextantSample.Droid.Resource.Attribute.listDividerAlertDialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.listItemLayout = global::SextantSample.Droid.Resource.Attribute.listItemLayout;
@@ -261,14 +349,18 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.listPreferredItemPaddingRight = global::SextantSample.Droid.Resource.Attribute.listPreferredItemPaddingRight;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.logo = global::SextantSample.Droid.Resource.Attribute.logo;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.logoDescription = global::SextantSample.Droid.Resource.Attribute.logoDescription;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.materialButtonStyle = global::SextantSample.Droid.Resource.Attribute.materialButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.materialCardViewStyle = global::SextantSample.Droid.Resource.Attribute.materialCardViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.maxActionInlineWidth = global::SextantSample.Droid.Resource.Attribute.maxActionInlineWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.maxButtonHeight = global::SextantSample.Droid.Resource.Attribute.maxButtonHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.maxImageSize = global::SextantSample.Droid.Resource.Attribute.maxImageSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.measureWithLargestChild = global::SextantSample.Droid.Resource.Attribute.measureWithLargestChild;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.menu = global::SextantSample.Droid.Resource.Attribute.menu;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.multiChoiceItemLayout = global::SextantSample.Droid.Resource.Attribute.multiChoiceItemLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.navigationContentDescription = global::SextantSample.Droid.Resource.Attribute.navigationContentDescription;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.navigationIcon = global::SextantSample.Droid.Resource.Attribute.navigationIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.navigationMode = global::SextantSample.Droid.Resource.Attribute.navigationMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.navigationViewStyle = global::SextantSample.Droid.Resource.Attribute.navigationViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.numericModifiers = global::SextantSample.Droid.Resource.Attribute.numericModifiers;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.overlapAnchor = global::SextantSample.Droid.Resource.Attribute.overlapAnchor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.paddingBottomNoButtons = global::SextantSample.Droid.Resource.Attribute.paddingBottomNoButtons;
@@ -299,6 +391,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.reverseLayout = global::SextantSample.Droid.Resource.Attribute.reverseLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.rippleColor = global::SextantSample.Droid.Resource.Attribute.rippleColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.scrimAnimationDuration = global::SextantSample.Droid.Resource.Attribute.scrimAnimationDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.scrimBackground = global::SextantSample.Droid.Resource.Attribute.scrimBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.scrimVisibleHeightTrigger = global::SextantSample.Droid.Resource.Attribute.scrimVisibleHeightTrigger;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.searchHintIcon = global::SextantSample.Droid.Resource.Attribute.searchHintIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.searchIcon = global::SextantSample.Droid.Resource.Attribute.searchIcon;
@@ -308,9 +401,14 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.selectableItemBackgroundBorderless = global::SextantSample.Droid.Resource.Attribute.selectableItemBackgroundBorderless;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showAsAction = global::SextantSample.Droid.Resource.Attribute.showAsAction;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showDividers = global::SextantSample.Droid.Resource.Attribute.showDividers;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showMotionSpec = global::SextantSample.Droid.Resource.Attribute.showMotionSpec;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showText = global::SextantSample.Droid.Resource.Attribute.showText;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.showTitle = global::SextantSample.Droid.Resource.Attribute.showTitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.singleChoiceItemLayout = global::SextantSample.Droid.Resource.Attribute.singleChoiceItemLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.singleLine = global::SextantSample.Droid.Resource.Attribute.singleLine;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.singleSelection = global::SextantSample.Droid.Resource.Attribute.singleSelection;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.snackbarButtonStyle = global::SextantSample.Droid.Resource.Attribute.snackbarButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.snackbarStyle = global::SextantSample.Droid.Resource.Attribute.snackbarStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.spanCount = global::SextantSample.Droid.Resource.Attribute.spanCount;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.spinBars = global::SextantSample.Droid.Resource.Attribute.spinBars;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.spinnerDropDownItemStyle = global::SextantSample.Droid.Resource.Attribute.spinnerDropDownItemStyle;
@@ -321,8 +419,12 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_above_anchor = global::SextantSample.Droid.Resource.Attribute.state_above_anchor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_collapsed = global::SextantSample.Droid.Resource.Attribute.state_collapsed;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_collapsible = global::SextantSample.Droid.Resource.Attribute.state_collapsible;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_liftable = global::SextantSample.Droid.Resource.Attribute.state_liftable;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.state_lifted = global::SextantSample.Droid.Resource.Attribute.state_lifted;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.statusBarBackground = global::SextantSample.Droid.Resource.Attribute.statusBarBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.statusBarScrim = global::SextantSample.Droid.Resource.Attribute.statusBarScrim;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.strokeColor = global::SextantSample.Droid.Resource.Attribute.strokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.strokeWidth = global::SextantSample.Droid.Resource.Attribute.strokeWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.subMenuArrow = global::SextantSample.Droid.Resource.Attribute.subMenuArrow;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.submitBackground = global::SextantSample.Droid.Resource.Attribute.submitBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.subtitle = global::SextantSample.Droid.Resource.Attribute.subtitle;
@@ -337,8 +439,15 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabBackground = global::SextantSample.Droid.Resource.Attribute.tabBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabContentStart = global::SextantSample.Droid.Resource.Attribute.tabContentStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabGravity = global::SextantSample.Droid.Resource.Attribute.tabGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIconTint = global::SextantSample.Droid.Resource.Attribute.tabIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIconTintMode = global::SextantSample.Droid.Resource.Attribute.tabIconTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicator = global::SextantSample.Droid.Resource.Attribute.tabIndicator;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorAnimationDuration = global::SextantSample.Droid.Resource.Attribute.tabIndicatorAnimationDuration;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorColor = global::SextantSample.Droid.Resource.Attribute.tabIndicatorColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorFullWidth = global::SextantSample.Droid.Resource.Attribute.tabIndicatorFullWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorGravity = global::SextantSample.Droid.Resource.Attribute.tabIndicatorGravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabIndicatorHeight = global::SextantSample.Droid.Resource.Attribute.tabIndicatorHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabInlineLabel = global::SextantSample.Droid.Resource.Attribute.tabInlineLabel;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabMaxWidth = global::SextantSample.Droid.Resource.Attribute.tabMaxWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabMinWidth = global::SextantSample.Droid.Resource.Attribute.tabMinWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabMode = global::SextantSample.Droid.Resource.Attribute.tabMode;
@@ -347,21 +456,39 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabPaddingEnd = global::SextantSample.Droid.Resource.Attribute.tabPaddingEnd;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabPaddingStart = global::SextantSample.Droid.Resource.Attribute.tabPaddingStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabPaddingTop = global::SextantSample.Droid.Resource.Attribute.tabPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabRippleColor = global::SextantSample.Droid.Resource.Attribute.tabRippleColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabSelectedTextColor = global::SextantSample.Droid.Resource.Attribute.tabSelectedTextColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabStyle = global::SextantSample.Droid.Resource.Attribute.tabStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabTextAppearance = global::SextantSample.Droid.Resource.Attribute.tabTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabTextColor = global::SextantSample.Droid.Resource.Attribute.tabTextColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.tabUnboundedRipple = global::SextantSample.Droid.Resource.Attribute.tabUnboundedRipple;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAllCaps = global::SextantSample.Droid.Resource.Attribute.textAllCaps;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceBody1 = global::SextantSample.Droid.Resource.Attribute.textAppearanceBody1;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceBody2 = global::SextantSample.Droid.Resource.Attribute.textAppearanceBody2;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceButton = global::SextantSample.Droid.Resource.Attribute.textAppearanceButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceCaption = global::SextantSample.Droid.Resource.Attribute.textAppearanceCaption;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline1 = global::SextantSample.Droid.Resource.Attribute.textAppearanceHeadline1;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline2 = global::SextantSample.Droid.Resource.Attribute.textAppearanceHeadline2;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline3 = global::SextantSample.Droid.Resource.Attribute.textAppearanceHeadline3;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline4 = global::SextantSample.Droid.Resource.Attribute.textAppearanceHeadline4;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline5 = global::SextantSample.Droid.Resource.Attribute.textAppearanceHeadline5;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceHeadline6 = global::SextantSample.Droid.Resource.Attribute.textAppearanceHeadline6;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceLargePopupMenu = global::SextantSample.Droid.Resource.Attribute.textAppearanceLargePopupMenu;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceListItem = global::SextantSample.Droid.Resource.Attribute.textAppearanceListItem;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceListItemSecondary = global::SextantSample.Droid.Resource.Attribute.textAppearanceListItemSecondary;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceListItemSmall = global::SextantSample.Droid.Resource.Attribute.textAppearanceListItemSmall;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceOverline = global::SextantSample.Droid.Resource.Attribute.textAppearanceOverline;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearancePopupMenuHeader = global::SextantSample.Droid.Resource.Attribute.textAppearancePopupMenuHeader;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSearchResultSubtitle = global::SextantSample.Droid.Resource.Attribute.textAppearanceSearchResultSubtitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSearchResultTitle = global::SextantSample.Droid.Resource.Attribute.textAppearanceSearchResultTitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSmallPopupMenu = global::SextantSample.Droid.Resource.Attribute.textAppearanceSmallPopupMenu;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSubtitle1 = global::SextantSample.Droid.Resource.Attribute.textAppearanceSubtitle1;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textAppearanceSubtitle2 = global::SextantSample.Droid.Resource.Attribute.textAppearanceSubtitle2;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textColorAlertDialogListItem = global::SextantSample.Droid.Resource.Attribute.textColorAlertDialogListItem;
-			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textColorError = global::SextantSample.Droid.Resource.Attribute.textColorError;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textColorSearchUrl = global::SextantSample.Droid.Resource.Attribute.textColorSearchUrl;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textEndPadding = global::SextantSample.Droid.Resource.Attribute.textEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textInputStyle = global::SextantSample.Droid.Resource.Attribute.textInputStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.textStartPadding = global::SextantSample.Droid.Resource.Attribute.textStartPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.theme = global::SextantSample.Droid.Resource.Attribute.theme;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.thickness = global::SextantSample.Droid.Resource.Attribute.thickness;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.thumbTextPadding = global::SextantSample.Droid.Resource.Attribute.thumbTextPadding;
@@ -392,7 +519,9 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.track = global::SextantSample.Droid.Resource.Attribute.track;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.trackTint = global::SextantSample.Droid.Resource.Attribute.trackTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.trackTintMode = global::SextantSample.Droid.Resource.Attribute.trackTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.ttcIndex = global::SextantSample.Droid.Resource.Attribute.ttcIndex;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.useCompatPadding = global::SextantSample.Droid.Resource.Attribute.useCompatPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.viewInflaterClass = global::SextantSample.Droid.Resource.Attribute.viewInflaterClass;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.voiceIcon = global::SextantSample.Droid.Resource.Attribute.voiceIcon;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.windowActionBar = global::SextantSample.Droid.Resource.Attribute.windowActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.windowActionBarOverlay = global::SextantSample.Droid.Resource.Attribute.windowActionBarOverlay;
@@ -407,8 +536,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_action_bar_embed_tabs = global::SextantSample.Droid.Resource.Boolean.abc_action_bar_embed_tabs;
 			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_allow_stacked_button_bar = global::SextantSample.Droid.Resource.Boolean.abc_allow_stacked_button_bar;
 			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_config_actionMenuItemAllCaps = global::SextantSample.Droid.Resource.Boolean.abc_config_actionMenuItemAllCaps;
-			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_config_closeDialogWhenTouchOutside = global::SextantSample.Droid.Resource.Boolean.abc_config_closeDialogWhenTouchOutside;
-			global::Xamarin.Forms.Platform.Android.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent = global::SextantSample.Droid.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent;
+			global::Xamarin.Forms.Platform.Android.Resource.Boolean.mtrl_btn_textappearance_all_caps = global::SextantSample.Droid.Resource.Boolean.mtrl_btn_textappearance_all_caps;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.abc_background_cache_hint_selector_material_dark = global::SextantSample.Droid.Resource.Color.abc_background_cache_hint_selector_material_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.abc_background_cache_hint_selector_material_light = global::SextantSample.Droid.Resource.Color.abc_background_cache_hint_selector_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.abc_btn_colored_borderless_text_material = global::SextantSample.Droid.Resource.Color.abc_btn_colored_borderless_text_material;
@@ -452,6 +580,8 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Color.cardview_shadow_end_color = global::SextantSample.Droid.Resource.Color.cardview_shadow_end_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.cardview_shadow_start_color = global::SextantSample.Droid.Resource.Color.cardview_shadow_start_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.design_bottom_navigation_shadow_color = global::SextantSample.Droid.Resource.Color.design_bottom_navigation_shadow_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.design_default_color_primary = global::SextantSample.Droid.Resource.Color.design_default_color_primary;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.design_default_color_primary_dark = global::SextantSample.Droid.Resource.Color.design_default_color_primary_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.design_error = global::SextantSample.Droid.Resource.Color.design_error;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.design_fab_shadow_end_color = global::SextantSample.Droid.Resource.Color.design_fab_shadow_end_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.design_fab_shadow_mid_color = global::SextantSample.Droid.Resource.Color.design_fab_shadow_mid_color;
@@ -466,7 +596,8 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Color.dim_foreground_disabled_material_light = global::SextantSample.Droid.Resource.Color.dim_foreground_disabled_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.dim_foreground_material_dark = global::SextantSample.Droid.Resource.Color.dim_foreground_material_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.dim_foreground_material_light = global::SextantSample.Droid.Resource.Color.dim_foreground_material_light;
-			global::Xamarin.Forms.Platform.Android.Resource.Color.error_color_material = global::SextantSample.Droid.Resource.Color.error_color_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.error_color_material_dark = global::SextantSample.Droid.Resource.Color.error_color_material_dark;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.error_color_material_light = global::SextantSample.Droid.Resource.Color.error_color_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.foreground_material_dark = global::SextantSample.Droid.Resource.Color.foreground_material_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.foreground_material_light = global::SextantSample.Droid.Resource.Color.foreground_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.highlighted_text_material_dark = global::SextantSample.Droid.Resource.Color.highlighted_text_material_dark;
@@ -483,6 +614,32 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Color.material_grey_800 = global::SextantSample.Droid.Resource.Color.material_grey_800;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.material_grey_850 = global::SextantSample.Droid.Resource.Color.material_grey_850;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.material_grey_900 = global::SextantSample.Droid.Resource.Color.material_grey_900;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_bottom_nav_colored_item_tint = global::SextantSample.Droid.Resource.Color.mtrl_bottom_nav_colored_item_tint;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_bottom_nav_item_tint = global::SextantSample.Droid.Resource.Color.mtrl_bottom_nav_item_tint;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_bg_color_disabled = global::SextantSample.Droid.Resource.Color.mtrl_btn_bg_color_disabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_bg_color_selector = global::SextantSample.Droid.Resource.Color.mtrl_btn_bg_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_ripple_color = global::SextantSample.Droid.Resource.Color.mtrl_btn_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_stroke_color_selector = global::SextantSample.Droid.Resource.Color.mtrl_btn_stroke_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_text_btn_ripple_color = global::SextantSample.Droid.Resource.Color.mtrl_btn_text_btn_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_text_color_disabled = global::SextantSample.Droid.Resource.Color.mtrl_btn_text_color_disabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_text_color_selector = global::SextantSample.Droid.Resource.Color.mtrl_btn_text_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_btn_transparent_bg_color = global::SextantSample.Droid.Resource.Color.mtrl_btn_transparent_bg_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_chip_background_color = global::SextantSample.Droid.Resource.Color.mtrl_chip_background_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_chip_close_icon_tint = global::SextantSample.Droid.Resource.Color.mtrl_chip_close_icon_tint;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_chip_ripple_color = global::SextantSample.Droid.Resource.Color.mtrl_chip_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_chip_text_color = global::SextantSample.Droid.Resource.Color.mtrl_chip_text_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_fab_ripple_color = global::SextantSample.Droid.Resource.Color.mtrl_fab_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_scrim_color = global::SextantSample.Droid.Resource.Color.mtrl_scrim_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_colored_ripple_color = global::SextantSample.Droid.Resource.Color.mtrl_tabs_colored_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_icon_color_selector = global::SextantSample.Droid.Resource.Color.mtrl_tabs_icon_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_icon_color_selector_colored = global::SextantSample.Droid.Resource.Color.mtrl_tabs_icon_color_selector_colored;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_legacy_text_color_selector = global::SextantSample.Droid.Resource.Color.mtrl_tabs_legacy_text_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_tabs_ripple_color = global::SextantSample.Droid.Resource.Color.mtrl_tabs_ripple_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_text_btn_text_color_selector = global::SextantSample.Droid.Resource.Color.mtrl_text_btn_text_color_selector;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_textinput_default_box_stroke_color = global::SextantSample.Droid.Resource.Color.mtrl_textinput_default_box_stroke_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_textinput_disabled_color = global::SextantSample.Droid.Resource.Color.mtrl_textinput_disabled_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_textinput_filled_box_default_background_color = global::SextantSample.Droid.Resource.Color.mtrl_textinput_filled_box_default_background_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Color.mtrl_textinput_hovered_box_stroke_color = global::SextantSample.Droid.Resource.Color.mtrl_textinput_hovered_box_stroke_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.notification_action_color_filter = global::SextantSample.Droid.Resource.Color.notification_action_color_filter;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.notification_icon_bg_color = global::SextantSample.Droid.Resource.Color.notification_icon_bg_color;
 			global::Xamarin.Forms.Platform.Android.Resource.Color.notification_material_background_media_default_color = global::SextantSample.Droid.Resource.Color.notification_material_background_media_default_color;
@@ -517,7 +674,6 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_icon_vertical_padding_material = global::SextantSample.Droid.Resource.Dimension.abc_action_bar_icon_vertical_padding_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_overflow_padding_end_material = global::SextantSample.Droid.Resource.Dimension.abc_action_bar_overflow_padding_end_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_overflow_padding_start_material = global::SextantSample.Droid.Resource.Dimension.abc_action_bar_overflow_padding_start_material;
-			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_progress_bar_size = global::SextantSample.Droid.Resource.Dimension.abc_action_bar_progress_bar_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_stacked_max_height = global::SextantSample.Droid.Resource.Dimension.abc_action_bar_stacked_max_height;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_stacked_tab_max_width = global::SextantSample.Droid.Resource.Dimension.abc_action_bar_stacked_tab_max_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_bar_subtitle_bottom_margin_material = global::SextantSample.Droid.Resource.Dimension.abc_action_bar_subtitle_bottom_margin_material;
@@ -526,6 +682,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_button_min_width_material = global::SextantSample.Droid.Resource.Dimension.abc_action_button_min_width_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_action_button_min_width_overflow_material = global::SextantSample.Droid.Resource.Dimension.abc_action_button_min_width_overflow_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_alert_dialog_button_bar_height = global::SextantSample.Droid.Resource.Dimension.abc_alert_dialog_button_bar_height;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_alert_dialog_button_dimen = global::SextantSample.Droid.Resource.Dimension.abc_alert_dialog_button_dimen;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_button_inset_horizontal_material = global::SextantSample.Droid.Resource.Dimension.abc_button_inset_horizontal_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_button_inset_vertical_material = global::SextantSample.Droid.Resource.Dimension.abc_button_inset_vertical_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_button_padding_horizontal_material = global::SextantSample.Droid.Resource.Dimension.abc_button_padding_horizontal_material;
@@ -535,6 +692,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_control_corner_material = global::SextantSample.Droid.Resource.Dimension.abc_control_corner_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_control_inset_material = global::SextantSample.Droid.Resource.Dimension.abc_control_inset_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_control_padding_material = global::SextantSample.Droid.Resource.Dimension.abc_control_padding_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_dialog_corner_radius_material = global::SextantSample.Droid.Resource.Dimension.abc_dialog_corner_radius_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_dialog_fixed_height_major = global::SextantSample.Droid.Resource.Dimension.abc_dialog_fixed_height_major;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_dialog_fixed_height_minor = global::SextantSample.Droid.Resource.Dimension.abc_dialog_fixed_height_minor;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.abc_dialog_fixed_width_major = global::SextantSample.Droid.Resource.Dimension.abc_dialog_fixed_width_major;
@@ -590,11 +748,15 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_button_padding_horizontal_material = global::SextantSample.Droid.Resource.Dimension.compat_button_padding_horizontal_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_button_padding_vertical_material = global::SextantSample.Droid.Resource.Dimension.compat_button_padding_vertical_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_control_corner_material = global::SextantSample.Droid.Resource.Dimension.compat_control_corner_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_notification_large_icon_max_height = global::SextantSample.Droid.Resource.Dimension.compat_notification_large_icon_max_height;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.compat_notification_large_icon_max_width = global::SextantSample.Droid.Resource.Dimension.compat_notification_large_icon_max_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_appbar_elevation = global::SextantSample.Droid.Resource.Dimension.design_appbar_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_active_item_max_width = global::SextantSample.Droid.Resource.Dimension.design_bottom_navigation_active_item_max_width;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_active_item_min_width = global::SextantSample.Droid.Resource.Dimension.design_bottom_navigation_active_item_min_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_active_text_size = global::SextantSample.Droid.Resource.Dimension.design_bottom_navigation_active_text_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_elevation = global::SextantSample.Droid.Resource.Dimension.design_bottom_navigation_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_height = global::SextantSample.Droid.Resource.Dimension.design_bottom_navigation_height;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_icon_size = global::SextantSample.Droid.Resource.Dimension.design_bottom_navigation_icon_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_item_max_width = global::SextantSample.Droid.Resource.Dimension.design_bottom_navigation_item_max_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_item_min_width = global::SextantSample.Droid.Resource.Dimension.design_bottom_navigation_item_min_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_bottom_navigation_margin = global::SextantSample.Droid.Resource.Dimension.design_bottom_navigation_margin;
@@ -607,10 +769,13 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_image_size = global::SextantSample.Droid.Resource.Dimension.design_fab_image_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_size_mini = global::SextantSample.Droid.Resource.Dimension.design_fab_size_mini;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_size_normal = global::SextantSample.Droid.Resource.Dimension.design_fab_size_normal;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_translation_z_hovered_focused = global::SextantSample.Droid.Resource.Dimension.design_fab_translation_z_hovered_focused;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_fab_translation_z_pressed = global::SextantSample.Droid.Resource.Dimension.design_fab_translation_z_pressed;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_elevation = global::SextantSample.Droid.Resource.Dimension.design_navigation_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_icon_padding = global::SextantSample.Droid.Resource.Dimension.design_navigation_icon_padding;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_icon_size = global::SextantSample.Droid.Resource.Dimension.design_navigation_icon_size;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_item_horizontal_padding = global::SextantSample.Droid.Resource.Dimension.design_navigation_item_horizontal_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_item_icon_padding = global::SextantSample.Droid.Resource.Dimension.design_navigation_item_icon_padding;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_max_width = global::SextantSample.Droid.Resource.Dimension.design_navigation_max_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_padding_bottom = global::SextantSample.Droid.Resource.Dimension.design_navigation_padding_bottom;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_navigation_separator_vertical_padding = global::SextantSample.Droid.Resource.Dimension.design_navigation_separator_vertical_padding;
@@ -628,6 +793,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_tab_scrollable_min_width = global::SextantSample.Droid.Resource.Dimension.design_tab_scrollable_min_width;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_tab_text_size = global::SextantSample.Droid.Resource.Dimension.design_tab_text_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_tab_text_size_2line = global::SextantSample.Droid.Resource.Dimension.design_tab_text_size_2line;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.design_textinput_caption_translate_y = global::SextantSample.Droid.Resource.Dimension.design_textinput_caption_translate_y;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.disabled_alpha_material_dark = global::SextantSample.Droid.Resource.Dimension.disabled_alpha_material_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.disabled_alpha_material_light = global::SextantSample.Droid.Resource.Dimension.disabled_alpha_material_light;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.fastscroll_default_thickness = global::SextantSample.Droid.Resource.Dimension.fastscroll_default_thickness;
@@ -643,6 +809,54 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.item_touch_helper_max_drag_scroll_per_frame = global::SextantSample.Droid.Resource.Dimension.item_touch_helper_max_drag_scroll_per_frame;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.item_touch_helper_swipe_escape_max_velocity = global::SextantSample.Droid.Resource.Dimension.item_touch_helper_swipe_escape_max_velocity;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.item_touch_helper_swipe_escape_velocity = global::SextantSample.Droid.Resource.Dimension.item_touch_helper_swipe_escape_velocity;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_fabOffsetEndMode = global::SextantSample.Droid.Resource.Dimension.mtrl_bottomappbar_fabOffsetEndMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_fab_cradle_margin = global::SextantSample.Droid.Resource.Dimension.mtrl_bottomappbar_fab_cradle_margin;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_fab_cradle_rounded_corner_radius = global::SextantSample.Droid.Resource.Dimension.mtrl_bottomappbar_fab_cradle_rounded_corner_radius;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_fab_cradle_vertical_offset = global::SextantSample.Droid.Resource.Dimension.mtrl_bottomappbar_fab_cradle_vertical_offset;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_bottomappbar_height = global::SextantSample.Droid.Resource.Dimension.mtrl_bottomappbar_height;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_corner_radius = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_corner_radius;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_dialog_btn_min_width = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_dialog_btn_min_width;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_disabled_elevation = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_disabled_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_disabled_z = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_disabled_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_elevation = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_focused_z = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_focused_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_hovered_z = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_hovered_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_icon_btn_padding_left = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_icon_btn_padding_left;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_icon_padding = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_icon_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_inset = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_inset;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_letter_spacing = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_letter_spacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_padding_bottom = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_padding_bottom;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_padding_left = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_padding_left;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_padding_right = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_padding_right;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_padding_top = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_padding_top;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_pressed_z = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_pressed_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_stroke_size = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_stroke_size;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_text_btn_icon_padding = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_text_btn_icon_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_text_btn_padding_left = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_text_btn_padding_left;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_text_btn_padding_right = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_text_btn_padding_right;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_text_size = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_text_size;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_btn_z = global::SextantSample.Droid.Resource.Dimension.mtrl_btn_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_card_elevation = global::SextantSample.Droid.Resource.Dimension.mtrl_card_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_card_spacing = global::SextantSample.Droid.Resource.Dimension.mtrl_card_spacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_chip_pressed_translation_z = global::SextantSample.Droid.Resource.Dimension.mtrl_chip_pressed_translation_z;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_chip_text_size = global::SextantSample.Droid.Resource.Dimension.mtrl_chip_text_size;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_fab_elevation = global::SextantSample.Droid.Resource.Dimension.mtrl_fab_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_fab_translation_z_hovered_focused = global::SextantSample.Droid.Resource.Dimension.mtrl_fab_translation_z_hovered_focused;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_fab_translation_z_pressed = global::SextantSample.Droid.Resource.Dimension.mtrl_fab_translation_z_pressed;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_navigation_elevation = global::SextantSample.Droid.Resource.Dimension.mtrl_navigation_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_navigation_item_horizontal_padding = global::SextantSample.Droid.Resource.Dimension.mtrl_navigation_item_horizontal_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_navigation_item_icon_padding = global::SextantSample.Droid.Resource.Dimension.mtrl_navigation_item_icon_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_snackbar_background_corner_radius = global::SextantSample.Droid.Resource.Dimension.mtrl_snackbar_background_corner_radius;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_snackbar_margin = global::SextantSample.Droid.Resource.Dimension.mtrl_snackbar_margin;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_bottom_offset = global::SextantSample.Droid.Resource.Dimension.mtrl_textinput_box_bottom_offset;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_corner_radius_medium = global::SextantSample.Droid.Resource.Dimension.mtrl_textinput_box_corner_radius_medium;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_corner_radius_small = global::SextantSample.Droid.Resource.Dimension.mtrl_textinput_box_corner_radius_small;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_label_cutout_padding = global::SextantSample.Droid.Resource.Dimension.mtrl_textinput_box_label_cutout_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_padding_end = global::SextantSample.Droid.Resource.Dimension.mtrl_textinput_box_padding_end;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_stroke_width_default = global::SextantSample.Droid.Resource.Dimension.mtrl_textinput_box_stroke_width_default;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_box_stroke_width_focused = global::SextantSample.Droid.Resource.Dimension.mtrl_textinput_box_stroke_width_focused;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_textinput_outline_box_expanded_padding = global::SextantSample.Droid.Resource.Dimension.mtrl_textinput_outline_box_expanded_padding;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.mtrl_toolbar_default_height = global::SextantSample.Droid.Resource.Dimension.mtrl_toolbar_default_height;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_action_icon_size = global::SextantSample.Droid.Resource.Dimension.notification_action_icon_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_action_text_size = global::SextantSample.Droid.Resource.Dimension.notification_action_text_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_big_circle_margin = global::SextantSample.Droid.Resource.Dimension.notification_big_circle_margin;
@@ -658,6 +872,10 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_subtext_size = global::SextantSample.Droid.Resource.Dimension.notification_subtext_size;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_top_pad = global::SextantSample.Droid.Resource.Dimension.notification_top_pad;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.notification_top_pad_large_text = global::SextantSample.Droid.Resource.Dimension.notification_top_pad_large_text;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.subtitle_corner_radius = global::SextantSample.Droid.Resource.Dimension.subtitle_corner_radius;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.subtitle_outline_width = global::SextantSample.Droid.Resource.Dimension.subtitle_outline_width;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.subtitle_shadow_offset = global::SextantSample.Droid.Resource.Dimension.subtitle_shadow_offset;
+			global::Xamarin.Forms.Platform.Android.Resource.Dimension.subtitle_shadow_radius = global::SextantSample.Droid.Resource.Dimension.subtitle_shadow_radius;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.tooltip_corner_radius = global::SextantSample.Droid.Resource.Dimension.tooltip_corner_radius;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.tooltip_horizontal_padding = global::SextantSample.Droid.Resource.Dimension.tooltip_horizontal_padding;
 			global::Xamarin.Forms.Platform.Android.Resource.Dimension.tooltip_margin = global::SextantSample.Droid.Resource.Dimension.tooltip_margin;
@@ -706,6 +924,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_ic_voice_search_api_material = global::SextantSample.Droid.Resource.Drawable.abc_ic_voice_search_api_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_item_background_holo_dark = global::SextantSample.Droid.Resource.Drawable.abc_item_background_holo_dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_item_background_holo_light = global::SextantSample.Droid.Resource.Drawable.abc_item_background_holo_light;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_list_divider_material = global::SextantSample.Droid.Resource.Drawable.abc_list_divider_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_list_divider_mtrl_alpha = global::SextantSample.Droid.Resource.Drawable.abc_list_divider_mtrl_alpha;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_list_focused_holo = global::SextantSample.Droid.Resource.Drawable.abc_list_focused_holo;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_list_longpressed_holo = global::SextantSample.Droid.Resource.Drawable.abc_list_longpressed_holo;
@@ -750,19 +969,18 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_textfield_search_material = global::SextantSample.Droid.Resource.Drawable.abc_textfield_search_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.abc_vector_test = global::SextantSample.Droid.Resource.Drawable.abc_vector_test;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.avd_hide_password = global::SextantSample.Droid.Resource.Drawable.avd_hide_password;
-			global::Xamarin.Forms.Platform.Android.Resource.Drawable.avd_hide_password_1 = global::SextantSample.Droid.Resource.Drawable.avd_hide_password_1;
-			global::Xamarin.Forms.Platform.Android.Resource.Drawable.avd_hide_password_2 = global::SextantSample.Droid.Resource.Drawable.avd_hide_password_2;
-			global::Xamarin.Forms.Platform.Android.Resource.Drawable.avd_hide_password_3 = global::SextantSample.Droid.Resource.Drawable.avd_hide_password_3;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.avd_show_password = global::SextantSample.Droid.Resource.Drawable.avd_show_password;
-			global::Xamarin.Forms.Platform.Android.Resource.Drawable.avd_show_password_1 = global::SextantSample.Droid.Resource.Drawable.avd_show_password_1;
-			global::Xamarin.Forms.Platform.Android.Resource.Drawable.avd_show_password_2 = global::SextantSample.Droid.Resource.Drawable.avd_show_password_2;
-			global::Xamarin.Forms.Platform.Android.Resource.Drawable.avd_show_password_3 = global::SextantSample.Droid.Resource.Drawable.avd_show_password_3;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.design_bottom_navigation_item_background = global::SextantSample.Droid.Resource.Drawable.design_bottom_navigation_item_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.design_fab_background = global::SextantSample.Droid.Resource.Drawable.design_fab_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.design_ic_visibility = global::SextantSample.Droid.Resource.Drawable.design_ic_visibility;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.design_ic_visibility_off = global::SextantSample.Droid.Resource.Drawable.design_ic_visibility_off;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.design_password_eye = global::SextantSample.Droid.Resource.Drawable.design_password_eye;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.design_snackbar_background = global::SextantSample.Droid.Resource.Drawable.design_snackbar_background;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.ic_mtrl_chip_checked_black = global::SextantSample.Droid.Resource.Drawable.ic_mtrl_chip_checked_black;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.ic_mtrl_chip_checked_circle = global::SextantSample.Droid.Resource.Drawable.ic_mtrl_chip_checked_circle;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.ic_mtrl_chip_close_circle = global::SextantSample.Droid.Resource.Drawable.ic_mtrl_chip_close_circle;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.mtrl_snackbar_background = global::SextantSample.Droid.Resource.Drawable.mtrl_snackbar_background;
+			global::Xamarin.Forms.Platform.Android.Resource.Drawable.mtrl_tabs_default_indicator = global::SextantSample.Droid.Resource.Drawable.mtrl_tabs_default_indicator;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.navigation_empty_icon = global::SextantSample.Droid.Resource.Drawable.navigation_empty_icon;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.notification_action_background = global::SextantSample.Droid.Resource.Drawable.notification_action_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Drawable.notification_bg = global::SextantSample.Droid.Resource.Drawable.notification_bg;
@@ -826,6 +1044,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.clip_vertical = global::SextantSample.Droid.Resource.Id.clip_vertical;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.collapseActionView = global::SextantSample.Droid.Resource.Id.collapseActionView;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.container = global::SextantSample.Droid.Resource.Id.container;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.content = global::SextantSample.Droid.Resource.Id.content;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.contentPanel = global::SextantSample.Droid.Resource.Id.contentPanel;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.coordinator = global::SextantSample.Droid.Resource.Id.coordinator;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.custom = global::SextantSample.Droid.Resource.Id.custom;
@@ -849,11 +1068,13 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.fill = global::SextantSample.Droid.Resource.Id.fill;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.fill_horizontal = global::SextantSample.Droid.Resource.Id.fill_horizontal;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.fill_vertical = global::SextantSample.Droid.Resource.Id.fill_vertical;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.filled = global::SextantSample.Droid.Resource.Id.filled;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.@fixed = global::SextantSample.Droid.Resource.Id.@fixed;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.flyoutcontent_appbar = global::SextantSample.Droid.Resource.Id.flyoutcontent_appbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.flyoutcontent_recycler = global::SextantSample.Droid.Resource.Id.flyoutcontent_recycler;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.forever = global::SextantSample.Droid.Resource.Id.forever;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.ghost_view = global::SextantSample.Droid.Resource.Id.ghost_view;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.group_divider = global::SextantSample.Droid.Resource.Id.group_divider;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.home = global::SextantSample.Droid.Resource.Id.home;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.homeAsUp = global::SextantSample.Droid.Resource.Id.homeAsUp;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.icon = global::SextantSample.Droid.Resource.Id.icon;
@@ -863,6 +1084,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.info = global::SextantSample.Droid.Resource.Id.info;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.italic = global::SextantSample.Droid.Resource.Id.italic;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.item_touch_helper_previous_elevation = global::SextantSample.Droid.Resource.Id.item_touch_helper_previous_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.labeled = global::SextantSample.Droid.Resource.Id.labeled;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.largeLabel = global::SextantSample.Droid.Resource.Id.largeLabel;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.left = global::SextantSample.Droid.Resource.Id.left;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.line1 = global::SextantSample.Droid.Resource.Id.line1;
@@ -870,14 +1092,16 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.listMode = global::SextantSample.Droid.Resource.Id.listMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.list_item = global::SextantSample.Droid.Resource.Id.list_item;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.main_appbar = global::SextantSample.Droid.Resource.Id.main_appbar;
-			global::Xamarin.Forms.Platform.Android.Resource.Id.main_scrollview = global::SextantSample.Droid.Resource.Id.main_scrollview;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.main_tablayout = global::SextantSample.Droid.Resource.Id.main_tablayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.main_toolbar = global::SextantSample.Droid.Resource.Id.main_toolbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.main_viewpager = global::SextantSample.Droid.Resource.Id.main_viewpager;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.masked = global::SextantSample.Droid.Resource.Id.masked;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.media_actions = global::SextantSample.Droid.Resource.Id.media_actions;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.message = global::SextantSample.Droid.Resource.Id.message;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.middle = global::SextantSample.Droid.Resource.Id.middle;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.mini = global::SextantSample.Droid.Resource.Id.mini;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.mtrl_child_content_container = global::SextantSample.Droid.Resource.Id.mtrl_child_content_container;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.mtrl_internal_children_alpha_tag = global::SextantSample.Droid.Resource.Id.mtrl_internal_children_alpha_tag;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.multiply = global::SextantSample.Droid.Resource.Id.multiply;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.navigation_header_container = global::SextantSample.Droid.Resource.Id.navigation_header_container;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.never = global::SextantSample.Droid.Resource.Id.never;
@@ -886,6 +1110,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.notification_background = global::SextantSample.Droid.Resource.Id.notification_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.notification_main_column = global::SextantSample.Droid.Resource.Id.notification_main_column;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.notification_main_column_container = global::SextantSample.Droid.Resource.Id.notification_main_column_container;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.outline = global::SextantSample.Droid.Resource.Id.outline;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.parallax = global::SextantSample.Droid.Resource.Id.parallax;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.parentPanel = global::SextantSample.Droid.Resource.Id.parentPanel;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.parent_matrix = global::SextantSample.Droid.Resource.Id.parent_matrix;
@@ -916,8 +1141,8 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.search_src_text = global::SextantSample.Droid.Resource.Id.search_src_text;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.search_voice_btn = global::SextantSample.Droid.Resource.Id.search_voice_btn;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.select_dialog_listview = global::SextantSample.Droid.Resource.Id.select_dialog_listview;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.selected = global::SextantSample.Droid.Resource.Id.selected;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.shellcontent_appbar = global::SextantSample.Droid.Resource.Id.shellcontent_appbar;
-			global::Xamarin.Forms.Platform.Android.Resource.Id.shellcontent_scrollview = global::SextantSample.Droid.Resource.Id.shellcontent_scrollview;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.shellcontent_toolbar = global::SextantSample.Droid.Resource.Id.shellcontent_toolbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.shortcut = global::SextantSample.Droid.Resource.Id.shortcut;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.showCustom = global::SextantSample.Droid.Resource.Id.showCustom;
@@ -927,6 +1152,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.snackbar_action = global::SextantSample.Droid.Resource.Id.snackbar_action;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.snackbar_text = global::SextantSample.Droid.Resource.Id.snackbar_text;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.snap = global::SextantSample.Droid.Resource.Id.snap;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.snapMargins = global::SextantSample.Droid.Resource.Id.snapMargins;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.spacer = global::SextantSample.Droid.Resource.Id.spacer;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.split_action_bar = global::SextantSample.Droid.Resource.Id.split_action_bar;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.src_atop = global::SextantSample.Droid.Resource.Id.src_atop;
@@ -934,17 +1160,22 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.src_over = global::SextantSample.Droid.Resource.Id.src_over;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.start = global::SextantSample.Droid.Resource.Id.start;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.status_bar_latest_event_content = global::SextantSample.Droid.Resource.Id.status_bar_latest_event_content;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.stretch = global::SextantSample.Droid.Resource.Id.stretch;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.submenuarrow = global::SextantSample.Droid.Resource.Id.submenuarrow;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.submit_area = global::SextantSample.Droid.Resource.Id.submit_area;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.tabMode = global::SextantSample.Droid.Resource.Id.tabMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.tag_transition_group = global::SextantSample.Droid.Resource.Id.tag_transition_group;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.tag_unhandled_key_event_manager = global::SextantSample.Droid.Resource.Id.tag_unhandled_key_event_manager;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.tag_unhandled_key_listeners = global::SextantSample.Droid.Resource.Id.tag_unhandled_key_listeners;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.text = global::SextantSample.Droid.Resource.Id.text;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.text2 = global::SextantSample.Droid.Resource.Id.text2;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.textSpacerNoButtons = global::SextantSample.Droid.Resource.Id.textSpacerNoButtons;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.textSpacerNoTitle = global::SextantSample.Droid.Resource.Id.textSpacerNoTitle;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.textStart = global::SextantSample.Droid.Resource.Id.textStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.text_input_password_toggle = global::SextantSample.Droid.Resource.Id.text_input_password_toggle;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.textinput_counter = global::SextantSample.Droid.Resource.Id.textinput_counter;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.textinput_error = global::SextantSample.Droid.Resource.Id.textinput_error;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.textinput_helper_text = global::SextantSample.Droid.Resource.Id.textinput_helper_text;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.time = global::SextantSample.Droid.Resource.Id.time;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.title = global::SextantSample.Droid.Resource.Id.title;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.titleDividerNoCustom = global::SextantSample.Droid.Resource.Id.titleDividerNoCustom;
@@ -958,6 +1189,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Id.transition_scene_layoutid_cache = global::SextantSample.Droid.Resource.Id.transition_scene_layoutid_cache;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.transition_transform = global::SextantSample.Droid.Resource.Id.transition_transform;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.uniform = global::SextantSample.Droid.Resource.Id.uniform;
+			global::Xamarin.Forms.Platform.Android.Resource.Id.unlabeled = global::SextantSample.Droid.Resource.Id.unlabeled;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.up = global::SextantSample.Droid.Resource.Id.up;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.useLogo = global::SextantSample.Droid.Resource.Id.useLogo;
 			global::Xamarin.Forms.Platform.Android.Resource.Id.view_offset_helper = global::SextantSample.Droid.Resource.Id.view_offset_helper;
@@ -971,9 +1203,18 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.cancel_button_image_alpha = global::SextantSample.Droid.Resource.Integer.cancel_button_image_alpha;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.config_tooltipAnimTime = global::SextantSample.Droid.Resource.Integer.config_tooltipAnimTime;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.design_snackbar_text_max_lines = global::SextantSample.Droid.Resource.Integer.design_snackbar_text_max_lines;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.design_tab_indicator_anim_duration_ms = global::SextantSample.Droid.Resource.Integer.design_tab_indicator_anim_duration_ms;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.hide_password_duration = global::SextantSample.Droid.Resource.Integer.hide_password_duration;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.mtrl_btn_anim_delay_ms = global::SextantSample.Droid.Resource.Integer.mtrl_btn_anim_delay_ms;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.mtrl_btn_anim_duration_ms = global::SextantSample.Droid.Resource.Integer.mtrl_btn_anim_duration_ms;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.mtrl_chip_anim_duration = global::SextantSample.Droid.Resource.Integer.mtrl_chip_anim_duration;
+			global::Xamarin.Forms.Platform.Android.Resource.Integer.mtrl_tab_indicator_anim_duration_ms = global::SextantSample.Droid.Resource.Integer.mtrl_tab_indicator_anim_duration_ms;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.show_password_duration = global::SextantSample.Droid.Resource.Integer.show_password_duration;
 			global::Xamarin.Forms.Platform.Android.Resource.Integer.status_bar_notification_info_maxnum = global::SextantSample.Droid.Resource.Integer.status_bar_notification_info_maxnum;
+			global::Xamarin.Forms.Platform.Android.Resource.Interpolator.mtrl_fast_out_linear_in = global::SextantSample.Droid.Resource.Interpolator.mtrl_fast_out_linear_in;
+			global::Xamarin.Forms.Platform.Android.Resource.Interpolator.mtrl_fast_out_slow_in = global::SextantSample.Droid.Resource.Interpolator.mtrl_fast_out_slow_in;
+			global::Xamarin.Forms.Platform.Android.Resource.Interpolator.mtrl_linear = global::SextantSample.Droid.Resource.Interpolator.mtrl_linear;
+			global::Xamarin.Forms.Platform.Android.Resource.Interpolator.mtrl_linear_out_slow_in = global::SextantSample.Droid.Resource.Interpolator.mtrl_linear_out_slow_in;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_action_bar_title_item = global::SextantSample.Droid.Resource.Layout.abc_action_bar_title_item;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_action_bar_up_container = global::SextantSample.Droid.Resource.Layout.abc_action_bar_up_container;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_action_menu_item_layout = global::SextantSample.Droid.Resource.Layout.abc_action_menu_item_layout;
@@ -985,6 +1226,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_alert_dialog_button_bar_material = global::SextantSample.Droid.Resource.Layout.abc_alert_dialog_button_bar_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_alert_dialog_material = global::SextantSample.Droid.Resource.Layout.abc_alert_dialog_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_alert_dialog_title_material = global::SextantSample.Droid.Resource.Layout.abc_alert_dialog_title_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_cascading_menu_item_layout = global::SextantSample.Droid.Resource.Layout.abc_cascading_menu_item_layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_dialog_title_material = global::SextantSample.Droid.Resource.Layout.abc_dialog_title_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_expanded_menu_layout = global::SextantSample.Droid.Resource.Layout.abc_expanded_menu_layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_list_menu_item_checkbox = global::SextantSample.Droid.Resource.Layout.abc_list_menu_item_checkbox;
@@ -1000,6 +1242,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_search_dropdown_item_icons_2line = global::SextantSample.Droid.Resource.Layout.abc_search_dropdown_item_icons_2line;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_search_view = global::SextantSample.Droid.Resource.Layout.abc_search_view;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_select_dialog_material = global::SextantSample.Droid.Resource.Layout.abc_select_dialog_material;
+			global::Xamarin.Forms.Platform.Android.Resource.Layout.abc_tooltip = global::SextantSample.Droid.Resource.Layout.abc_tooltip;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.BottomTabLayout = global::SextantSample.Droid.Resource.Layout.BottomTabLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.design_bottom_navigation_item = global::SextantSample.Droid.Resource.Layout.design_bottom_navigation_item;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.design_bottom_sheet_dialog = global::SextantSample.Droid.Resource.Layout.design_bottom_sheet_dialog;
@@ -1016,6 +1259,8 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.design_navigation_menu_item = global::SextantSample.Droid.Resource.Layout.design_navigation_menu_item;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.design_text_input_password_icon = global::SextantSample.Droid.Resource.Layout.design_text_input_password_icon;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.FlyoutContent = global::SextantSample.Droid.Resource.Layout.FlyoutContent;
+			global::Xamarin.Forms.Platform.Android.Resource.Layout.mtrl_layout_snackbar = global::SextantSample.Droid.Resource.Layout.mtrl_layout_snackbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Layout.mtrl_layout_snackbar_include = global::SextantSample.Droid.Resource.Layout.mtrl_layout_snackbar_include;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.notification_action = global::SextantSample.Droid.Resource.Layout.notification_action;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.notification_action_tombstone = global::SextantSample.Droid.Resource.Layout.notification_action_tombstone;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.notification_media_action = global::SextantSample.Droid.Resource.Layout.notification_media_action;
@@ -1037,7 +1282,6 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.select_dialog_singlechoice_material = global::SextantSample.Droid.Resource.Layout.select_dialog_singlechoice_material;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.ShellContent = global::SextantSample.Droid.Resource.Layout.ShellContent;
 			global::Xamarin.Forms.Platform.Android.Resource.Layout.support_simple_spinner_dropdown_item = global::SextantSample.Droid.Resource.Layout.support_simple_spinner_dropdown_item;
-			global::Xamarin.Forms.Platform.Android.Resource.Layout.tooltip = global::SextantSample.Droid.Resource.Layout.tooltip;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_action_bar_home_description = global::SextantSample.Droid.Resource.String.abc_action_bar_home_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_action_bar_up_description = global::SextantSample.Droid.Resource.String.abc_action_bar_up_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_action_menu_overflow_description = global::SextantSample.Droid.Resource.String.abc_action_menu_overflow_description;
@@ -1058,6 +1302,16 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_font_family_menu_material = global::SextantSample.Droid.Resource.String.abc_font_family_menu_material;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_font_family_subhead_material = global::SextantSample.Droid.Resource.String.abc_font_family_subhead_material;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_font_family_title_material = global::SextantSample.Droid.Resource.String.abc_font_family_title_material;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_alt_shortcut_label = global::SextantSample.Droid.Resource.String.abc_menu_alt_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_ctrl_shortcut_label = global::SextantSample.Droid.Resource.String.abc_menu_ctrl_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_delete_shortcut_label = global::SextantSample.Droid.Resource.String.abc_menu_delete_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_enter_shortcut_label = global::SextantSample.Droid.Resource.String.abc_menu_enter_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_function_shortcut_label = global::SextantSample.Droid.Resource.String.abc_menu_function_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_meta_shortcut_label = global::SextantSample.Droid.Resource.String.abc_menu_meta_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_shift_shortcut_label = global::SextantSample.Droid.Resource.String.abc_menu_shift_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_space_shortcut_label = global::SextantSample.Droid.Resource.String.abc_menu_space_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_menu_sym_shortcut_label = global::SextantSample.Droid.Resource.String.abc_menu_sym_shortcut_label;
+			global::Xamarin.Forms.Platform.Android.Resource.String.abc_prepend_shortcut_label = global::SextantSample.Droid.Resource.String.abc_prepend_shortcut_label;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_search_hint = global::SextantSample.Droid.Resource.String.abc_search_hint;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_searchview_description_clear = global::SextantSample.Droid.Resource.String.abc_searchview_description_clear;
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_searchview_description_query = global::SextantSample.Droid.Resource.String.abc_searchview_description_query;
@@ -1069,7 +1323,12 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.String.abc_toolbar_collapse_description = global::SextantSample.Droid.Resource.String.abc_toolbar_collapse_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.appbar_scrolling_view_behavior = global::SextantSample.Droid.Resource.String.appbar_scrolling_view_behavior;
 			global::Xamarin.Forms.Platform.Android.Resource.String.bottom_sheet_behavior = global::SextantSample.Droid.Resource.String.bottom_sheet_behavior;
+			global::Xamarin.Forms.Platform.Android.Resource.String.character_counter_content_description = global::SextantSample.Droid.Resource.String.character_counter_content_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.character_counter_pattern = global::SextantSample.Droid.Resource.String.character_counter_pattern;
+			global::Xamarin.Forms.Platform.Android.Resource.String.fab_transformation_scrim_behavior = global::SextantSample.Droid.Resource.String.fab_transformation_scrim_behavior;
+			global::Xamarin.Forms.Platform.Android.Resource.String.fab_transformation_sheet_behavior = global::SextantSample.Droid.Resource.String.fab_transformation_sheet_behavior;
+			global::Xamarin.Forms.Platform.Android.Resource.String.hide_bottom_view_on_scroll_behavior = global::SextantSample.Droid.Resource.String.hide_bottom_view_on_scroll_behavior;
+			global::Xamarin.Forms.Platform.Android.Resource.String.mtrl_chip_close_icon_content_description = global::SextantSample.Droid.Resource.String.mtrl_chip_close_icon_content_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.password_toggle_content_description = global::SextantSample.Droid.Resource.String.password_toggle_content_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.path_password_eye = global::SextantSample.Droid.Resource.String.path_password_eye;
 			global::Xamarin.Forms.Platform.Android.Resource.String.path_password_eye_mask_strike_through = global::SextantSample.Droid.Resource.String.path_password_eye_mask_strike_through;
@@ -1153,6 +1412,23 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_AppCompat_Light_Dialog_FixedSize = global::SextantSample.Droid.Resource.Style.Base_Theme_AppCompat_Light_Dialog_FixedSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_AppCompat_Light_Dialog_MinWidth = global::SextantSample.Droid.Resource.Style.Base_Theme_AppCompat_Light_Dialog_MinWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_AppCompat_Light_DialogWhenLarge = global::SextantSample.Droid.Resource.Style.Base_Theme_AppCompat_Light_DialogWhenLarge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Bridge = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_CompactMenu = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_CompactMenu;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Dialog = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Dialog_Alert = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Dialog_FixedSize = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Dialog_FixedSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Dialog_MinWidth = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Dialog_MinWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_DialogWhenLarge = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_DialogWhenLarge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Bridge = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_DarkActionBar = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_DarkActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_DarkActionBar_Bridge = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_DarkActionBar_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_Alert = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_FixedSize = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_FixedSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_MinWidth = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_Dialog_MinWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Theme_MaterialComponents_Light_DialogWhenLarge = global::SextantSample.Droid.Resource.Style.Base_Theme_MaterialComponents_Light_DialogWhenLarge;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat = global::SextantSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar = global::SextantSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_Dark = global::SextantSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark;
@@ -1160,18 +1436,22 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog = global::SextantSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert = global::SextantSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Light;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V11_Theme_AppCompat_Dialog = global::SextantSample.Droid.Resource.Style.Base_V11_Theme_AppCompat_Dialog;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog = global::SextantSample.Droid.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog = global::SextantSample.Droid.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView = global::SextantSample.Droid.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V12_Widget_AppCompat_EditText = global::SextantSample.Droid.Resource.Style.Base_V12_Widget_AppCompat_EditText;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Widget_Design_AppBarLayout = global::SextantSample.Droid.Resource.Style.Base_V14_Widget_Design_AppBarLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_MaterialComponents_Dialog = global::SextantSample.Droid.Resource.Style.Base_ThemeOverlay_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_ThemeOverlay_MaterialComponents_Dialog_Alert = global::SextantSample.Droid.Resource.Style.Base_ThemeOverlay_MaterialComponents_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents = global::SextantSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Bridge = global::SextantSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Dialog = global::SextantSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Light = global::SextantSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Light_Bridge = global::SextantSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Light_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Light_DarkActionBar_Bridge = global::SextantSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Light_DarkActionBar_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_Theme_MaterialComponents_Light_Dialog = global::SextantSample.Droid.Resource.Style.Base_V14_Theme_MaterialComponents_Light_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_ThemeOverlay_MaterialComponents_Dialog = global::SextantSample.Droid.Resource.Style.Base_V14_ThemeOverlay_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V14_ThemeOverlay_MaterialComponents_Dialog_Alert = global::SextantSample.Droid.Resource.Style.Base_V14_ThemeOverlay_MaterialComponents_Dialog_Alert;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Theme_AppCompat = global::SextantSample.Droid.Resource.Style.Base_V21_Theme_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Theme_AppCompat_Dialog = global::SextantSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Theme_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog = global::SextantSample.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog = global::SextantSample.Droid.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V21_Widget_Design_AppBarLayout = global::SextantSample.Droid.Resource.Style.Base_V21_Widget_Design_AppBarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V22_Theme_AppCompat = global::SextantSample.Droid.Resource.Style.Base_V22_Theme_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V22_Theme_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Base_V22_Theme_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V23_Theme_AppCompat = global::SextantSample.Droid.Resource.Style.Base_V23_Theme_AppCompat;
@@ -1179,7 +1459,8 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V26_Theme_AppCompat = global::SextantSample.Droid.Resource.Style.Base_V26_Theme_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V26_Theme_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Base_V26_Theme_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V26_Widget_AppCompat_Toolbar = global::SextantSample.Droid.Resource.Style.Base_V26_Widget_AppCompat_Toolbar;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V26_Widget_Design_AppBarLayout = global::SextantSample.Droid.Resource.Style.Base_V26_Widget_Design_AppBarLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V28_Theme_AppCompat = global::SextantSample.Droid.Resource.Style.Base_V28_Theme_AppCompat;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V28_Theme_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Base_V28_Theme_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V7_Theme_AppCompat = global::SextantSample.Droid.Resource.Style.Base_V7_Theme_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V7_Theme_AppCompat_Dialog = global::SextantSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_V7_Theme_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light;
@@ -1245,20 +1526,22 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem = global::SextantSample.Droid.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_AppCompat_Toolbar = global::SextantSample.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_AppCompat_Toolbar_Button_Navigation = global::SextantSample.Droid.Resource.Style.Base_Widget_AppCompat_Toolbar_Button_Navigation;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_Design_AppBarLayout = global::SextantSample.Droid.Resource.Style.Base_Widget_Design_AppBarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_Design_TabLayout = global::SextantSample.Droid.Resource.Style.Base_Widget_Design_TabLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_MaterialComponents_Chip = global::SextantSample.Droid.Resource.Style.Base_Widget_MaterialComponents_Chip;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_MaterialComponents_TextInputEditText = global::SextantSample.Droid.Resource.Style.Base_Widget_MaterialComponents_TextInputEditText;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Base_Widget_MaterialComponents_TextInputLayout = global::SextantSample.Droid.Resource.Style.Base_Widget_MaterialComponents_TextInputLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.CardView = global::SextantSample.Droid.Resource.Style.CardView;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.CardView_Dark = global::SextantSample.Droid.Resource.Style.CardView_Dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.CardView_Light = global::SextantSample.Droid.Resource.Style.CardView_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_AppCompat = global::SextantSample.Droid.Resource.Style.Platform_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Platform_AppCompat_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_MaterialComponents = global::SextantSample.Droid.Resource.Style.Platform_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_MaterialComponents_Dialog = global::SextantSample.Droid.Resource.Style.Platform_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_MaterialComponents_Light = global::SextantSample.Droid.Resource.Style.Platform_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_MaterialComponents_Light_Dialog = global::SextantSample.Droid.Resource.Style.Platform_MaterialComponents_Light_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_ThemeOverlay_AppCompat = global::SextantSample.Droid.Resource.Style.Platform_ThemeOverlay_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_ThemeOverlay_AppCompat_Dark = global::SextantSample.Droid.Resource.Style.Platform_ThemeOverlay_AppCompat_Dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_ThemeOverlay_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Platform_ThemeOverlay_AppCompat_Light;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V11_AppCompat = global::SextantSample.Droid.Resource.Style.Platform_V11_AppCompat;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V11_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Platform_V11_AppCompat_Light;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V14_AppCompat = global::SextantSample.Droid.Resource.Style.Platform_V14_AppCompat;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V14_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Platform_V14_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V21_AppCompat = global::SextantSample.Droid.Resource.Style.Platform_V21_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V21_AppCompat_Light = global::SextantSample.Droid.Resource.Style.Platform_V21_AppCompat_Light;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_V25_AppCompat = global::SextantSample.Droid.Resource.Style.Platform_V25_AppCompat;
@@ -1269,7 +1552,10 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_DialogTitle_Icon = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_DialogTitle_Icon;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Shortcut = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Shortcut;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_SubmenuArrow = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_SubmenuArrow;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Text;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Title = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_PopupMenuItem_Title;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = global::SextantSample.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2;
@@ -1340,9 +1626,25 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Counter = global::SextantSample.Droid.Resource.Style.TextAppearance_Design_Counter;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Counter_Overflow = global::SextantSample.Droid.Resource.Style.TextAppearance_Design_Counter_Overflow;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Error = global::SextantSample.Droid.Resource.Style.TextAppearance_Design_Error;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_HelperText = global::SextantSample.Droid.Resource.Style.TextAppearance_Design_HelperText;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Hint = global::SextantSample.Droid.Resource.Style.TextAppearance_Design_Hint;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Snackbar_Message = global::SextantSample.Droid.Resource.Style.TextAppearance_Design_Snackbar_Message;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Design_Tab = global::SextantSample.Droid.Resource.Style.TextAppearance_Design_Tab;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Body1 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Body1;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Body2 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Body2;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Button = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Button;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Caption = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Caption;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Chip = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Chip;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline1 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline1;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline2 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline2;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline3 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline3;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline4 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline4;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline5 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline5;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Headline6 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Headline6;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Overline = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Overline;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Subtitle1 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Subtitle1;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Subtitle2 = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Subtitle2;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_MaterialComponents_Tab = global::SextantSample.Droid.Resource.Style.TextAppearance_MaterialComponents_Tab;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Widget_AppCompat_ExpandedMenu_Item = global::SextantSample.Droid.Resource.Style.TextAppearance_Widget_AppCompat_ExpandedMenu_Item;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Widget_AppCompat_Toolbar_Subtitle = global::SextantSample.Droid.Resource.Style.TextAppearance_Widget_AppCompat_Toolbar_Subtitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.TextAppearance_Widget_AppCompat_Toolbar_Title = global::SextantSample.Droid.Resource.Style.TextAppearance_Widget_AppCompat_Toolbar_Title;
@@ -1373,6 +1675,27 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_Design_Light_BottomSheetDialog = global::SextantSample.Droid.Resource.Style.Theme_Design_Light_BottomSheetDialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_Design_Light_NoActionBar = global::SextantSample.Droid.Resource.Style.Theme_Design_Light_NoActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_Design_NoActionBar = global::SextantSample.Droid.Resource.Style.Theme_Design_NoActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_BottomSheetDialog = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_BottomSheetDialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Bridge = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_CompactMenu = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_CompactMenu;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Dialog = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Dialog_Alert = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Dialog_MinWidth = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Dialog_MinWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_DialogWhenLarge = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_DialogWhenLarge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_BottomSheetDialog = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_BottomSheetDialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_Bridge = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_DarkActionBar = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_DarkActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_DarkActionBar_Bridge = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_DarkActionBar_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_Dialog = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_Dialog_Alert = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_Dialog_MinWidth = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_Dialog_MinWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_DialogWhenLarge = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_DialogWhenLarge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_NoActionBar = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_NoActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_Light_NoActionBar_Bridge = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_Light_NoActionBar_Bridge;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_NoActionBar = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_NoActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Theme_MaterialComponents_NoActionBar_Bridge = global::SextantSample.Droid.Resource.Style.Theme_MaterialComponents_NoActionBar_Bridge;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat = global::SextantSample.Droid.Resource.Style.ThemeOverlay_AppCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_ActionBar = global::SextantSample.Droid.Resource.Style.ThemeOverlay_AppCompat_ActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_Dark = global::SextantSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark;
@@ -1380,6 +1703,18 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_Dialog = global::SextantSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert = global::SextantSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_AppCompat_Light = global::SextantSample.Droid.Resource.Style.ThemeOverlay_AppCompat_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_ActionBar = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_ActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Dark = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Dark;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Dark_ActionBar = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Dark_ActionBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Dialog = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Dialog_Alert = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Dialog_Alert;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_Light = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_Light;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox_Dense = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox_Dense = global::SextantSample.Droid.Resource.Style.ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox_Dense;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_AppCompat_ActionBar = global::SextantSample.Droid.Resource.Style.Widget_AppCompat_ActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_AppCompat_ActionBar_Solid = global::SextantSample.Droid.Resource.Style.Widget_AppCompat_ActionBar_Solid;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_AppCompat_ActionBar_TabBar = global::SextantSample.Droid.Resource.Style.Widget_AppCompat_ActionBar_TabBar;
@@ -1458,13 +1793,50 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_BottomNavigationView = global::SextantSample.Droid.Resource.Style.Widget_Design_BottomNavigationView;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_BottomSheet_Modal = global::SextantSample.Droid.Resource.Style.Widget_Design_BottomSheet_Modal;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_CollapsingToolbar = global::SextantSample.Droid.Resource.Style.Widget_Design_CollapsingToolbar;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_CoordinatorLayout = global::SextantSample.Droid.Resource.Style.Widget_Design_CoordinatorLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_FloatingActionButton = global::SextantSample.Droid.Resource.Style.Widget_Design_FloatingActionButton;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_NavigationView = global::SextantSample.Droid.Resource.Style.Widget_Design_NavigationView;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_ScrimInsetsFrameLayout = global::SextantSample.Droid.Resource.Style.Widget_Design_ScrimInsetsFrameLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_Snackbar = global::SextantSample.Droid.Resource.Style.Widget_Design_Snackbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_TabLayout = global::SextantSample.Droid.Resource.Style.Widget_Design_TabLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Design_TextInputLayout = global::SextantSample.Droid.Resource.Style.Widget_Design_TextInputLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomAppBar = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_BottomAppBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomAppBar_Colored = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_BottomAppBar_Colored;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomNavigationView = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_BottomNavigationView;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomNavigationView_Colored = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_BottomNavigationView_Colored;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_BottomSheet_Modal = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_BottomSheet_Modal;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_Icon = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_OutlinedButton = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button_OutlinedButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_OutlinedButton_Icon = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button_OutlinedButton_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_TextButton = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button_TextButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_TextButton_Dialog = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button_TextButton_Dialog;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_TextButton_Dialog_Icon = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button_TextButton_Dialog_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_TextButton_Icon = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button_TextButton_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_UnelevatedButton = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button_UnelevatedButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Button_UnelevatedButton_Icon = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Button_UnelevatedButton_Icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_CardView = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_CardView;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Chip_Action = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Chip_Action;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Chip_Choice = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Chip_Choice;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Chip_Entry = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Chip_Entry;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Chip_Filter = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Chip_Filter;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_ChipGroup = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_ChipGroup;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_FloatingActionButton = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_FloatingActionButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_NavigationView = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_NavigationView;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Snackbar = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Snackbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Snackbar_FullWidth = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Snackbar_FullWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TabLayout = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TabLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TabLayout_Colored = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TabLayout_Colored;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputEditText_FilledBox = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputEditText_FilledBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputEditText_FilledBox_Dense = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputEditText_FilledBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputEditText_OutlinedBox = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputEditText_OutlinedBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputEditText_OutlinedBox_Dense = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputEditText_OutlinedBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputLayout_FilledBox = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputLayout_FilledBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputLayout_FilledBox_Dense = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputLayout_FilledBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_MaterialComponents_Toolbar = global::SextantSample.Droid.Resource.Style.Widget_MaterialComponents_Toolbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.Widget_Support_CoordinatorLayout = global::SextantSample.Droid.Resource.Style.Widget_Support_CoordinatorLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.collectionViewStyle = global::SextantSample.Droid.Resource.Style.collectionViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActionBar = global::SextantSample.Droid.Resource.Styleable.ActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActionBar_background = global::SextantSample.Droid.Resource.Styleable.ActionBar_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActionBar_backgroundSplit = global::SextantSample.Droid.Resource.Styleable.ActionBar_backgroundSplit;
@@ -1512,21 +1884,40 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ActivityChooserView_initialActivityCount = global::SextantSample.Droid.Resource.Styleable.ActivityChooserView_initialActivityCount;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog = global::SextantSample.Droid.Resource.Styleable.AlertDialog;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_android_layout = global::SextantSample.Droid.Resource.Styleable.AlertDialog_android_layout;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_buttonIconDimen = global::SextantSample.Droid.Resource.Styleable.AlertDialog_buttonIconDimen;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_buttonPanelSideLayout = global::SextantSample.Droid.Resource.Styleable.AlertDialog_buttonPanelSideLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_listItemLayout = global::SextantSample.Droid.Resource.Styleable.AlertDialog_listItemLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_listLayout = global::SextantSample.Droid.Resource.Styleable.AlertDialog_listLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_multiChoiceItemLayout = global::SextantSample.Droid.Resource.Styleable.AlertDialog_multiChoiceItemLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_showTitle = global::SextantSample.Droid.Resource.Styleable.AlertDialog_showTitle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AlertDialog_singleChoiceItemLayout = global::SextantSample.Droid.Resource.Styleable.AlertDialog_singleChoiceItemLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_constantSize = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_constantSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_dither = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_dither;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_enterFadeDuration = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_enterFadeDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_exitFadeDuration = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_exitFadeDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_variablePadding = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_variablePadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableCompat_android_visible = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableCompat_android_visible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableItem = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableItem;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableItem_android_drawable = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableItem_android_drawable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableItem_android_id = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableItem_android_id;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition_android_drawable = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition_android_drawable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition_android_fromId = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition_android_fromId;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition_android_reversible = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition_android_reversible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AnimatedStateListDrawableTransition_android_toId = global::SextantSample.Droid.Resource.Styleable.AnimatedStateListDrawableTransition_android_toId;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout = global::SextantSample.Droid.Resource.Styleable.AppBarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_android_background = global::SextantSample.Droid.Resource.Styleable.AppBarLayout_android_background;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_android_keyboardNavigationCluster = global::SextantSample.Droid.Resource.Styleable.AppBarLayout_android_keyboardNavigationCluster;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_android_touchscreenBlocksFocus = global::SextantSample.Droid.Resource.Styleable.AppBarLayout_android_touchscreenBlocksFocus;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_elevation = global::SextantSample.Droid.Resource.Styleable.AppBarLayout_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_expanded = global::SextantSample.Droid.Resource.Styleable.AppBarLayout_expanded;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_liftOnScroll = global::SextantSample.Droid.Resource.Styleable.AppBarLayout_liftOnScroll;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates = global::SextantSample.Droid.Resource.Styleable.AppBarLayoutStates;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates_state_collapsed = global::SextantSample.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsed;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates_state_collapsible = global::SextantSample.Droid.Resource.Styleable.AppBarLayoutStates_state_collapsible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates_state_liftable = global::SextantSample.Droid.Resource.Styleable.AppBarLayoutStates_state_liftable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayoutStates_state_lifted = global::SextantSample.Droid.Resource.Styleable.AppBarLayoutStates_state_lifted;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_Layout = global::SextantSample.Droid.Resource.Styleable.AppBarLayout_Layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_Layout_layout_scrollFlags = global::SextantSample.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollFlags;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppBarLayout_Layout_layout_scrollInterpolator = global::SextantSample.Droid.Resource.Styleable.AppBarLayout_Layout_layout_scrollInterpolator;
@@ -1555,7 +1946,10 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_autoSizePresetSizes = global::SextantSample.Droid.Resource.Styleable.AppCompatTextView_autoSizePresetSizes;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_autoSizeStepGranularity = global::SextantSample.Droid.Resource.Styleable.AppCompatTextView_autoSizeStepGranularity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_autoSizeTextType = global::SextantSample.Droid.Resource.Styleable.AppCompatTextView_autoSizeTextType;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_firstBaselineToTopHeight = global::SextantSample.Droid.Resource.Styleable.AppCompatTextView_firstBaselineToTopHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_fontFamily = global::SextantSample.Droid.Resource.Styleable.AppCompatTextView_fontFamily;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_lastBaselineToBottomHeight = global::SextantSample.Droid.Resource.Styleable.AppCompatTextView_lastBaselineToBottomHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_lineHeight = global::SextantSample.Droid.Resource.Styleable.AppCompatTextView_lineHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTextView_textAllCaps = global::SextantSample.Droid.Resource.Styleable.AppCompatTextView_textAllCaps;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_actionBarDivider = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_actionBarDivider;
@@ -1617,6 +2011,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_colorPrimaryDark = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_colorPrimaryDark;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_colorSwitchThumbNormal = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_colorSwitchThumbNormal;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_controlBackground = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_controlBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_dialogCornerRadius = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_dialogCornerRadius;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_dialogPreferredPadding = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_dialogPreferredPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_dialogTheme = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_dialogTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_dividerHorizontal = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_dividerHorizontal;
@@ -1667,6 +2062,7 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_toolbarStyle = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_toolbarStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_tooltipForegroundColor = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_tooltipForegroundColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_tooltipFrameBackground = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_tooltipFrameBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_viewInflaterClass = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_viewInflaterClass;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowActionBar = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_windowActionBar;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowActionBarOverlay = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_windowActionBarOverlay;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowActionModeOverlay = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_windowActionModeOverlay;
@@ -1677,13 +2073,26 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowMinWidthMajor = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMajor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowMinWidthMinor = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_windowMinWidthMinor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.AppCompatTheme_windowNoTitle = global::SextantSample.Droid.Resource.Styleable.AppCompatTheme_windowNoTitle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar = global::SextantSample.Droid.Resource.Styleable.BottomAppBar;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_backgroundTint = global::SextantSample.Droid.Resource.Styleable.BottomAppBar_backgroundTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_fabAlignmentMode = global::SextantSample.Droid.Resource.Styleable.BottomAppBar_fabAlignmentMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_fabCradleMargin = global::SextantSample.Droid.Resource.Styleable.BottomAppBar_fabCradleMargin;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_fabCradleRoundedCornerRadius = global::SextantSample.Droid.Resource.Styleable.BottomAppBar_fabCradleRoundedCornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_fabCradleVerticalOffset = global::SextantSample.Droid.Resource.Styleable.BottomAppBar_fabCradleVerticalOffset;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomAppBar_hideOnScroll = global::SextantSample.Droid.Resource.Styleable.BottomAppBar_hideOnScroll;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_elevation = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemBackground = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_itemBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemHorizontalTranslationEnabled = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_itemHorizontalTranslationEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemIconSize = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_itemIconSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemIconTint = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_itemIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemTextAppearanceActive = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_itemTextAppearanceActive;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemTextAppearanceInactive = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_itemTextAppearanceInactive;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_itemTextColor = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_itemTextColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_labelVisibilityMode = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_labelVisibilityMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomNavigationView_menu = global::SextantSample.Droid.Resource.Styleable.BottomNavigationView_menu;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout = global::SextantSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout_behavior_fitToContents = global::SextantSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_fitToContents;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout_behavior_hideable = global::SextantSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_hideable;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout_behavior_peekHeight = global::SextantSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_peekHeight;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.BottomSheetBehavior_Layout_behavior_skipCollapsed = global::SextantSample.Droid.Resource.Styleable.BottomSheetBehavior_Layout_behavior_skipCollapsed;
@@ -1703,6 +2112,48 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CardView_contentPaddingLeft = global::SextantSample.Droid.Resource.Styleable.CardView_contentPaddingLeft;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CardView_contentPaddingRight = global::SextantSample.Droid.Resource.Styleable.CardView_contentPaddingRight;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CardView_contentPaddingTop = global::SextantSample.Droid.Resource.Styleable.CardView_contentPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip = global::SextantSample.Droid.Resource.Styleable.Chip;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_checkable = global::SextantSample.Droid.Resource.Styleable.Chip_android_checkable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_ellipsize = global::SextantSample.Droid.Resource.Styleable.Chip_android_ellipsize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_maxWidth = global::SextantSample.Droid.Resource.Styleable.Chip_android_maxWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_text = global::SextantSample.Droid.Resource.Styleable.Chip_android_text;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_android_textAppearance = global::SextantSample.Droid.Resource.Styleable.Chip_android_textAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_checkedIcon = global::SextantSample.Droid.Resource.Styleable.Chip_checkedIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_checkedIconEnabled = global::SextantSample.Droid.Resource.Styleable.Chip_checkedIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_checkedIconVisible = global::SextantSample.Droid.Resource.Styleable.Chip_checkedIconVisible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipBackgroundColor = global::SextantSample.Droid.Resource.Styleable.Chip_chipBackgroundColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipCornerRadius = global::SextantSample.Droid.Resource.Styleable.Chip_chipCornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipEndPadding = global::SextantSample.Droid.Resource.Styleable.Chip_chipEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIcon = global::SextantSample.Droid.Resource.Styleable.Chip_chipIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIconEnabled = global::SextantSample.Droid.Resource.Styleable.Chip_chipIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIconSize = global::SextantSample.Droid.Resource.Styleable.Chip_chipIconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIconTint = global::SextantSample.Droid.Resource.Styleable.Chip_chipIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipIconVisible = global::SextantSample.Droid.Resource.Styleable.Chip_chipIconVisible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipMinHeight = global::SextantSample.Droid.Resource.Styleable.Chip_chipMinHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipStartPadding = global::SextantSample.Droid.Resource.Styleable.Chip_chipStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipStrokeColor = global::SextantSample.Droid.Resource.Styleable.Chip_chipStrokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_chipStrokeWidth = global::SextantSample.Droid.Resource.Styleable.Chip_chipStrokeWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIcon = global::SextantSample.Droid.Resource.Styleable.Chip_closeIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconEnabled = global::SextantSample.Droid.Resource.Styleable.Chip_closeIconEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconEndPadding = global::SextantSample.Droid.Resource.Styleable.Chip_closeIconEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconSize = global::SextantSample.Droid.Resource.Styleable.Chip_closeIconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconStartPadding = global::SextantSample.Droid.Resource.Styleable.Chip_closeIconStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconTint = global::SextantSample.Droid.Resource.Styleable.Chip_closeIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_closeIconVisible = global::SextantSample.Droid.Resource.Styleable.Chip_closeIconVisible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_hideMotionSpec = global::SextantSample.Droid.Resource.Styleable.Chip_hideMotionSpec;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_iconEndPadding = global::SextantSample.Droid.Resource.Styleable.Chip_iconEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_iconStartPadding = global::SextantSample.Droid.Resource.Styleable.Chip_iconStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_rippleColor = global::SextantSample.Droid.Resource.Styleable.Chip_rippleColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_showMotionSpec = global::SextantSample.Droid.Resource.Styleable.Chip_showMotionSpec;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_textEndPadding = global::SextantSample.Droid.Resource.Styleable.Chip_textEndPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Chip_textStartPadding = global::SextantSample.Droid.Resource.Styleable.Chip_textStartPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup = global::SextantSample.Droid.Resource.Styleable.ChipGroup;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_checkedChip = global::SextantSample.Droid.Resource.Styleable.ChipGroup_checkedChip;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_chipSpacing = global::SextantSample.Droid.Resource.Styleable.ChipGroup_chipSpacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_chipSpacingHorizontal = global::SextantSample.Droid.Resource.Styleable.ChipGroup_chipSpacingHorizontal;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_chipSpacingVertical = global::SextantSample.Droid.Resource.Styleable.ChipGroup_chipSpacingVertical;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_singleLine = global::SextantSample.Droid.Resource.Styleable.ChipGroup_singleLine;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ChipGroup_singleSelection = global::SextantSample.Droid.Resource.Styleable.ChipGroup_singleSelection;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CollapsingToolbarLayout = global::SextantSample.Droid.Resource.Styleable.CollapsingToolbarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleGravity = global::SextantSample.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleGravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleTextAppearance = global::SextantSample.Droid.Resource.Styleable.CollapsingToolbarLayout_collapsedTitleTextAppearance;
@@ -1745,7 +2196,6 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DesignTheme = global::SextantSample.Droid.Resource.Styleable.DesignTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DesignTheme_bottomSheetDialogTheme = global::SextantSample.Droid.Resource.Styleable.DesignTheme_bottomSheetDialogTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DesignTheme_bottomSheetStyle = global::SextantSample.Droid.Resource.Styleable.DesignTheme_bottomSheetStyle;
-			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DesignTheme_textColorError = global::SextantSample.Droid.Resource.Styleable.DesignTheme_textColorError;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DrawerArrowToggle = global::SextantSample.Droid.Resource.Styleable.DrawerArrowToggle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DrawerArrowToggle_arrowHeadLength = global::SextantSample.Droid.Resource.Styleable.DrawerArrowToggle_arrowHeadLength;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.DrawerArrowToggle_arrowShaftLength = global::SextantSample.Droid.Resource.Styleable.DrawerArrowToggle_arrowShaftLength;
@@ -1760,12 +2210,20 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_backgroundTintMode = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_backgroundTintMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_borderWidth = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_borderWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_elevation = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_elevation;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_fabCustomSize = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_fabCustomSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_fabSize = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_fabSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_hideMotionSpec = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_hideMotionSpec;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_hoveredFocusedTranslationZ = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_hoveredFocusedTranslationZ;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_maxImageSize = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_maxImageSize;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_pressedTranslationZ = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_pressedTranslationZ;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_rippleColor = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_rippleColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_showMotionSpec = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_showMotionSpec;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_useCompatPadding = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_useCompatPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_Behavior_Layout = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FloatingActionButton_Behavior_Layout_behavior_autoHide = global::SextantSample.Droid.Resource.Styleable.FloatingActionButton_Behavior_Layout_behavior_autoHide;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FlowLayout = global::SextantSample.Droid.Resource.Styleable.FlowLayout;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FlowLayout_itemSpacing = global::SextantSample.Droid.Resource.Styleable.FlowLayout_itemSpacing;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FlowLayout_lineSpacing = global::SextantSample.Droid.Resource.Styleable.FlowLayout_lineSpacing;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamily = global::SextantSample.Droid.Resource.Styleable.FontFamily;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamily_fontProviderAuthority = global::SextantSample.Droid.Resource.Styleable.FontFamily_fontProviderAuthority;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamily_fontProviderCerts = global::SextantSample.Droid.Resource.Styleable.FontFamily_fontProviderCerts;
@@ -1776,14 +2234,34 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_font = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_android_font;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_fontStyle = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_android_fontStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_fontVariationSettings = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_android_fontVariationSettings;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_fontWeight = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_android_fontWeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_android_ttcIndex = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_android_ttcIndex;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_font = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_font;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_fontStyle = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_fontStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_fontVariationSettings = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_fontVariationSettings;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_fontWeight = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_fontWeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.FontFamilyFont_ttcIndex = global::SextantSample.Droid.Resource.Styleable.FontFamilyFont_ttcIndex;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ForegroundLinearLayout = global::SextantSample.Droid.Resource.Styleable.ForegroundLinearLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ForegroundLinearLayout_android_foreground = global::SextantSample.Droid.Resource.Styleable.ForegroundLinearLayout_android_foreground;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ForegroundLinearLayout_android_foregroundGravity = global::SextantSample.Droid.Resource.Styleable.ForegroundLinearLayout_android_foregroundGravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ForegroundLinearLayout_foregroundInsidePadding = global::SextantSample.Droid.Resource.Styleable.ForegroundLinearLayout_foregroundInsidePadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor = global::SextantSample.Droid.Resource.Styleable.GradientColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_centerColor = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_centerColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_centerX = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_centerX;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_centerY = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_centerY;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_endColor = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_endColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_endX = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_endX;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_endY = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_endY;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_gradientRadius = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_gradientRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_startColor = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_startColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_startX = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_startX;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_startY = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_startY;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_tileMode = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_tileMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_type = global::SextantSample.Droid.Resource.Styleable.GradientColor_android_type;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColorItem = global::SextantSample.Droid.Resource.Styleable.GradientColorItem;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColorItem_android_color = global::SextantSample.Droid.Resource.Styleable.GradientColorItem_android_color;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColorItem_android_offset = global::SextantSample.Droid.Resource.Styleable.GradientColorItem_android_offset;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.LinearLayoutCompat = global::SextantSample.Droid.Resource.Styleable.LinearLayoutCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.LinearLayoutCompat_android_baselineAligned = global::SextantSample.Droid.Resource.Styleable.LinearLayoutCompat_android_baselineAligned;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.LinearLayoutCompat_android_baselineAlignedChildIndex = global::SextantSample.Droid.Resource.Styleable.LinearLayoutCompat_android_baselineAlignedChildIndex;
@@ -1802,6 +2280,59 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ListPopupWindow = global::SextantSample.Droid.Resource.Styleable.ListPopupWindow;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ListPopupWindow_android_dropDownHorizontalOffset = global::SextantSample.Droid.Resource.Styleable.ListPopupWindow_android_dropDownHorizontalOffset;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ListPopupWindow_android_dropDownVerticalOffset = global::SextantSample.Droid.Resource.Styleable.ListPopupWindow_android_dropDownVerticalOffset;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton = global::SextantSample.Droid.Resource.Styleable.MaterialButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_android_insetBottom = global::SextantSample.Droid.Resource.Styleable.MaterialButton_android_insetBottom;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_android_insetLeft = global::SextantSample.Droid.Resource.Styleable.MaterialButton_android_insetLeft;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_android_insetRight = global::SextantSample.Droid.Resource.Styleable.MaterialButton_android_insetRight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_android_insetTop = global::SextantSample.Droid.Resource.Styleable.MaterialButton_android_insetTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_backgroundTint = global::SextantSample.Droid.Resource.Styleable.MaterialButton_backgroundTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_backgroundTintMode = global::SextantSample.Droid.Resource.Styleable.MaterialButton_backgroundTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_cornerRadius = global::SextantSample.Droid.Resource.Styleable.MaterialButton_cornerRadius;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_icon = global::SextantSample.Droid.Resource.Styleable.MaterialButton_icon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconGravity = global::SextantSample.Droid.Resource.Styleable.MaterialButton_iconGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconPadding = global::SextantSample.Droid.Resource.Styleable.MaterialButton_iconPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconSize = global::SextantSample.Droid.Resource.Styleable.MaterialButton_iconSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconTint = global::SextantSample.Droid.Resource.Styleable.MaterialButton_iconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_iconTintMode = global::SextantSample.Droid.Resource.Styleable.MaterialButton_iconTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_rippleColor = global::SextantSample.Droid.Resource.Styleable.MaterialButton_rippleColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_strokeColor = global::SextantSample.Droid.Resource.Styleable.MaterialButton_strokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialButton_strokeWidth = global::SextantSample.Droid.Resource.Styleable.MaterialButton_strokeWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialCardView = global::SextantSample.Droid.Resource.Styleable.MaterialCardView;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialCardView_strokeColor = global::SextantSample.Droid.Resource.Styleable.MaterialCardView_strokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialCardView_strokeWidth = global::SextantSample.Droid.Resource.Styleable.MaterialCardView_strokeWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_bottomSheetDialogTheme = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_bottomSheetDialogTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_bottomSheetStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_bottomSheetStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_chipGroupStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_chipGroupStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_chipStandaloneStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_chipStandaloneStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_chipStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_chipStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorAccent = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorAccent;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorBackgroundFloating = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorBackgroundFloating;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorPrimary = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorPrimary;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorPrimaryDark = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorPrimaryDark;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_colorSecondary = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_colorSecondary;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_editTextStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_editTextStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_floatingActionButtonStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_floatingActionButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_materialButtonStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_materialButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_materialCardViewStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_materialCardViewStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_navigationViewStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_navigationViewStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_scrimBackground = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_scrimBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_snackbarButtonStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_snackbarButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_tabStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_tabStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceBody1 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceBody1;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceBody2 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceBody2;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceButton = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceButton;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceCaption = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceCaption;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline1 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline1;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline2 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline2;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline3 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline3;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline4 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline4;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline5 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline5;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline6 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceHeadline6;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceOverline = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceOverline;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceSubtitle1 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceSubtitle1;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textAppearanceSubtitle2 = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textAppearanceSubtitle2;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MaterialComponentsTheme_textInputStyle = global::SextantSample.Droid.Resource.Styleable.MaterialComponentsTheme_textInputStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MenuGroup = global::SextantSample.Droid.Resource.Styleable.MenuGroup;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MenuGroup_android_checkableBehavior = global::SextantSample.Droid.Resource.Styleable.MenuGroup_android_checkableBehavior;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.MenuGroup_android_enabled = global::SextantSample.Droid.Resource.Styleable.MenuGroup_android_enabled;
@@ -1850,6 +2381,8 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_elevation = global::SextantSample.Droid.Resource.Styleable.NavigationView_elevation;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_headerLayout = global::SextantSample.Droid.Resource.Styleable.NavigationView_headerLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemBackground = global::SextantSample.Droid.Resource.Styleable.NavigationView_itemBackground;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemHorizontalPadding = global::SextantSample.Droid.Resource.Styleable.NavigationView_itemHorizontalPadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemIconPadding = global::SextantSample.Droid.Resource.Styleable.NavigationView_itemIconPadding;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemIconTint = global::SextantSample.Droid.Resource.Styleable.NavigationView_itemIconTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemTextAppearance = global::SextantSample.Droid.Resource.Styleable.NavigationView_itemTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.NavigationView_itemTextColor = global::SextantSample.Droid.Resource.Styleable.NavigationView_itemTextColor;
@@ -1897,6 +2430,9 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SearchView_submitBackground = global::SextantSample.Droid.Resource.Styleable.SearchView_submitBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SearchView_suggestionRowLayout = global::SextantSample.Droid.Resource.Styleable.SearchView_suggestionRowLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SearchView_voiceIcon = global::SextantSample.Droid.Resource.Styleable.SearchView_voiceIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Snackbar = global::SextantSample.Droid.Resource.Styleable.Snackbar;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Snackbar_snackbarButtonStyle = global::SextantSample.Droid.Resource.Styleable.Snackbar_snackbarButtonStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Snackbar_snackbarStyle = global::SextantSample.Droid.Resource.Styleable.Snackbar_snackbarStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SnackbarLayout = global::SextantSample.Droid.Resource.Styleable.SnackbarLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SnackbarLayout_android_maxWidth = global::SextantSample.Droid.Resource.Styleable.SnackbarLayout_android_maxWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SnackbarLayout_elevation = global::SextantSample.Droid.Resource.Styleable.SnackbarLayout_elevation;
@@ -1907,6 +2443,15 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Spinner_android_popupBackground = global::SextantSample.Droid.Resource.Styleable.Spinner_android_popupBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Spinner_android_prompt = global::SextantSample.Droid.Resource.Styleable.Spinner_android_prompt;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Spinner_popupTheme = global::SextantSample.Droid.Resource.Styleable.Spinner_popupTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable = global::SextantSample.Droid.Resource.Styleable.StateListDrawable;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_constantSize = global::SextantSample.Droid.Resource.Styleable.StateListDrawable_android_constantSize;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_dither = global::SextantSample.Droid.Resource.Styleable.StateListDrawable_android_dither;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_enterFadeDuration = global::SextantSample.Droid.Resource.Styleable.StateListDrawable_android_enterFadeDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_exitFadeDuration = global::SextantSample.Droid.Resource.Styleable.StateListDrawable_android_exitFadeDuration;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_variablePadding = global::SextantSample.Droid.Resource.Styleable.StateListDrawable_android_variablePadding;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawable_android_visible = global::SextantSample.Droid.Resource.Styleable.StateListDrawable_android_visible;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawableItem = global::SextantSample.Droid.Resource.Styleable.StateListDrawableItem;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.StateListDrawableItem_android_drawable = global::SextantSample.Droid.Resource.Styleable.StateListDrawableItem_android_drawable;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SwitchCompat = global::SextantSample.Droid.Resource.Styleable.SwitchCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SwitchCompat_android_textOff = global::SextantSample.Droid.Resource.Styleable.SwitchCompat_android_textOff;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.SwitchCompat_android_textOn = global::SextantSample.Droid.Resource.Styleable.SwitchCompat_android_textOn;
@@ -1930,8 +2475,15 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabBackground = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabBackground;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabContentStart = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabContentStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabGravity = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabGravity;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIconTint = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabIconTint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIconTintMode = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabIconTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicator = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabIndicator;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorAnimationDuration = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabIndicatorAnimationDuration;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorColor = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabIndicatorColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorFullWidth = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabIndicatorFullWidth;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorGravity = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabIndicatorGravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabIndicatorHeight = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabIndicatorHeight;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabInlineLabel = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabInlineLabel;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabMaxWidth = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabMaxWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabMinWidth = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabMinWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabMode = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabMode;
@@ -1940,9 +2492,11 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabPaddingEnd = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabPaddingEnd;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabPaddingStart = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabPaddingStart;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabPaddingTop = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabRippleColor = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabRippleColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabSelectedTextColor = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabSelectedTextColor;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabTextAppearance = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabTextColor = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabTextColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TabLayout_tabUnboundedRipple = global::SextantSample.Droid.Resource.Styleable.TabLayout_tabUnboundedRipple;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextAppearance = global::SextantSample.Droid.Resource.Styleable.TextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextAppearance_android_fontFamily = global::SextantSample.Droid.Resource.Styleable.TextAppearance_android_fontFamily;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextAppearance_android_shadowColor = global::SextantSample.Droid.Resource.Styleable.TextAppearance_android_shadowColor;
@@ -1960,12 +2514,24 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout = global::SextantSample.Droid.Resource.Styleable.TextInputLayout;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_android_hint = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_android_hint;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_android_textColorHint = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_android_textColorHint;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxBackgroundColor = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_boxBackgroundColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxBackgroundMode = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_boxBackgroundMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCollapsedPaddingTop = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_boxCollapsedPaddingTop;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCornerRadiusBottomEnd = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_boxCornerRadiusBottomEnd;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCornerRadiusBottomStart = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_boxCornerRadiusBottomStart;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCornerRadiusTopEnd = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_boxCornerRadiusTopEnd;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxCornerRadiusTopStart = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_boxCornerRadiusTopStart;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxStrokeColor = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_boxStrokeColor;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_boxStrokeWidth = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_boxStrokeWidth;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_counterEnabled = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_counterEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_counterMaxLength = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_counterMaxLength;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_counterOverflowTextAppearance = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_counterOverflowTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_counterTextAppearance = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_counterTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_errorEnabled = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_errorEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_errorTextAppearance = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_errorTextAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_helperText = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_helperText;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_helperTextEnabled = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_helperTextEnabled;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_helperTextTextAppearance = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_helperTextTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_hintAnimationEnabled = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_hintAnimationEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_hintEnabled = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_hintEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_hintTextAppearance = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_hintTextAppearance;
@@ -1974,6 +2540,10 @@ namespace SextantSample.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_passwordToggleEnabled = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleEnabled;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_passwordToggleTint = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleTint;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.TextInputLayout_passwordToggleTintMode = global::SextantSample.Droid.Resource.Styleable.TextInputLayout_passwordToggleTintMode;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ThemeEnforcement = global::SextantSample.Droid.Resource.Styleable.ThemeEnforcement;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ThemeEnforcement_android_textAppearance = global::SextantSample.Droid.Resource.Styleable.ThemeEnforcement_android_textAppearance;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ThemeEnforcement_enforceMaterialTheme = global::SextantSample.Droid.Resource.Styleable.ThemeEnforcement_enforceMaterialTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ThemeEnforcement_enforceTextAppearance = global::SextantSample.Droid.Resource.Styleable.ThemeEnforcement_enforceTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Toolbar = global::SextantSample.Droid.Resource.Styleable.Toolbar;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Toolbar_android_gravity = global::SextantSample.Droid.Resource.Styleable.Toolbar_android_gravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.Toolbar_android_minHeight = global::SextantSample.Droid.Resource.Styleable.Toolbar_android_minHeight;
@@ -2023,65 +2593,65 @@ namespace SextantSample.Droid
 		public partial class Animation
 		{
 			
-			// aapt resource value: 0x7f050000
-			public const int abc_fade_in = 2131034112;
+			// aapt resource value: 0x7F010000
+			public const int abc_fade_in = 2130771968;
 			
-			// aapt resource value: 0x7f050001
-			public const int abc_fade_out = 2131034113;
+			// aapt resource value: 0x7F010001
+			public const int abc_fade_out = 2130771969;
 			
-			// aapt resource value: 0x7f050002
-			public const int abc_grow_fade_in_from_bottom = 2131034114;
+			// aapt resource value: 0x7F010002
+			public const int abc_grow_fade_in_from_bottom = 2130771970;
 			
-			// aapt resource value: 0x7f050003
-			public const int abc_popup_enter = 2131034115;
+			// aapt resource value: 0x7F010003
+			public const int abc_popup_enter = 2130771971;
 			
-			// aapt resource value: 0x7f050004
-			public const int abc_popup_exit = 2131034116;
+			// aapt resource value: 0x7F010004
+			public const int abc_popup_exit = 2130771972;
 			
-			// aapt resource value: 0x7f050005
-			public const int abc_shrink_fade_out_from_bottom = 2131034117;
+			// aapt resource value: 0x7F010005
+			public const int abc_shrink_fade_out_from_bottom = 2130771973;
 			
-			// aapt resource value: 0x7f050006
-			public const int abc_slide_in_bottom = 2131034118;
+			// aapt resource value: 0x7F010006
+			public const int abc_slide_in_bottom = 2130771974;
 			
-			// aapt resource value: 0x7f050007
-			public const int abc_slide_in_top = 2131034119;
+			// aapt resource value: 0x7F010007
+			public const int abc_slide_in_top = 2130771975;
 			
-			// aapt resource value: 0x7f050008
-			public const int abc_slide_out_bottom = 2131034120;
+			// aapt resource value: 0x7F010008
+			public const int abc_slide_out_bottom = 2130771976;
 			
-			// aapt resource value: 0x7f050009
-			public const int abc_slide_out_top = 2131034121;
+			// aapt resource value: 0x7F010009
+			public const int abc_slide_out_top = 2130771977;
 			
-			// aapt resource value: 0x7f05000a
-			public const int design_bottom_sheet_slide_in = 2131034122;
+			// aapt resource value: 0x7F01000A
+			public const int abc_tooltip_enter = 2130771978;
 			
-			// aapt resource value: 0x7f05000b
-			public const int design_bottom_sheet_slide_out = 2131034123;
+			// aapt resource value: 0x7F01000B
+			public const int abc_tooltip_exit = 2130771979;
 			
-			// aapt resource value: 0x7f05000c
-			public const int design_snackbar_in = 2131034124;
+			// aapt resource value: 0x7F01000C
+			public const int design_bottom_sheet_slide_in = 2130771980;
 			
-			// aapt resource value: 0x7f05000d
-			public const int design_snackbar_out = 2131034125;
+			// aapt resource value: 0x7F01000D
+			public const int design_bottom_sheet_slide_out = 2130771981;
 			
-			// aapt resource value: 0x7f05000e
-			public const int EnterFromLeft = 2131034126;
+			// aapt resource value: 0x7F01000E
+			public const int design_snackbar_in = 2130771982;
 			
-			// aapt resource value: 0x7f05000f
-			public const int EnterFromRight = 2131034127;
+			// aapt resource value: 0x7F01000F
+			public const int design_snackbar_out = 2130771983;
 			
-			// aapt resource value: 0x7f050010
-			public const int ExitToLeft = 2131034128;
+			// aapt resource value: 0x7F010010
+			public const int EnterFromLeft = 2130771984;
 			
-			// aapt resource value: 0x7f050011
-			public const int ExitToRight = 2131034129;
+			// aapt resource value: 0x7F010011
+			public const int EnterFromRight = 2130771985;
 			
-			// aapt resource value: 0x7f050012
-			public const int tooltip_enter = 2131034130;
+			// aapt resource value: 0x7F010012
+			public const int ExitToLeft = 2130771986;
 			
-			// aapt resource value: 0x7f050013
-			public const int tooltip_exit = 2131034131;
+			// aapt resource value: 0x7F010013
+			public const int ExitToRight = 2130771987;
 			
 			static Animation()
 			{
@@ -2096,8 +2666,35 @@ namespace SextantSample.Droid
 		public partial class Animator
 		{
 			
-			// aapt resource value: 0x7f060000
-			public const int design_appbar_state_list_animator = 2131099648;
+			// aapt resource value: 0x7F020000
+			public const int design_appbar_state_list_animator = 2130837504;
+			
+			// aapt resource value: 0x7F020001
+			public const int design_fab_hide_motion_spec = 2130837505;
+			
+			// aapt resource value: 0x7F020002
+			public const int design_fab_show_motion_spec = 2130837506;
+			
+			// aapt resource value: 0x7F020003
+			public const int mtrl_btn_state_list_anim = 2130837507;
+			
+			// aapt resource value: 0x7F020004
+			public const int mtrl_btn_unelevated_state_list_anim = 2130837508;
+			
+			// aapt resource value: 0x7F020005
+			public const int mtrl_chip_state_list_anim = 2130837509;
+			
+			// aapt resource value: 0x7F020006
+			public const int mtrl_fab_hide_motion_spec = 2130837510;
+			
+			// aapt resource value: 0x7F020007
+			public const int mtrl_fab_show_motion_spec = 2130837511;
+			
+			// aapt resource value: 0x7F020008
+			public const int mtrl_fab_transformation_sheet_collapse_spec = 2130837512;
+			
+			// aapt resource value: 0x7F020009
+			public const int mtrl_fab_transformation_sheet_expand_spec = 2130837513;
 			
 			static Animator()
 			{
@@ -2112,1118 +2709,1478 @@ namespace SextantSample.Droid
 		public partial class Attribute
 		{
 			
-			// aapt resource value: 0x7f01006b
-			public const int actionBarDivider = 2130772075;
+			// aapt resource value: 0x7F030000
+			public const int actionBarDivider = 2130903040;
 			
-			// aapt resource value: 0x7f01006c
-			public const int actionBarItemBackground = 2130772076;
+			// aapt resource value: 0x7F030001
+			public const int actionBarItemBackground = 2130903041;
 			
-			// aapt resource value: 0x7f010065
-			public const int actionBarPopupTheme = 2130772069;
+			// aapt resource value: 0x7F030002
+			public const int actionBarPopupTheme = 2130903042;
 			
-			// aapt resource value: 0x7f01006a
-			public const int actionBarSize = 2130772074;
+			// aapt resource value: 0x7F030003
+			public const int actionBarSize = 2130903043;
 			
-			// aapt resource value: 0x7f010067
-			public const int actionBarSplitStyle = 2130772071;
+			// aapt resource value: 0x7F030004
+			public const int actionBarSplitStyle = 2130903044;
 			
-			// aapt resource value: 0x7f010066
-			public const int actionBarStyle = 2130772070;
+			// aapt resource value: 0x7F030005
+			public const int actionBarStyle = 2130903045;
 			
-			// aapt resource value: 0x7f010061
-			public const int actionBarTabBarStyle = 2130772065;
+			// aapt resource value: 0x7F030006
+			public const int actionBarTabBarStyle = 2130903046;
 			
-			// aapt resource value: 0x7f010060
-			public const int actionBarTabStyle = 2130772064;
+			// aapt resource value: 0x7F030007
+			public const int actionBarTabStyle = 2130903047;
 			
-			// aapt resource value: 0x7f010062
-			public const int actionBarTabTextStyle = 2130772066;
+			// aapt resource value: 0x7F030008
+			public const int actionBarTabTextStyle = 2130903048;
 			
-			// aapt resource value: 0x7f010068
-			public const int actionBarTheme = 2130772072;
+			// aapt resource value: 0x7F030009
+			public const int actionBarTheme = 2130903049;
 			
-			// aapt resource value: 0x7f010069
-			public const int actionBarWidgetTheme = 2130772073;
+			// aapt resource value: 0x7F03000A
+			public const int actionBarWidgetTheme = 2130903050;
 			
-			// aapt resource value: 0x7f010086
-			public const int actionButtonStyle = 2130772102;
+			// aapt resource value: 0x7F03000B
+			public const int actionButtonStyle = 2130903051;
 			
-			// aapt resource value: 0x7f010082
-			public const int actionDropDownStyle = 2130772098;
+			// aapt resource value: 0x7F03000C
+			public const int actionDropDownStyle = 2130903052;
 			
-			// aapt resource value: 0x7f0100dd
-			public const int actionLayout = 2130772189;
+			// aapt resource value: 0x7F03000D
+			public const int actionLayout = 2130903053;
 			
-			// aapt resource value: 0x7f01006d
-			public const int actionMenuTextAppearance = 2130772077;
+			// aapt resource value: 0x7F03000E
+			public const int actionMenuTextAppearance = 2130903054;
 			
-			// aapt resource value: 0x7f01006e
-			public const int actionMenuTextColor = 2130772078;
+			// aapt resource value: 0x7F03000F
+			public const int actionMenuTextColor = 2130903055;
 			
-			// aapt resource value: 0x7f010071
-			public const int actionModeBackground = 2130772081;
+			// aapt resource value: 0x7F030010
+			public const int actionModeBackground = 2130903056;
 			
-			// aapt resource value: 0x7f010070
-			public const int actionModeCloseButtonStyle = 2130772080;
+			// aapt resource value: 0x7F030011
+			public const int actionModeCloseButtonStyle = 2130903057;
 			
-			// aapt resource value: 0x7f010073
-			public const int actionModeCloseDrawable = 2130772083;
+			// aapt resource value: 0x7F030012
+			public const int actionModeCloseDrawable = 2130903058;
 			
-			// aapt resource value: 0x7f010075
-			public const int actionModeCopyDrawable = 2130772085;
+			// aapt resource value: 0x7F030013
+			public const int actionModeCopyDrawable = 2130903059;
 			
-			// aapt resource value: 0x7f010074
-			public const int actionModeCutDrawable = 2130772084;
+			// aapt resource value: 0x7F030014
+			public const int actionModeCutDrawable = 2130903060;
 			
-			// aapt resource value: 0x7f010079
-			public const int actionModeFindDrawable = 2130772089;
+			// aapt resource value: 0x7F030015
+			public const int actionModeFindDrawable = 2130903061;
 			
-			// aapt resource value: 0x7f010076
-			public const int actionModePasteDrawable = 2130772086;
+			// aapt resource value: 0x7F030016
+			public const int actionModePasteDrawable = 2130903062;
 			
-			// aapt resource value: 0x7f01007b
-			public const int actionModePopupWindowStyle = 2130772091;
+			// aapt resource value: 0x7F030017
+			public const int actionModePopupWindowStyle = 2130903063;
 			
-			// aapt resource value: 0x7f010077
-			public const int actionModeSelectAllDrawable = 2130772087;
+			// aapt resource value: 0x7F030018
+			public const int actionModeSelectAllDrawable = 2130903064;
 			
-			// aapt resource value: 0x7f010078
-			public const int actionModeShareDrawable = 2130772088;
+			// aapt resource value: 0x7F030019
+			public const int actionModeShareDrawable = 2130903065;
 			
-			// aapt resource value: 0x7f010072
-			public const int actionModeSplitBackground = 2130772082;
+			// aapt resource value: 0x7F03001A
+			public const int actionModeSplitBackground = 2130903066;
 			
-			// aapt resource value: 0x7f01006f
-			public const int actionModeStyle = 2130772079;
+			// aapt resource value: 0x7F03001B
+			public const int actionModeStyle = 2130903067;
 			
-			// aapt resource value: 0x7f01007a
-			public const int actionModeWebSearchDrawable = 2130772090;
+			// aapt resource value: 0x7F03001C
+			public const int actionModeWebSearchDrawable = 2130903068;
 			
-			// aapt resource value: 0x7f010063
-			public const int actionOverflowButtonStyle = 2130772067;
+			// aapt resource value: 0x7F03001D
+			public const int actionOverflowButtonStyle = 2130903069;
 			
-			// aapt resource value: 0x7f010064
-			public const int actionOverflowMenuStyle = 2130772068;
+			// aapt resource value: 0x7F03001E
+			public const int actionOverflowMenuStyle = 2130903070;
 			
-			// aapt resource value: 0x7f0100df
-			public const int actionProviderClass = 2130772191;
+			// aapt resource value: 0x7F03001F
+			public const int actionProviderClass = 2130903071;
 			
-			// aapt resource value: 0x7f0100de
-			public const int actionViewClass = 2130772190;
+			// aapt resource value: 0x7F030020
+			public const int actionViewClass = 2130903072;
 			
-			// aapt resource value: 0x7f01008e
-			public const int activityChooserViewStyle = 2130772110;
+			// aapt resource value: 0x7F030021
+			public const int activityChooserViewStyle = 2130903073;
 			
-			// aapt resource value: 0x7f0100b3
-			public const int alertDialogButtonGroupStyle = 2130772147;
+			// aapt resource value: 0x7F030022
+			public const int alertDialogButtonGroupStyle = 2130903074;
 			
-			// aapt resource value: 0x7f0100b4
-			public const int alertDialogCenterButtons = 2130772148;
+			// aapt resource value: 0x7F030023
+			public const int alertDialogCenterButtons = 2130903075;
 			
-			// aapt resource value: 0x7f0100b2
-			public const int alertDialogStyle = 2130772146;
+			// aapt resource value: 0x7F030024
+			public const int alertDialogStyle = 2130903076;
 			
-			// aapt resource value: 0x7f0100b5
-			public const int alertDialogTheme = 2130772149;
+			// aapt resource value: 0x7F030025
+			public const int alertDialogTheme = 2130903077;
 			
-			// aapt resource value: 0x7f0100cb
-			public const int allowStacking = 2130772171;
+			// aapt resource value: 0x7F030026
+			public const int allowStacking = 2130903078;
 			
-			// aapt resource value: 0x7f0100cc
-			public const int alpha = 2130772172;
+			// aapt resource value: 0x7F030027
+			public const int alpha = 2130903079;
 			
-			// aapt resource value: 0x7f0100da
-			public const int alphabeticModifiers = 2130772186;
+			// aapt resource value: 0x7F030028
+			public const int alphabeticModifiers = 2130903080;
 			
-			// aapt resource value: 0x7f0100d3
-			public const int arrowHeadLength = 2130772179;
+			// aapt resource value: 0x7F030029
+			public const int arrowHeadLength = 2130903081;
 			
-			// aapt resource value: 0x7f0100d4
-			public const int arrowShaftLength = 2130772180;
+			// aapt resource value: 0x7F03002A
+			public const int arrowShaftLength = 2130903082;
 			
-			// aapt resource value: 0x7f0100ba
-			public const int autoCompleteTextViewStyle = 2130772154;
+			// aapt resource value: 0x7F03002B
+			public const int autoCompleteTextViewStyle = 2130903083;
 			
-			// aapt resource value: 0x7f010054
-			public const int autoSizeMaxTextSize = 2130772052;
+			// aapt resource value: 0x7F03002C
+			public const int autoSizeMaxTextSize = 2130903084;
 			
-			// aapt resource value: 0x7f010053
-			public const int autoSizeMinTextSize = 2130772051;
+			// aapt resource value: 0x7F03002D
+			public const int autoSizeMinTextSize = 2130903085;
 			
-			// aapt resource value: 0x7f010052
-			public const int autoSizePresetSizes = 2130772050;
+			// aapt resource value: 0x7F03002E
+			public const int autoSizePresetSizes = 2130903086;
 			
-			// aapt resource value: 0x7f010051
-			public const int autoSizeStepGranularity = 2130772049;
+			// aapt resource value: 0x7F03002F
+			public const int autoSizeStepGranularity = 2130903087;
 			
-			// aapt resource value: 0x7f010050
-			public const int autoSizeTextType = 2130772048;
+			// aapt resource value: 0x7F030030
+			public const int autoSizeTextType = 2130903088;
 			
-			// aapt resource value: 0x7f01002e
-			public const int background = 2130772014;
+			// aapt resource value: 0x7F030031
+			public const int background = 2130903089;
 			
-			// aapt resource value: 0x7f010030
-			public const int backgroundSplit = 2130772016;
+			// aapt resource value: 0x7F030032
+			public const int backgroundSplit = 2130903090;
 			
-			// aapt resource value: 0x7f01002f
-			public const int backgroundStacked = 2130772015;
+			// aapt resource value: 0x7F030033
+			public const int backgroundStacked = 2130903091;
 			
-			// aapt resource value: 0x7f010116
-			public const int backgroundTint = 2130772246;
+			// aapt resource value: 0x7F030034
+			public const int backgroundTint = 2130903092;
 			
-			// aapt resource value: 0x7f010117
-			public const int backgroundTintMode = 2130772247;
+			// aapt resource value: 0x7F030035
+			public const int backgroundTintMode = 2130903093;
 			
-			// aapt resource value: 0x7f0100d5
-			public const int barLength = 2130772181;
+			// aapt resource value: 0x7F030036
+			public const int barLength = 2130903094;
 			
-			// aapt resource value: 0x7f010141
-			public const int behavior_autoHide = 2130772289;
+			// aapt resource value: 0x7F030037
+			public const int behavior_autoHide = 2130903095;
 			
-			// aapt resource value: 0x7f01011e
-			public const int behavior_hideable = 2130772254;
+			// aapt resource value: 0x7F030038
+			public const int behavior_fitToContents = 2130903096;
 			
-			// aapt resource value: 0x7f01014a
-			public const int behavior_overlapTop = 2130772298;
+			// aapt resource value: 0x7F030039
+			public const int behavior_hideable = 2130903097;
 			
-			// aapt resource value: 0x7f01011d
-			public const int behavior_peekHeight = 2130772253;
+			// aapt resource value: 0x7F03003A
+			public const int behavior_overlapTop = 2130903098;
 			
-			// aapt resource value: 0x7f01011f
-			public const int behavior_skipCollapsed = 2130772255;
+			// aapt resource value: 0x7F03003B
+			public const int behavior_peekHeight = 2130903099;
 			
-			// aapt resource value: 0x7f01013f
-			public const int borderWidth = 2130772287;
+			// aapt resource value: 0x7F03003C
+			public const int behavior_skipCollapsed = 2130903100;
 			
-			// aapt resource value: 0x7f01008b
-			public const int borderlessButtonStyle = 2130772107;
+			// aapt resource value: 0x7F03003E
+			public const int borderlessButtonStyle = 2130903102;
 			
-			// aapt resource value: 0x7f010139
-			public const int bottomSheetDialogTheme = 2130772281;
+			// aapt resource value: 0x7F03003D
+			public const int borderWidth = 2130903101;
 			
-			// aapt resource value: 0x7f01013a
-			public const int bottomSheetStyle = 2130772282;
+			// aapt resource value: 0x7F03003F
+			public const int bottomAppBarStyle = 2130903103;
 			
-			// aapt resource value: 0x7f010088
-			public const int buttonBarButtonStyle = 2130772104;
+			// aapt resource value: 0x7F030040
+			public const int bottomNavigationStyle = 2130903104;
 			
-			// aapt resource value: 0x7f0100b8
-			public const int buttonBarNegativeButtonStyle = 2130772152;
+			// aapt resource value: 0x7F030041
+			public const int bottomSheetDialogTheme = 2130903105;
 			
-			// aapt resource value: 0x7f0100b9
-			public const int buttonBarNeutralButtonStyle = 2130772153;
+			// aapt resource value: 0x7F030042
+			public const int bottomSheetStyle = 2130903106;
 			
-			// aapt resource value: 0x7f0100b7
-			public const int buttonBarPositiveButtonStyle = 2130772151;
+			// aapt resource value: 0x7F030043
+			public const int boxBackgroundColor = 2130903107;
 			
-			// aapt resource value: 0x7f010087
-			public const int buttonBarStyle = 2130772103;
+			// aapt resource value: 0x7F030044
+			public const int boxBackgroundMode = 2130903108;
 			
-			// aapt resource value: 0x7f01010b
-			public const int buttonGravity = 2130772235;
+			// aapt resource value: 0x7F030045
+			public const int boxCollapsedPaddingTop = 2130903109;
 			
-			// aapt resource value: 0x7f010043
-			public const int buttonPanelSideLayout = 2130772035;
+			// aapt resource value: 0x7F030046
+			public const int boxCornerRadiusBottomEnd = 2130903110;
 			
-			// aapt resource value: 0x7f0100bb
-			public const int buttonStyle = 2130772155;
+			// aapt resource value: 0x7F030047
+			public const int boxCornerRadiusBottomStart = 2130903111;
 			
-			// aapt resource value: 0x7f0100bc
-			public const int buttonStyleSmall = 2130772156;
+			// aapt resource value: 0x7F030048
+			public const int boxCornerRadiusTopEnd = 2130903112;
 			
-			// aapt resource value: 0x7f0100cd
-			public const int buttonTint = 2130772173;
+			// aapt resource value: 0x7F030049
+			public const int boxCornerRadiusTopStart = 2130903113;
 			
-			// aapt resource value: 0x7f0100ce
-			public const int buttonTintMode = 2130772174;
+			// aapt resource value: 0x7F03004A
+			public const int boxStrokeColor = 2130903114;
 			
-			// aapt resource value: 0x7f010017
-			public const int cardBackgroundColor = 2130771991;
+			// aapt resource value: 0x7F03004B
+			public const int boxStrokeWidth = 2130903115;
 			
-			// aapt resource value: 0x7f010018
-			public const int cardCornerRadius = 2130771992;
+			// aapt resource value: 0x7F03004C
+			public const int buttonBarButtonStyle = 2130903116;
 			
-			// aapt resource value: 0x7f010019
-			public const int cardElevation = 2130771993;
+			// aapt resource value: 0x7F03004D
+			public const int buttonBarNegativeButtonStyle = 2130903117;
 			
-			// aapt resource value: 0x7f01001a
-			public const int cardMaxElevation = 2130771994;
+			// aapt resource value: 0x7F03004E
+			public const int buttonBarNeutralButtonStyle = 2130903118;
 			
-			// aapt resource value: 0x7f01001c
-			public const int cardPreventCornerOverlap = 2130771996;
+			// aapt resource value: 0x7F03004F
+			public const int buttonBarPositiveButtonStyle = 2130903119;
 			
-			// aapt resource value: 0x7f01001b
-			public const int cardUseCompatPadding = 2130771995;
+			// aapt resource value: 0x7F030050
+			public const int buttonBarStyle = 2130903120;
 			
-			// aapt resource value: 0x7f0100bd
-			public const int checkboxStyle = 2130772157;
+			// aapt resource value: 0x7F030051
+			public const int buttonGravity = 2130903121;
 			
-			// aapt resource value: 0x7f0100be
-			public const int checkedTextViewStyle = 2130772158;
+			// aapt resource value: 0x7F030052
+			public const int buttonIconDimen = 2130903122;
 			
-			// aapt resource value: 0x7f0100ee
-			public const int closeIcon = 2130772206;
+			// aapt resource value: 0x7F030053
+			public const int buttonPanelSideLayout = 2130903123;
 			
-			// aapt resource value: 0x7f010040
-			public const int closeItemLayout = 2130772032;
+			// aapt resource value: 0x7F030054
+			public const int buttonStyle = 2130903124;
 			
-			// aapt resource value: 0x7f01010d
-			public const int collapseContentDescription = 2130772237;
+			// aapt resource value: 0x7F030055
+			public const int buttonStyleSmall = 2130903125;
 			
-			// aapt resource value: 0x7f01010c
-			public const int collapseIcon = 2130772236;
+			// aapt resource value: 0x7F030056
+			public const int buttonTint = 2130903126;
 			
-			// aapt resource value: 0x7f01012c
-			public const int collapsedTitleGravity = 2130772268;
+			// aapt resource value: 0x7F030057
+			public const int buttonTintMode = 2130903127;
 			
-			// aapt resource value: 0x7f010126
-			public const int collapsedTitleTextAppearance = 2130772262;
+			// aapt resource value: 0x7F030058
+			public const int cardBackgroundColor = 2130903128;
 			
-			// aapt resource value: 0x7f0100cf
-			public const int color = 2130772175;
+			// aapt resource value: 0x7F030059
+			public const int cardCornerRadius = 2130903129;
 			
-			// aapt resource value: 0x7f0100aa
-			public const int colorAccent = 2130772138;
+			// aapt resource value: 0x7F03005A
+			public const int cardElevation = 2130903130;
 			
-			// aapt resource value: 0x7f0100b1
-			public const int colorBackgroundFloating = 2130772145;
+			// aapt resource value: 0x7F03005B
+			public const int cardMaxElevation = 2130903131;
 			
-			// aapt resource value: 0x7f0100ae
-			public const int colorButtonNormal = 2130772142;
+			// aapt resource value: 0x7F03005C
+			public const int cardPreventCornerOverlap = 2130903132;
 			
-			// aapt resource value: 0x7f0100ac
-			public const int colorControlActivated = 2130772140;
+			// aapt resource value: 0x7F03005D
+			public const int cardUseCompatPadding = 2130903133;
 			
-			// aapt resource value: 0x7f0100ad
-			public const int colorControlHighlight = 2130772141;
+			// aapt resource value: 0x7F03005E
+			public const int cardViewStyle = 2130903134;
 			
-			// aapt resource value: 0x7f0100ab
-			public const int colorControlNormal = 2130772139;
+			// aapt resource value: 0x7F03005F
+			public const int checkboxStyle = 2130903135;
 			
-			// aapt resource value: 0x7f0100ca
-			public const int colorError = 2130772170;
+			// aapt resource value: 0x7F030060
+			public const int checkedChip = 2130903136;
 			
-			// aapt resource value: 0x7f0100a8
-			public const int colorPrimary = 2130772136;
+			// aapt resource value: 0x7F030061
+			public const int checkedIcon = 2130903137;
 			
-			// aapt resource value: 0x7f0100a9
-			public const int colorPrimaryDark = 2130772137;
+			// aapt resource value: 0x7F030062
+			public const int checkedIconEnabled = 2130903138;
 			
-			// aapt resource value: 0x7f0100af
-			public const int colorSwitchThumbNormal = 2130772143;
+			// aapt resource value: 0x7F030063
+			public const int checkedIconVisible = 2130903139;
 			
-			// aapt resource value: 0x7f0100f3
-			public const int commitIcon = 2130772211;
+			// aapt resource value: 0x7F030064
+			public const int checkedTextViewStyle = 2130903140;
 			
-			// aapt resource value: 0x7f0100e0
-			public const int contentDescription = 2130772192;
+			// aapt resource value: 0x7F030065
+			public const int chipBackgroundColor = 2130903141;
 			
-			// aapt resource value: 0x7f010039
-			public const int contentInsetEnd = 2130772025;
+			// aapt resource value: 0x7F030066
+			public const int chipCornerRadius = 2130903142;
 			
-			// aapt resource value: 0x7f01003d
-			public const int contentInsetEndWithActions = 2130772029;
+			// aapt resource value: 0x7F030067
+			public const int chipEndPadding = 2130903143;
 			
-			// aapt resource value: 0x7f01003a
-			public const int contentInsetLeft = 2130772026;
+			// aapt resource value: 0x7F030068
+			public const int chipGroupStyle = 2130903144;
 			
-			// aapt resource value: 0x7f01003b
-			public const int contentInsetRight = 2130772027;
+			// aapt resource value: 0x7F030069
+			public const int chipIcon = 2130903145;
 			
-			// aapt resource value: 0x7f010038
-			public const int contentInsetStart = 2130772024;
+			// aapt resource value: 0x7F03006A
+			public const int chipIconEnabled = 2130903146;
 			
-			// aapt resource value: 0x7f01003c
-			public const int contentInsetStartWithNavigation = 2130772028;
+			// aapt resource value: 0x7F03006B
+			public const int chipIconSize = 2130903147;
 			
-			// aapt resource value: 0x7f01001d
-			public const int contentPadding = 2130771997;
+			// aapt resource value: 0x7F03006C
+			public const int chipIconTint = 2130903148;
 			
-			// aapt resource value: 0x7f010021
-			public const int contentPaddingBottom = 2130772001;
+			// aapt resource value: 0x7F03006D
+			public const int chipIconVisible = 2130903149;
 			
-			// aapt resource value: 0x7f01001e
-			public const int contentPaddingLeft = 2130771998;
+			// aapt resource value: 0x7F03006E
+			public const int chipMinHeight = 2130903150;
 			
-			// aapt resource value: 0x7f01001f
-			public const int contentPaddingRight = 2130771999;
+			// aapt resource value: 0x7F03006F
+			public const int chipSpacing = 2130903151;
 			
-			// aapt resource value: 0x7f010020
-			public const int contentPaddingTop = 2130772000;
+			// aapt resource value: 0x7F030070
+			public const int chipSpacingHorizontal = 2130903152;
 			
-			// aapt resource value: 0x7f010127
-			public const int contentScrim = 2130772263;
+			// aapt resource value: 0x7F030071
+			public const int chipSpacingVertical = 2130903153;
 			
-			// aapt resource value: 0x7f0100b0
-			public const int controlBackground = 2130772144;
+			// aapt resource value: 0x7F030072
+			public const int chipStandaloneStyle = 2130903154;
 			
-			// aapt resource value: 0x7f010160
-			public const int counterEnabled = 2130772320;
+			// aapt resource value: 0x7F030073
+			public const int chipStartPadding = 2130903155;
 			
-			// aapt resource value: 0x7f010161
-			public const int counterMaxLength = 2130772321;
+			// aapt resource value: 0x7F030074
+			public const int chipStrokeColor = 2130903156;
 			
-			// aapt resource value: 0x7f010163
-			public const int counterOverflowTextAppearance = 2130772323;
+			// aapt resource value: 0x7F030075
+			public const int chipStrokeWidth = 2130903157;
 			
-			// aapt resource value: 0x7f010162
-			public const int counterTextAppearance = 2130772322;
+			// aapt resource value: 0x7F030076
+			public const int chipStyle = 2130903158;
 			
-			// aapt resource value: 0x7f010031
-			public const int customNavigationLayout = 2130772017;
+			// aapt resource value: 0x7F030077
+			public const int closeIcon = 2130903159;
 			
-			// aapt resource value: 0x7f0100ed
-			public const int defaultQueryHint = 2130772205;
+			// aapt resource value: 0x7F030078
+			public const int closeIconEnabled = 2130903160;
 			
-			// aapt resource value: 0x7f010080
-			public const int dialogPreferredPadding = 2130772096;
+			// aapt resource value: 0x7F030079
+			public const int closeIconEndPadding = 2130903161;
 			
-			// aapt resource value: 0x7f01007f
-			public const int dialogTheme = 2130772095;
+			// aapt resource value: 0x7F03007A
+			public const int closeIconSize = 2130903162;
 			
-			// aapt resource value: 0x7f010027
-			public const int displayOptions = 2130772007;
+			// aapt resource value: 0x7F03007B
+			public const int closeIconStartPadding = 2130903163;
 			
-			// aapt resource value: 0x7f01002d
-			public const int divider = 2130772013;
+			// aapt resource value: 0x7F03007C
+			public const int closeIconTint = 2130903164;
 			
-			// aapt resource value: 0x7f01008d
-			public const int dividerHorizontal = 2130772109;
+			// aapt resource value: 0x7F03007D
+			public const int closeIconVisible = 2130903165;
 			
-			// aapt resource value: 0x7f0100d9
-			public const int dividerPadding = 2130772185;
+			// aapt resource value: 0x7F03007E
+			public const int closeItemLayout = 2130903166;
 			
-			// aapt resource value: 0x7f01008c
-			public const int dividerVertical = 2130772108;
+			// aapt resource value: 0x7F03007F
+			public const int collapseContentDescription = 2130903167;
 			
-			// aapt resource value: 0x7f0100d1
-			public const int drawableSize = 2130772177;
+			// aapt resource value: 0x7F030081
+			public const int collapsedTitleGravity = 2130903169;
 			
-			// aapt resource value: 0x7f010022
-			public const int drawerArrowStyle = 2130772002;
+			// aapt resource value: 0x7F030082
+			public const int collapsedTitleTextAppearance = 2130903170;
 			
-			// aapt resource value: 0x7f01009f
-			public const int dropDownListViewStyle = 2130772127;
+			// aapt resource value: 0x7F030080
+			public const int collapseIcon = 2130903168;
 			
-			// aapt resource value: 0x7f010083
-			public const int dropdownListPreferredItemHeight = 2130772099;
+			// aapt resource value: 0x7F030083
+			public const int color = 2130903171;
 			
-			// aapt resource value: 0x7f010094
-			public const int editTextBackground = 2130772116;
+			// aapt resource value: 0x7F030084
+			public const int colorAccent = 2130903172;
 			
-			// aapt resource value: 0x7f010093
-			public const int editTextColor = 2130772115;
+			// aapt resource value: 0x7F030085
+			public const int colorBackgroundFloating = 2130903173;
 			
-			// aapt resource value: 0x7f0100bf
-			public const int editTextStyle = 2130772159;
+			// aapt resource value: 0x7F030086
+			public const int colorButtonNormal = 2130903174;
 			
-			// aapt resource value: 0x7f01003e
-			public const int elevation = 2130772030;
+			// aapt resource value: 0x7F030087
+			public const int colorControlActivated = 2130903175;
 			
-			// aapt resource value: 0x7f01015e
-			public const int errorEnabled = 2130772318;
+			// aapt resource value: 0x7F030088
+			public const int colorControlHighlight = 2130903176;
 			
-			// aapt resource value: 0x7f01015f
-			public const int errorTextAppearance = 2130772319;
+			// aapt resource value: 0x7F030089
+			public const int colorControlNormal = 2130903177;
 			
-			// aapt resource value: 0x7f010042
-			public const int expandActivityOverflowButtonDrawable = 2130772034;
+			// aapt resource value: 0x7F03008A
+			public const int colorError = 2130903178;
 			
-			// aapt resource value: 0x7f010118
-			public const int expanded = 2130772248;
+			// aapt resource value: 0x7F03008B
+			public const int colorPrimary = 2130903179;
 			
-			// aapt resource value: 0x7f01012d
-			public const int expandedTitleGravity = 2130772269;
+			// aapt resource value: 0x7F03008C
+			public const int colorPrimaryDark = 2130903180;
 			
-			// aapt resource value: 0x7f010120
-			public const int expandedTitleMargin = 2130772256;
+			// aapt resource value: 0x7F03008D
+			public const int colorSecondary = 2130903181;
 			
-			// aapt resource value: 0x7f010124
-			public const int expandedTitleMarginBottom = 2130772260;
+			// aapt resource value: 0x7F03008E
+			public const int colorSwitchThumbNormal = 2130903182;
 			
-			// aapt resource value: 0x7f010123
-			public const int expandedTitleMarginEnd = 2130772259;
+			// aapt resource value: 0x7F03008F
+			public const int commitIcon = 2130903183;
 			
-			// aapt resource value: 0x7f010121
-			public const int expandedTitleMarginStart = 2130772257;
+			// aapt resource value: 0x7F030090
+			public const int contentDescription = 2130903184;
 			
-			// aapt resource value: 0x7f010122
-			public const int expandedTitleMarginTop = 2130772258;
+			// aapt resource value: 0x7F030091
+			public const int contentInsetEnd = 2130903185;
 			
-			// aapt resource value: 0x7f010125
-			public const int expandedTitleTextAppearance = 2130772261;
+			// aapt resource value: 0x7F030092
+			public const int contentInsetEndWithActions = 2130903186;
 			
-			// aapt resource value: 0x7f010015
-			public const int externalRouteEnabledDrawable = 2130771989;
+			// aapt resource value: 0x7F030093
+			public const int contentInsetLeft = 2130903187;
 			
-			// aapt resource value: 0x7f01013d
-			public const int fabSize = 2130772285;
+			// aapt resource value: 0x7F030094
+			public const int contentInsetRight = 2130903188;
 			
-			// aapt resource value: 0x7f010004
-			public const int fastScrollEnabled = 2130771972;
+			// aapt resource value: 0x7F030095
+			public const int contentInsetStart = 2130903189;
 			
-			// aapt resource value: 0x7f010007
-			public const int fastScrollHorizontalThumbDrawable = 2130771975;
+			// aapt resource value: 0x7F030096
+			public const int contentInsetStartWithNavigation = 2130903190;
 			
-			// aapt resource value: 0x7f010008
-			public const int fastScrollHorizontalTrackDrawable = 2130771976;
+			// aapt resource value: 0x7F030097
+			public const int contentPadding = 2130903191;
 			
-			// aapt resource value: 0x7f010005
-			public const int fastScrollVerticalThumbDrawable = 2130771973;
+			// aapt resource value: 0x7F030098
+			public const int contentPaddingBottom = 2130903192;
 			
-			// aapt resource value: 0x7f010006
-			public const int fastScrollVerticalTrackDrawable = 2130771974;
+			// aapt resource value: 0x7F030099
+			public const int contentPaddingLeft = 2130903193;
 			
-			// aapt resource value: 0x7f010171
-			public const int font = 2130772337;
+			// aapt resource value: 0x7F03009A
+			public const int contentPaddingRight = 2130903194;
 			
-			// aapt resource value: 0x7f010055
-			public const int fontFamily = 2130772053;
+			// aapt resource value: 0x7F03009B
+			public const int contentPaddingTop = 2130903195;
 			
-			// aapt resource value: 0x7f01016a
-			public const int fontProviderAuthority = 2130772330;
+			// aapt resource value: 0x7F03009C
+			public const int contentScrim = 2130903196;
 			
-			// aapt resource value: 0x7f01016d
-			public const int fontProviderCerts = 2130772333;
+			// aapt resource value: 0x7F03009D
+			public const int controlBackground = 2130903197;
 			
-			// aapt resource value: 0x7f01016e
-			public const int fontProviderFetchStrategy = 2130772334;
+			// aapt resource value: 0x7F03009E
+			public const int coordinatorLayoutStyle = 2130903198;
 			
-			// aapt resource value: 0x7f01016f
-			public const int fontProviderFetchTimeout = 2130772335;
+			// aapt resource value: 0x7F03009F
+			public const int cornerRadius = 2130903199;
 			
-			// aapt resource value: 0x7f01016b
-			public const int fontProviderPackage = 2130772331;
+			// aapt resource value: 0x7F0300A0
+			public const int counterEnabled = 2130903200;
 			
-			// aapt resource value: 0x7f01016c
-			public const int fontProviderQuery = 2130772332;
+			// aapt resource value: 0x7F0300A1
+			public const int counterMaxLength = 2130903201;
 			
-			// aapt resource value: 0x7f010170
-			public const int fontStyle = 2130772336;
+			// aapt resource value: 0x7F0300A2
+			public const int counterOverflowTextAppearance = 2130903202;
 			
-			// aapt resource value: 0x7f010172
-			public const int fontWeight = 2130772338;
+			// aapt resource value: 0x7F0300A3
+			public const int counterTextAppearance = 2130903203;
 			
-			// aapt resource value: 0x7f010142
-			public const int foregroundInsidePadding = 2130772290;
+			// aapt resource value: 0x7F0300A4
+			public const int customNavigationLayout = 2130903204;
 			
-			// aapt resource value: 0x7f0100d2
-			public const int gapBetweenBars = 2130772178;
+			// aapt resource value: 0x7F0300A5
+			public const int defaultQueryHint = 2130903205;
 			
-			// aapt resource value: 0x7f0100ef
-			public const int goIcon = 2130772207;
+			// aapt resource value: 0x7F0300A6
+			public const int dialogCornerRadius = 2130903206;
 			
-			// aapt resource value: 0x7f010148
-			public const int headerLayout = 2130772296;
+			// aapt resource value: 0x7F0300A7
+			public const int dialogPreferredPadding = 2130903207;
 			
-			// aapt resource value: 0x7f010023
-			public const int height = 2130772003;
+			// aapt resource value: 0x7F0300A8
+			public const int dialogTheme = 2130903208;
 			
-			// aapt resource value: 0x7f010037
-			public const int hideOnContentScroll = 2130772023;
+			// aapt resource value: 0x7F0300A9
+			public const int displayOptions = 2130903209;
 			
-			// aapt resource value: 0x7f010164
-			public const int hintAnimationEnabled = 2130772324;
+			// aapt resource value: 0x7F0300AA
+			public const int divider = 2130903210;
 			
-			// aapt resource value: 0x7f01015d
-			public const int hintEnabled = 2130772317;
+			// aapt resource value: 0x7F0300AB
+			public const int dividerHorizontal = 2130903211;
 			
-			// aapt resource value: 0x7f01015c
-			public const int hintTextAppearance = 2130772316;
+			// aapt resource value: 0x7F0300AC
+			public const int dividerPadding = 2130903212;
 			
-			// aapt resource value: 0x7f010085
-			public const int homeAsUpIndicator = 2130772101;
+			// aapt resource value: 0x7F0300AD
+			public const int dividerVertical = 2130903213;
 			
-			// aapt resource value: 0x7f010032
-			public const int homeLayout = 2130772018;
+			// aapt resource value: 0x7F0300AE
+			public const int drawableSize = 2130903214;
 			
-			// aapt resource value: 0x7f01002b
-			public const int icon = 2130772011;
+			// aapt resource value: 0x7F0300AF
+			public const int drawerArrowStyle = 2130903215;
 			
-			// aapt resource value: 0x7f0100e2
-			public const int iconTint = 2130772194;
+			// aapt resource value: 0x7F0300B1
+			public const int dropdownListPreferredItemHeight = 2130903217;
 			
-			// aapt resource value: 0x7f0100e3
-			public const int iconTintMode = 2130772195;
+			// aapt resource value: 0x7F0300B0
+			public const int dropDownListViewStyle = 2130903216;
 			
-			// aapt resource value: 0x7f0100eb
-			public const int iconifiedByDefault = 2130772203;
+			// aapt resource value: 0x7F0300B2
+			public const int editTextBackground = 2130903218;
 			
-			// aapt resource value: 0x7f010095
-			public const int imageButtonStyle = 2130772117;
+			// aapt resource value: 0x7F0300B3
+			public const int editTextColor = 2130903219;
 			
-			// aapt resource value: 0x7f010034
-			public const int indeterminateProgressStyle = 2130772020;
+			// aapt resource value: 0x7F0300B4
+			public const int editTextStyle = 2130903220;
 			
-			// aapt resource value: 0x7f010041
-			public const int initialActivityCount = 2130772033;
+			// aapt resource value: 0x7F0300B5
+			public const int elevation = 2130903221;
 			
-			// aapt resource value: 0x7f010149
-			public const int insetForeground = 2130772297;
+			// aapt resource value: 0x7F0300B6
+			public const int enforceMaterialTheme = 2130903222;
 			
-			// aapt resource value: 0x7f010024
-			public const int isLightTheme = 2130772004;
+			// aapt resource value: 0x7F0300B7
+			public const int enforceTextAppearance = 2130903223;
 			
-			// aapt resource value: 0x7f010146
-			public const int itemBackground = 2130772294;
+			// aapt resource value: 0x7F0300B8
+			public const int errorEnabled = 2130903224;
 			
-			// aapt resource value: 0x7f010144
-			public const int itemIconTint = 2130772292;
+			// aapt resource value: 0x7F0300B9
+			public const int errorTextAppearance = 2130903225;
 			
-			// aapt resource value: 0x7f010036
-			public const int itemPadding = 2130772022;
+			// aapt resource value: 0x7F0300BA
+			public const int expandActivityOverflowButtonDrawable = 2130903226;
 			
-			// aapt resource value: 0x7f010147
-			public const int itemTextAppearance = 2130772295;
+			// aapt resource value: 0x7F0300BB
+			public const int expanded = 2130903227;
 			
-			// aapt resource value: 0x7f010145
-			public const int itemTextColor = 2130772293;
+			// aapt resource value: 0x7F0300BC
+			public const int expandedTitleGravity = 2130903228;
 			
-			// aapt resource value: 0x7f010131
-			public const int keylines = 2130772273;
+			// aapt resource value: 0x7F0300BD
+			public const int expandedTitleMargin = 2130903229;
 			
-			// aapt resource value: 0x7f0100ea
-			public const int layout = 2130772202;
+			// aapt resource value: 0x7F0300BE
+			public const int expandedTitleMarginBottom = 2130903230;
 			
-			// aapt resource value: 0x7f010000
-			public const int layoutManager = 2130771968;
+			// aapt resource value: 0x7F0300BF
+			public const int expandedTitleMarginEnd = 2130903231;
 			
-			// aapt resource value: 0x7f010134
-			public const int layout_anchor = 2130772276;
+			// aapt resource value: 0x7F0300C0
+			public const int expandedTitleMarginStart = 2130903232;
 			
-			// aapt resource value: 0x7f010136
-			public const int layout_anchorGravity = 2130772278;
+			// aapt resource value: 0x7F0300C1
+			public const int expandedTitleMarginTop = 2130903233;
 			
-			// aapt resource value: 0x7f010133
-			public const int layout_behavior = 2130772275;
+			// aapt resource value: 0x7F0300C2
+			public const int expandedTitleTextAppearance = 2130903234;
 			
-			// aapt resource value: 0x7f01012f
-			public const int layout_collapseMode = 2130772271;
+			// aapt resource value: 0x7F0300C3
+			public const int externalRouteEnabledDrawable = 2130903235;
 			
-			// aapt resource value: 0x7f010130
-			public const int layout_collapseParallaxMultiplier = 2130772272;
+			// aapt resource value: 0x7F0300C4
+			public const int fabAlignmentMode = 2130903236;
 			
-			// aapt resource value: 0x7f010138
-			public const int layout_dodgeInsetEdges = 2130772280;
+			// aapt resource value: 0x7F0300C5
+			public const int fabCradleMargin = 2130903237;
 			
-			// aapt resource value: 0x7f010137
-			public const int layout_insetEdge = 2130772279;
+			// aapt resource value: 0x7F0300C6
+			public const int fabCradleRoundedCornerRadius = 2130903238;
 			
-			// aapt resource value: 0x7f010135
-			public const int layout_keyline = 2130772277;
+			// aapt resource value: 0x7F0300C7
+			public const int fabCradleVerticalOffset = 2130903239;
 			
-			// aapt resource value: 0x7f01011b
-			public const int layout_scrollFlags = 2130772251;
+			// aapt resource value: 0x7F0300C8
+			public const int fabCustomSize = 2130903240;
 			
-			// aapt resource value: 0x7f01011c
-			public const int layout_scrollInterpolator = 2130772252;
+			// aapt resource value: 0x7F0300C9
+			public const int fabSize = 2130903241;
 			
-			// aapt resource value: 0x7f0100a7
-			public const int listChoiceBackgroundIndicator = 2130772135;
+			// aapt resource value: 0x7F0300CA
+			public const int fastScrollEnabled = 2130903242;
 			
-			// aapt resource value: 0x7f010081
-			public const int listDividerAlertDialog = 2130772097;
+			// aapt resource value: 0x7F0300CB
+			public const int fastScrollHorizontalThumbDrawable = 2130903243;
 			
-			// aapt resource value: 0x7f010047
-			public const int listItemLayout = 2130772039;
+			// aapt resource value: 0x7F0300CC
+			public const int fastScrollHorizontalTrackDrawable = 2130903244;
 			
-			// aapt resource value: 0x7f010044
-			public const int listLayout = 2130772036;
+			// aapt resource value: 0x7F0300CD
+			public const int fastScrollVerticalThumbDrawable = 2130903245;
 			
-			// aapt resource value: 0x7f0100c7
-			public const int listMenuViewStyle = 2130772167;
+			// aapt resource value: 0x7F0300CE
+			public const int fastScrollVerticalTrackDrawable = 2130903246;
 			
-			// aapt resource value: 0x7f0100a0
-			public const int listPopupWindowStyle = 2130772128;
+			// aapt resource value: 0x7F0300CF
+			public const int firstBaselineToTopHeight = 2130903247;
 			
-			// aapt resource value: 0x7f01009a
-			public const int listPreferredItemHeight = 2130772122;
+			// aapt resource value: 0x7F0300D0
+			public const int floatingActionButtonStyle = 2130903248;
 			
-			// aapt resource value: 0x7f01009c
-			public const int listPreferredItemHeightLarge = 2130772124;
+			// aapt resource value: 0x7F0300D1
+			public const int font = 2130903249;
 			
-			// aapt resource value: 0x7f01009b
-			public const int listPreferredItemHeightSmall = 2130772123;
+			// aapt resource value: 0x7F0300D2
+			public const int fontFamily = 2130903250;
 			
-			// aapt resource value: 0x7f01009d
-			public const int listPreferredItemPaddingLeft = 2130772125;
+			// aapt resource value: 0x7F0300D3
+			public const int fontProviderAuthority = 2130903251;
 			
-			// aapt resource value: 0x7f01009e
-			public const int listPreferredItemPaddingRight = 2130772126;
+			// aapt resource value: 0x7F0300D4
+			public const int fontProviderCerts = 2130903252;
 			
-			// aapt resource value: 0x7f01002c
-			public const int logo = 2130772012;
+			// aapt resource value: 0x7F0300D5
+			public const int fontProviderFetchStrategy = 2130903253;
 			
-			// aapt resource value: 0x7f010110
-			public const int logoDescription = 2130772240;
+			// aapt resource value: 0x7F0300D6
+			public const int fontProviderFetchTimeout = 2130903254;
 			
-			// aapt resource value: 0x7f01014b
-			public const int maxActionInlineWidth = 2130772299;
+			// aapt resource value: 0x7F0300D7
+			public const int fontProviderPackage = 2130903255;
 			
-			// aapt resource value: 0x7f01010a
-			public const int maxButtonHeight = 2130772234;
+			// aapt resource value: 0x7F0300D8
+			public const int fontProviderQuery = 2130903256;
 			
-			// aapt resource value: 0x7f0100d7
-			public const int measureWithLargestChild = 2130772183;
+			// aapt resource value: 0x7F0300D9
+			public const int fontStyle = 2130903257;
 			
-			// aapt resource value: 0x7f010009
-			public const int mediaRouteAudioTrackDrawable = 2130771977;
+			// aapt resource value: 0x7F0300DA
+			public const int fontVariationSettings = 2130903258;
 			
-			// aapt resource value: 0x7f01000a
-			public const int mediaRouteButtonStyle = 2130771978;
+			// aapt resource value: 0x7F0300DB
+			public const int fontWeight = 2130903259;
 			
-			// aapt resource value: 0x7f010016
-			public const int mediaRouteButtonTint = 2130771990;
+			// aapt resource value: 0x7F0300DC
+			public const int foregroundInsidePadding = 2130903260;
 			
-			// aapt resource value: 0x7f01000b
-			public const int mediaRouteCloseDrawable = 2130771979;
+			// aapt resource value: 0x7F0300DD
+			public const int gapBetweenBars = 2130903261;
 			
-			// aapt resource value: 0x7f01000c
-			public const int mediaRouteControlPanelThemeOverlay = 2130771980;
+			// aapt resource value: 0x7F0300DE
+			public const int goIcon = 2130903262;
 			
-			// aapt resource value: 0x7f01000d
-			public const int mediaRouteDefaultIconDrawable = 2130771981;
+			// aapt resource value: 0x7F0300DF
+			public const int headerLayout = 2130903263;
 			
-			// aapt resource value: 0x7f01000e
-			public const int mediaRoutePauseDrawable = 2130771982;
+			// aapt resource value: 0x7F0300E0
+			public const int height = 2130903264;
 			
-			// aapt resource value: 0x7f01000f
-			public const int mediaRoutePlayDrawable = 2130771983;
+			// aapt resource value: 0x7F0300E1
+			public const int helperText = 2130903265;
 			
-			// aapt resource value: 0x7f010010
-			public const int mediaRouteSpeakerGroupIconDrawable = 2130771984;
+			// aapt resource value: 0x7F0300E2
+			public const int helperTextEnabled = 2130903266;
 			
-			// aapt resource value: 0x7f010011
-			public const int mediaRouteSpeakerIconDrawable = 2130771985;
+			// aapt resource value: 0x7F0300E3
+			public const int helperTextTextAppearance = 2130903267;
 			
-			// aapt resource value: 0x7f010012
-			public const int mediaRouteStopDrawable = 2130771986;
+			// aapt resource value: 0x7F0300E4
+			public const int hideMotionSpec = 2130903268;
 			
-			// aapt resource value: 0x7f010013
-			public const int mediaRouteTheme = 2130771987;
+			// aapt resource value: 0x7F0300E5
+			public const int hideOnContentScroll = 2130903269;
 			
-			// aapt resource value: 0x7f010014
-			public const int mediaRouteTvIconDrawable = 2130771988;
+			// aapt resource value: 0x7F0300E6
+			public const int hideOnScroll = 2130903270;
 			
-			// aapt resource value: 0x7f010143
-			public const int menu = 2130772291;
+			// aapt resource value: 0x7F0300E7
+			public const int hintAnimationEnabled = 2130903271;
 			
-			// aapt resource value: 0x7f010045
-			public const int multiChoiceItemLayout = 2130772037;
+			// aapt resource value: 0x7F0300E8
+			public const int hintEnabled = 2130903272;
 			
-			// aapt resource value: 0x7f01010f
-			public const int navigationContentDescription = 2130772239;
+			// aapt resource value: 0x7F0300E9
+			public const int hintTextAppearance = 2130903273;
 			
-			// aapt resource value: 0x7f01010e
-			public const int navigationIcon = 2130772238;
+			// aapt resource value: 0x7F0300EA
+			public const int homeAsUpIndicator = 2130903274;
 			
-			// aapt resource value: 0x7f010026
-			public const int navigationMode = 2130772006;
+			// aapt resource value: 0x7F0300EB
+			public const int homeLayout = 2130903275;
 			
-			// aapt resource value: 0x7f0100db
-			public const int numericModifiers = 2130772187;
+			// aapt resource value: 0x7F0300EC
+			public const int hoveredFocusedTranslationZ = 2130903276;
 			
-			// aapt resource value: 0x7f0100e6
-			public const int overlapAnchor = 2130772198;
+			// aapt resource value: 0x7F0300ED
+			public const int icon = 2130903277;
 			
-			// aapt resource value: 0x7f0100e8
-			public const int paddingBottomNoButtons = 2130772200;
+			// aapt resource value: 0x7F0300EE
+			public const int iconEndPadding = 2130903278;
 			
-			// aapt resource value: 0x7f010114
-			public const int paddingEnd = 2130772244;
+			// aapt resource value: 0x7F0300EF
+			public const int iconGravity = 2130903279;
 			
-			// aapt resource value: 0x7f010113
-			public const int paddingStart = 2130772243;
+			// aapt resource value: 0x7F0300F5
+			public const int iconifiedByDefault = 2130903285;
 			
-			// aapt resource value: 0x7f0100e9
-			public const int paddingTopNoTitle = 2130772201;
+			// aapt resource value: 0x7F0300F0
+			public const int iconPadding = 2130903280;
 			
-			// aapt resource value: 0x7f0100a4
-			public const int panelBackground = 2130772132;
+			// aapt resource value: 0x7F0300F1
+			public const int iconSize = 2130903281;
 			
-			// aapt resource value: 0x7f0100a6
-			public const int panelMenuListTheme = 2130772134;
+			// aapt resource value: 0x7F0300F2
+			public const int iconStartPadding = 2130903282;
 			
-			// aapt resource value: 0x7f0100a5
-			public const int panelMenuListWidth = 2130772133;
+			// aapt resource value: 0x7F0300F3
+			public const int iconTint = 2130903283;
 			
-			// aapt resource value: 0x7f010167
-			public const int passwordToggleContentDescription = 2130772327;
+			// aapt resource value: 0x7F0300F4
+			public const int iconTintMode = 2130903284;
 			
-			// aapt resource value: 0x7f010166
-			public const int passwordToggleDrawable = 2130772326;
+			// aapt resource value: 0x7F0300F6
+			public const int imageButtonStyle = 2130903286;
 			
-			// aapt resource value: 0x7f010165
-			public const int passwordToggleEnabled = 2130772325;
+			// aapt resource value: 0x7F0300F7
+			public const int indeterminateProgressStyle = 2130903287;
 			
-			// aapt resource value: 0x7f010168
-			public const int passwordToggleTint = 2130772328;
+			// aapt resource value: 0x7F0300F8
+			public const int initialActivityCount = 2130903288;
 			
-			// aapt resource value: 0x7f010169
-			public const int passwordToggleTintMode = 2130772329;
+			// aapt resource value: 0x7F0300F9
+			public const int insetForeground = 2130903289;
 			
-			// aapt resource value: 0x7f010091
-			public const int popupMenuStyle = 2130772113;
+			// aapt resource value: 0x7F0300FA
+			public const int isLightTheme = 2130903290;
 			
-			// aapt resource value: 0x7f01003f
-			public const int popupTheme = 2130772031;
+			// aapt resource value: 0x7F0300FB
+			public const int itemBackground = 2130903291;
 			
-			// aapt resource value: 0x7f010092
-			public const int popupWindowStyle = 2130772114;
+			// aapt resource value: 0x7F0300FC
+			public const int itemHorizontalPadding = 2130903292;
 			
-			// aapt resource value: 0x7f0100e4
-			public const int preserveIconSpacing = 2130772196;
+			// aapt resource value: 0x7F0300FD
+			public const int itemHorizontalTranslationEnabled = 2130903293;
 			
-			// aapt resource value: 0x7f01013e
-			public const int pressedTranslationZ = 2130772286;
+			// aapt resource value: 0x7F0300FE
+			public const int itemIconPadding = 2130903294;
 			
-			// aapt resource value: 0x7f010035
-			public const int progressBarPadding = 2130772021;
+			// aapt resource value: 0x7F0300FF
+			public const int itemIconSize = 2130903295;
 			
-			// aapt resource value: 0x7f010033
-			public const int progressBarStyle = 2130772019;
+			// aapt resource value: 0x7F030100
+			public const int itemIconTint = 2130903296;
 			
-			// aapt resource value: 0x7f0100f5
-			public const int queryBackground = 2130772213;
+			// aapt resource value: 0x7F030101
+			public const int itemPadding = 2130903297;
 			
-			// aapt resource value: 0x7f0100ec
-			public const int queryHint = 2130772204;
+			// aapt resource value: 0x7F030102
+			public const int itemSpacing = 2130903298;
 			
-			// aapt resource value: 0x7f0100c0
-			public const int radioButtonStyle = 2130772160;
+			// aapt resource value: 0x7F030103
+			public const int itemTextAppearance = 2130903299;
 			
-			// aapt resource value: 0x7f0100c1
-			public const int ratingBarStyle = 2130772161;
+			// aapt resource value: 0x7F030104
+			public const int itemTextAppearanceActive = 2130903300;
 			
-			// aapt resource value: 0x7f0100c2
-			public const int ratingBarStyleIndicator = 2130772162;
+			// aapt resource value: 0x7F030105
+			public const int itemTextAppearanceInactive = 2130903301;
 			
-			// aapt resource value: 0x7f0100c3
-			public const int ratingBarStyleSmall = 2130772163;
+			// aapt resource value: 0x7F030106
+			public const int itemTextColor = 2130903302;
 			
-			// aapt resource value: 0x7f010002
-			public const int reverseLayout = 2130771970;
+			// aapt resource value: 0x7F030107
+			public const int keylines = 2130903303;
 			
-			// aapt resource value: 0x7f01013c
-			public const int rippleColor = 2130772284;
+			// aapt resource value: 0x7F030108
+			public const int labelVisibilityMode = 2130903304;
 			
-			// aapt resource value: 0x7f01012b
-			public const int scrimAnimationDuration = 2130772267;
+			// aapt resource value: 0x7F030109
+			public const int lastBaselineToBottomHeight = 2130903305;
 			
-			// aapt resource value: 0x7f01012a
-			public const int scrimVisibleHeightTrigger = 2130772266;
+			// aapt resource value: 0x7F03010A
+			public const int layout = 2130903306;
 			
-			// aapt resource value: 0x7f0100f1
-			public const int searchHintIcon = 2130772209;
+			// aapt resource value: 0x7F03010B
+			public const int layoutManager = 2130903307;
 			
-			// aapt resource value: 0x7f0100f0
-			public const int searchIcon = 2130772208;
+			// aapt resource value: 0x7F03010C
+			public const int layout_anchor = 2130903308;
 			
-			// aapt resource value: 0x7f010099
-			public const int searchViewStyle = 2130772121;
+			// aapt resource value: 0x7F03010D
+			public const int layout_anchorGravity = 2130903309;
 			
-			// aapt resource value: 0x7f0100c4
-			public const int seekBarStyle = 2130772164;
+			// aapt resource value: 0x7F03010E
+			public const int layout_behavior = 2130903310;
 			
-			// aapt resource value: 0x7f010089
-			public const int selectableItemBackground = 2130772105;
+			// aapt resource value: 0x7F03010F
+			public const int layout_collapseMode = 2130903311;
 			
-			// aapt resource value: 0x7f01008a
-			public const int selectableItemBackgroundBorderless = 2130772106;
+			// aapt resource value: 0x7F030110
+			public const int layout_collapseParallaxMultiplier = 2130903312;
 			
-			// aapt resource value: 0x7f0100dc
-			public const int showAsAction = 2130772188;
+			// aapt resource value: 0x7F030111
+			public const int layout_dodgeInsetEdges = 2130903313;
 			
-			// aapt resource value: 0x7f0100d8
-			public const int showDividers = 2130772184;
+			// aapt resource value: 0x7F030112
+			public const int layout_insetEdge = 2130903314;
 			
-			// aapt resource value: 0x7f010101
-			public const int showText = 2130772225;
+			// aapt resource value: 0x7F030113
+			public const int layout_keyline = 2130903315;
 			
-			// aapt resource value: 0x7f010048
-			public const int showTitle = 2130772040;
+			// aapt resource value: 0x7F030114
+			public const int layout_scrollFlags = 2130903316;
 			
-			// aapt resource value: 0x7f010046
-			public const int singleChoiceItemLayout = 2130772038;
+			// aapt resource value: 0x7F030115
+			public const int layout_scrollInterpolator = 2130903317;
 			
-			// aapt resource value: 0x7f010001
-			public const int spanCount = 2130771969;
+			// aapt resource value: 0x7F030116
+			public const int liftOnScroll = 2130903318;
 			
-			// aapt resource value: 0x7f0100d0
-			public const int spinBars = 2130772176;
+			// aapt resource value: 0x7F030117
+			public const int lineHeight = 2130903319;
 			
-			// aapt resource value: 0x7f010084
-			public const int spinnerDropDownItemStyle = 2130772100;
+			// aapt resource value: 0x7F030118
+			public const int lineSpacing = 2130903320;
 			
-			// aapt resource value: 0x7f0100c5
-			public const int spinnerStyle = 2130772165;
+			// aapt resource value: 0x7F030119
+			public const int listChoiceBackgroundIndicator = 2130903321;
 			
-			// aapt resource value: 0x7f010100
-			public const int splitTrack = 2130772224;
+			// aapt resource value: 0x7F03011A
+			public const int listDividerAlertDialog = 2130903322;
 			
-			// aapt resource value: 0x7f010049
-			public const int srcCompat = 2130772041;
+			// aapt resource value: 0x7F03011B
+			public const int listItemLayout = 2130903323;
 			
-			// aapt resource value: 0x7f010003
-			public const int stackFromEnd = 2130771971;
+			// aapt resource value: 0x7F03011C
+			public const int listLayout = 2130903324;
 			
-			// aapt resource value: 0x7f0100e7
-			public const int state_above_anchor = 2130772199;
+			// aapt resource value: 0x7F03011D
+			public const int listMenuViewStyle = 2130903325;
 			
-			// aapt resource value: 0x7f010119
-			public const int state_collapsed = 2130772249;
+			// aapt resource value: 0x7F03011E
+			public const int listPopupWindowStyle = 2130903326;
 			
-			// aapt resource value: 0x7f01011a
-			public const int state_collapsible = 2130772250;
+			// aapt resource value: 0x7F03011F
+			public const int listPreferredItemHeight = 2130903327;
 			
-			// aapt resource value: 0x7f010132
-			public const int statusBarBackground = 2130772274;
+			// aapt resource value: 0x7F030120
+			public const int listPreferredItemHeightLarge = 2130903328;
 			
-			// aapt resource value: 0x7f010128
-			public const int statusBarScrim = 2130772264;
+			// aapt resource value: 0x7F030121
+			public const int listPreferredItemHeightSmall = 2130903329;
 			
-			// aapt resource value: 0x7f0100e5
-			public const int subMenuArrow = 2130772197;
+			// aapt resource value: 0x7F030122
+			public const int listPreferredItemPaddingLeft = 2130903330;
 			
-			// aapt resource value: 0x7f0100f6
-			public const int submitBackground = 2130772214;
+			// aapt resource value: 0x7F030123
+			public const int listPreferredItemPaddingRight = 2130903331;
 			
-			// aapt resource value: 0x7f010028
-			public const int subtitle = 2130772008;
+			// aapt resource value: 0x7F030124
+			public const int logo = 2130903332;
 			
-			// aapt resource value: 0x7f010103
-			public const int subtitleTextAppearance = 2130772227;
+			// aapt resource value: 0x7F030125
+			public const int logoDescription = 2130903333;
 			
-			// aapt resource value: 0x7f010112
-			public const int subtitleTextColor = 2130772242;
+			// aapt resource value: 0x7F030126
+			public const int materialButtonStyle = 2130903334;
 			
-			// aapt resource value: 0x7f01002a
-			public const int subtitleTextStyle = 2130772010;
+			// aapt resource value: 0x7F030127
+			public const int materialCardViewStyle = 2130903335;
 			
-			// aapt resource value: 0x7f0100f4
-			public const int suggestionRowLayout = 2130772212;
+			// aapt resource value: 0x7F030128
+			public const int maxActionInlineWidth = 2130903336;
 			
-			// aapt resource value: 0x7f0100fe
-			public const int switchMinWidth = 2130772222;
+			// aapt resource value: 0x7F030129
+			public const int maxButtonHeight = 2130903337;
 			
-			// aapt resource value: 0x7f0100ff
-			public const int switchPadding = 2130772223;
+			// aapt resource value: 0x7F03012A
+			public const int maxImageSize = 2130903338;
 			
-			// aapt resource value: 0x7f0100c6
-			public const int switchStyle = 2130772166;
+			// aapt resource value: 0x7F03012B
+			public const int measureWithLargestChild = 2130903339;
 			
-			// aapt resource value: 0x7f0100fd
-			public const int switchTextAppearance = 2130772221;
+			// aapt resource value: 0x7F03012C
+			public const int mediaRouteAudioTrackDrawable = 2130903340;
 			
-			// aapt resource value: 0x7f01014f
-			public const int tabBackground = 2130772303;
+			// aapt resource value: 0x7F03012D
+			public const int mediaRouteButtonStyle = 2130903341;
 			
-			// aapt resource value: 0x7f01014e
-			public const int tabContentStart = 2130772302;
+			// aapt resource value: 0x7F03012E
+			public const int mediaRouteButtonTint = 2130903342;
 			
-			// aapt resource value: 0x7f010151
-			public const int tabGravity = 2130772305;
+			// aapt resource value: 0x7F03012F
+			public const int mediaRouteCloseDrawable = 2130903343;
 			
-			// aapt resource value: 0x7f01014c
-			public const int tabIndicatorColor = 2130772300;
+			// aapt resource value: 0x7F030130
+			public const int mediaRouteControlPanelThemeOverlay = 2130903344;
 			
-			// aapt resource value: 0x7f01014d
-			public const int tabIndicatorHeight = 2130772301;
+			// aapt resource value: 0x7F030131
+			public const int mediaRouteDefaultIconDrawable = 2130903345;
 			
-			// aapt resource value: 0x7f010153
-			public const int tabMaxWidth = 2130772307;
+			// aapt resource value: 0x7F030132
+			public const int mediaRoutePauseDrawable = 2130903346;
 			
-			// aapt resource value: 0x7f010152
-			public const int tabMinWidth = 2130772306;
+			// aapt resource value: 0x7F030133
+			public const int mediaRoutePlayDrawable = 2130903347;
 			
-			// aapt resource value: 0x7f010150
-			public const int tabMode = 2130772304;
+			// aapt resource value: 0x7F030134
+			public const int mediaRouteSpeakerGroupIconDrawable = 2130903348;
 			
-			// aapt resource value: 0x7f01015b
-			public const int tabPadding = 2130772315;
+			// aapt resource value: 0x7F030135
+			public const int mediaRouteSpeakerIconDrawable = 2130903349;
 			
-			// aapt resource value: 0x7f01015a
-			public const int tabPaddingBottom = 2130772314;
+			// aapt resource value: 0x7F030136
+			public const int mediaRouteStopDrawable = 2130903350;
 			
-			// aapt resource value: 0x7f010159
-			public const int tabPaddingEnd = 2130772313;
+			// aapt resource value: 0x7F030137
+			public const int mediaRouteTheme = 2130903351;
 			
-			// aapt resource value: 0x7f010157
-			public const int tabPaddingStart = 2130772311;
+			// aapt resource value: 0x7F030138
+			public const int mediaRouteTvIconDrawable = 2130903352;
 			
-			// aapt resource value: 0x7f010158
-			public const int tabPaddingTop = 2130772312;
+			// aapt resource value: 0x7F030139
+			public const int menu = 2130903353;
 			
-			// aapt resource value: 0x7f010156
-			public const int tabSelectedTextColor = 2130772310;
+			// aapt resource value: 0x7F03013A
+			public const int multiChoiceItemLayout = 2130903354;
 			
-			// aapt resource value: 0x7f010154
-			public const int tabTextAppearance = 2130772308;
+			// aapt resource value: 0x7F03013B
+			public const int navigationContentDescription = 2130903355;
 			
-			// aapt resource value: 0x7f010155
-			public const int tabTextColor = 2130772309;
+			// aapt resource value: 0x7F03013C
+			public const int navigationIcon = 2130903356;
 			
-			// aapt resource value: 0x7f01004f
-			public const int textAllCaps = 2130772047;
+			// aapt resource value: 0x7F03013D
+			public const int navigationMode = 2130903357;
 			
-			// aapt resource value: 0x7f01007c
-			public const int textAppearanceLargePopupMenu = 2130772092;
+			// aapt resource value: 0x7F03013E
+			public const int navigationViewStyle = 2130903358;
 			
-			// aapt resource value: 0x7f0100a1
-			public const int textAppearanceListItem = 2130772129;
+			// aapt resource value: 0x7F03013F
+			public const int numericModifiers = 2130903359;
 			
-			// aapt resource value: 0x7f0100a2
-			public const int textAppearanceListItemSecondary = 2130772130;
+			// aapt resource value: 0x7F030140
+			public const int overlapAnchor = 2130903360;
 			
-			// aapt resource value: 0x7f0100a3
-			public const int textAppearanceListItemSmall = 2130772131;
+			// aapt resource value: 0x7F030141
+			public const int paddingBottomNoButtons = 2130903361;
 			
-			// aapt resource value: 0x7f01007e
-			public const int textAppearancePopupMenuHeader = 2130772094;
+			// aapt resource value: 0x7F030142
+			public const int paddingEnd = 2130903362;
 			
-			// aapt resource value: 0x7f010097
-			public const int textAppearanceSearchResultSubtitle = 2130772119;
+			// aapt resource value: 0x7F030143
+			public const int paddingStart = 2130903363;
 			
-			// aapt resource value: 0x7f010096
-			public const int textAppearanceSearchResultTitle = 2130772118;
+			// aapt resource value: 0x7F030144
+			public const int paddingTopNoTitle = 2130903364;
 			
-			// aapt resource value: 0x7f01007d
-			public const int textAppearanceSmallPopupMenu = 2130772093;
+			// aapt resource value: 0x7F030145
+			public const int panelBackground = 2130903365;
 			
-			// aapt resource value: 0x7f0100b6
-			public const int textColorAlertDialogListItem = 2130772150;
+			// aapt resource value: 0x7F030146
+			public const int panelMenuListTheme = 2130903366;
 			
-			// aapt resource value: 0x7f01013b
-			public const int textColorError = 2130772283;
+			// aapt resource value: 0x7F030147
+			public const int panelMenuListWidth = 2130903367;
 			
-			// aapt resource value: 0x7f010098
-			public const int textColorSearchUrl = 2130772120;
+			// aapt resource value: 0x7F030148
+			public const int passwordToggleContentDescription = 2130903368;
 			
-			// aapt resource value: 0x7f010115
-			public const int theme = 2130772245;
+			// aapt resource value: 0x7F030149
+			public const int passwordToggleDrawable = 2130903369;
 			
-			// aapt resource value: 0x7f0100d6
-			public const int thickness = 2130772182;
+			// aapt resource value: 0x7F03014A
+			public const int passwordToggleEnabled = 2130903370;
 			
-			// aapt resource value: 0x7f0100fc
-			public const int thumbTextPadding = 2130772220;
+			// aapt resource value: 0x7F03014B
+			public const int passwordToggleTint = 2130903371;
 			
-			// aapt resource value: 0x7f0100f7
-			public const int thumbTint = 2130772215;
+			// aapt resource value: 0x7F03014C
+			public const int passwordToggleTintMode = 2130903372;
 			
-			// aapt resource value: 0x7f0100f8
-			public const int thumbTintMode = 2130772216;
+			// aapt resource value: 0x7F03014D
+			public const int popupMenuStyle = 2130903373;
 			
-			// aapt resource value: 0x7f01004c
-			public const int tickMark = 2130772044;
+			// aapt resource value: 0x7F03014E
+			public const int popupTheme = 2130903374;
 			
-			// aapt resource value: 0x7f01004d
-			public const int tickMarkTint = 2130772045;
+			// aapt resource value: 0x7F03014F
+			public const int popupWindowStyle = 2130903375;
 			
-			// aapt resource value: 0x7f01004e
-			public const int tickMarkTintMode = 2130772046;
+			// aapt resource value: 0x7F030150
+			public const int preserveIconSpacing = 2130903376;
 			
-			// aapt resource value: 0x7f01004a
-			public const int tint = 2130772042;
+			// aapt resource value: 0x7F030151
+			public const int pressedTranslationZ = 2130903377;
 			
-			// aapt resource value: 0x7f01004b
-			public const int tintMode = 2130772043;
+			// aapt resource value: 0x7F030152
+			public const int progressBarPadding = 2130903378;
 			
-			// aapt resource value: 0x7f010025
-			public const int title = 2130772005;
+			// aapt resource value: 0x7F030153
+			public const int progressBarStyle = 2130903379;
 			
-			// aapt resource value: 0x7f01012e
-			public const int titleEnabled = 2130772270;
+			// aapt resource value: 0x7F030154
+			public const int queryBackground = 2130903380;
 			
-			// aapt resource value: 0x7f010104
-			public const int titleMargin = 2130772228;
+			// aapt resource value: 0x7F030155
+			public const int queryHint = 2130903381;
 			
-			// aapt resource value: 0x7f010108
-			public const int titleMarginBottom = 2130772232;
+			// aapt resource value: 0x7F030156
+			public const int radioButtonStyle = 2130903382;
 			
-			// aapt resource value: 0x7f010106
-			public const int titleMarginEnd = 2130772230;
+			// aapt resource value: 0x7F030157
+			public const int ratingBarStyle = 2130903383;
 			
-			// aapt resource value: 0x7f010105
-			public const int titleMarginStart = 2130772229;
+			// aapt resource value: 0x7F030158
+			public const int ratingBarStyleIndicator = 2130903384;
 			
-			// aapt resource value: 0x7f010107
-			public const int titleMarginTop = 2130772231;
+			// aapt resource value: 0x7F030159
+			public const int ratingBarStyleSmall = 2130903385;
 			
-			// aapt resource value: 0x7f010109
-			public const int titleMargins = 2130772233;
+			// aapt resource value: 0x7F03015A
+			public const int reverseLayout = 2130903386;
 			
-			// aapt resource value: 0x7f010102
-			public const int titleTextAppearance = 2130772226;
+			// aapt resource value: 0x7F03015B
+			public const int rippleColor = 2130903387;
 			
-			// aapt resource value: 0x7f010111
-			public const int titleTextColor = 2130772241;
+			// aapt resource value: 0x7F03015C
+			public const int scrimAnimationDuration = 2130903388;
 			
-			// aapt resource value: 0x7f010029
-			public const int titleTextStyle = 2130772009;
+			// aapt resource value: 0x7F03015D
+			public const int scrimBackground = 2130903389;
 			
-			// aapt resource value: 0x7f010129
-			public const int toolbarId = 2130772265;
+			// aapt resource value: 0x7F03015E
+			public const int scrimVisibleHeightTrigger = 2130903390;
 			
-			// aapt resource value: 0x7f010090
-			public const int toolbarNavigationButtonStyle = 2130772112;
+			// aapt resource value: 0x7F03015F
+			public const int searchHintIcon = 2130903391;
 			
-			// aapt resource value: 0x7f01008f
-			public const int toolbarStyle = 2130772111;
+			// aapt resource value: 0x7F030160
+			public const int searchIcon = 2130903392;
 			
-			// aapt resource value: 0x7f0100c9
-			public const int tooltipForegroundColor = 2130772169;
+			// aapt resource value: 0x7F030161
+			public const int searchViewStyle = 2130903393;
 			
-			// aapt resource value: 0x7f0100c8
-			public const int tooltipFrameBackground = 2130772168;
+			// aapt resource value: 0x7F030162
+			public const int seekBarStyle = 2130903394;
 			
-			// aapt resource value: 0x7f0100e1
-			public const int tooltipText = 2130772193;
+			// aapt resource value: 0x7F030163
+			public const int selectableItemBackground = 2130903395;
 			
-			// aapt resource value: 0x7f0100f9
-			public const int track = 2130772217;
+			// aapt resource value: 0x7F030164
+			public const int selectableItemBackgroundBorderless = 2130903396;
 			
-			// aapt resource value: 0x7f0100fa
-			public const int trackTint = 2130772218;
+			// aapt resource value: 0x7F030165
+			public const int showAsAction = 2130903397;
 			
-			// aapt resource value: 0x7f0100fb
-			public const int trackTintMode = 2130772219;
+			// aapt resource value: 0x7F030166
+			public const int showDividers = 2130903398;
 			
-			// aapt resource value: 0x7f010140
-			public const int useCompatPadding = 2130772288;
+			// aapt resource value: 0x7F030167
+			public const int showMotionSpec = 2130903399;
 			
-			// aapt resource value: 0x7f0100f2
-			public const int voiceIcon = 2130772210;
+			// aapt resource value: 0x7F030168
+			public const int showText = 2130903400;
 			
-			// aapt resource value: 0x7f010056
-			public const int windowActionBar = 2130772054;
+			// aapt resource value: 0x7F030169
+			public const int showTitle = 2130903401;
 			
-			// aapt resource value: 0x7f010058
-			public const int windowActionBarOverlay = 2130772056;
+			// aapt resource value: 0x7F03016A
+			public const int singleChoiceItemLayout = 2130903402;
 			
-			// aapt resource value: 0x7f010059
-			public const int windowActionModeOverlay = 2130772057;
+			// aapt resource value: 0x7F03016B
+			public const int singleLine = 2130903403;
 			
-			// aapt resource value: 0x7f01005d
-			public const int windowFixedHeightMajor = 2130772061;
+			// aapt resource value: 0x7F03016C
+			public const int singleSelection = 2130903404;
 			
-			// aapt resource value: 0x7f01005b
-			public const int windowFixedHeightMinor = 2130772059;
+			// aapt resource value: 0x7F03016D
+			public const int snackbarButtonStyle = 2130903405;
 			
-			// aapt resource value: 0x7f01005a
-			public const int windowFixedWidthMajor = 2130772058;
+			// aapt resource value: 0x7F03016E
+			public const int snackbarStyle = 2130903406;
 			
-			// aapt resource value: 0x7f01005c
-			public const int windowFixedWidthMinor = 2130772060;
+			// aapt resource value: 0x7F03016F
+			public const int spanCount = 2130903407;
 			
-			// aapt resource value: 0x7f01005e
-			public const int windowMinWidthMajor = 2130772062;
+			// aapt resource value: 0x7F030170
+			public const int spinBars = 2130903408;
 			
-			// aapt resource value: 0x7f01005f
-			public const int windowMinWidthMinor = 2130772063;
+			// aapt resource value: 0x7F030171
+			public const int spinnerDropDownItemStyle = 2130903409;
 			
-			// aapt resource value: 0x7f010057
-			public const int windowNoTitle = 2130772055;
+			// aapt resource value: 0x7F030172
+			public const int spinnerStyle = 2130903410;
+			
+			// aapt resource value: 0x7F030173
+			public const int splitTrack = 2130903411;
+			
+			// aapt resource value: 0x7F030174
+			public const int srcCompat = 2130903412;
+			
+			// aapt resource value: 0x7F030175
+			public const int stackFromEnd = 2130903413;
+			
+			// aapt resource value: 0x7F030176
+			public const int state_above_anchor = 2130903414;
+			
+			// aapt resource value: 0x7F030177
+			public const int state_collapsed = 2130903415;
+			
+			// aapt resource value: 0x7F030178
+			public const int state_collapsible = 2130903416;
+			
+			// aapt resource value: 0x7F030179
+			public const int state_liftable = 2130903417;
+			
+			// aapt resource value: 0x7F03017A
+			public const int state_lifted = 2130903418;
+			
+			// aapt resource value: 0x7F03017B
+			public const int statusBarBackground = 2130903419;
+			
+			// aapt resource value: 0x7F03017C
+			public const int statusBarScrim = 2130903420;
+			
+			// aapt resource value: 0x7F03017D
+			public const int strokeColor = 2130903421;
+			
+			// aapt resource value: 0x7F03017E
+			public const int strokeWidth = 2130903422;
+			
+			// aapt resource value: 0x7F03017F
+			public const int subMenuArrow = 2130903423;
+			
+			// aapt resource value: 0x7F030180
+			public const int submitBackground = 2130903424;
+			
+			// aapt resource value: 0x7F030181
+			public const int subtitle = 2130903425;
+			
+			// aapt resource value: 0x7F030182
+			public const int subtitleTextAppearance = 2130903426;
+			
+			// aapt resource value: 0x7F030183
+			public const int subtitleTextColor = 2130903427;
+			
+			// aapt resource value: 0x7F030184
+			public const int subtitleTextStyle = 2130903428;
+			
+			// aapt resource value: 0x7F030185
+			public const int suggestionRowLayout = 2130903429;
+			
+			// aapt resource value: 0x7F030186
+			public const int switchMinWidth = 2130903430;
+			
+			// aapt resource value: 0x7F030187
+			public const int switchPadding = 2130903431;
+			
+			// aapt resource value: 0x7F030188
+			public const int switchStyle = 2130903432;
+			
+			// aapt resource value: 0x7F030189
+			public const int switchTextAppearance = 2130903433;
+			
+			// aapt resource value: 0x7F03018A
+			public const int tabBackground = 2130903434;
+			
+			// aapt resource value: 0x7F03018B
+			public const int tabContentStart = 2130903435;
+			
+			// aapt resource value: 0x7F03018C
+			public const int tabGravity = 2130903436;
+			
+			// aapt resource value: 0x7F03018D
+			public const int tabIconTint = 2130903437;
+			
+			// aapt resource value: 0x7F03018E
+			public const int tabIconTintMode = 2130903438;
+			
+			// aapt resource value: 0x7F03018F
+			public const int tabIndicator = 2130903439;
+			
+			// aapt resource value: 0x7F030190
+			public const int tabIndicatorAnimationDuration = 2130903440;
+			
+			// aapt resource value: 0x7F030191
+			public const int tabIndicatorColor = 2130903441;
+			
+			// aapt resource value: 0x7F030192
+			public const int tabIndicatorFullWidth = 2130903442;
+			
+			// aapt resource value: 0x7F030193
+			public const int tabIndicatorGravity = 2130903443;
+			
+			// aapt resource value: 0x7F030194
+			public const int tabIndicatorHeight = 2130903444;
+			
+			// aapt resource value: 0x7F030195
+			public const int tabInlineLabel = 2130903445;
+			
+			// aapt resource value: 0x7F030196
+			public const int tabMaxWidth = 2130903446;
+			
+			// aapt resource value: 0x7F030197
+			public const int tabMinWidth = 2130903447;
+			
+			// aapt resource value: 0x7F030198
+			public const int tabMode = 2130903448;
+			
+			// aapt resource value: 0x7F030199
+			public const int tabPadding = 2130903449;
+			
+			// aapt resource value: 0x7F03019A
+			public const int tabPaddingBottom = 2130903450;
+			
+			// aapt resource value: 0x7F03019B
+			public const int tabPaddingEnd = 2130903451;
+			
+			// aapt resource value: 0x7F03019C
+			public const int tabPaddingStart = 2130903452;
+			
+			// aapt resource value: 0x7F03019D
+			public const int tabPaddingTop = 2130903453;
+			
+			// aapt resource value: 0x7F03019E
+			public const int tabRippleColor = 2130903454;
+			
+			// aapt resource value: 0x7F03019F
+			public const int tabSelectedTextColor = 2130903455;
+			
+			// aapt resource value: 0x7F0301A0
+			public const int tabStyle = 2130903456;
+			
+			// aapt resource value: 0x7F0301A1
+			public const int tabTextAppearance = 2130903457;
+			
+			// aapt resource value: 0x7F0301A2
+			public const int tabTextColor = 2130903458;
+			
+			// aapt resource value: 0x7F0301A3
+			public const int tabUnboundedRipple = 2130903459;
+			
+			// aapt resource value: 0x7F0301A4
+			public const int textAllCaps = 2130903460;
+			
+			// aapt resource value: 0x7F0301A5
+			public const int textAppearanceBody1 = 2130903461;
+			
+			// aapt resource value: 0x7F0301A6
+			public const int textAppearanceBody2 = 2130903462;
+			
+			// aapt resource value: 0x7F0301A7
+			public const int textAppearanceButton = 2130903463;
+			
+			// aapt resource value: 0x7F0301A8
+			public const int textAppearanceCaption = 2130903464;
+			
+			// aapt resource value: 0x7F0301A9
+			public const int textAppearanceHeadline1 = 2130903465;
+			
+			// aapt resource value: 0x7F0301AA
+			public const int textAppearanceHeadline2 = 2130903466;
+			
+			// aapt resource value: 0x7F0301AB
+			public const int textAppearanceHeadline3 = 2130903467;
+			
+			// aapt resource value: 0x7F0301AC
+			public const int textAppearanceHeadline4 = 2130903468;
+			
+			// aapt resource value: 0x7F0301AD
+			public const int textAppearanceHeadline5 = 2130903469;
+			
+			// aapt resource value: 0x7F0301AE
+			public const int textAppearanceHeadline6 = 2130903470;
+			
+			// aapt resource value: 0x7F0301AF
+			public const int textAppearanceLargePopupMenu = 2130903471;
+			
+			// aapt resource value: 0x7F0301B0
+			public const int textAppearanceListItem = 2130903472;
+			
+			// aapt resource value: 0x7F0301B1
+			public const int textAppearanceListItemSecondary = 2130903473;
+			
+			// aapt resource value: 0x7F0301B2
+			public const int textAppearanceListItemSmall = 2130903474;
+			
+			// aapt resource value: 0x7F0301B3
+			public const int textAppearanceOverline = 2130903475;
+			
+			// aapt resource value: 0x7F0301B4
+			public const int textAppearancePopupMenuHeader = 2130903476;
+			
+			// aapt resource value: 0x7F0301B5
+			public const int textAppearanceSearchResultSubtitle = 2130903477;
+			
+			// aapt resource value: 0x7F0301B6
+			public const int textAppearanceSearchResultTitle = 2130903478;
+			
+			// aapt resource value: 0x7F0301B7
+			public const int textAppearanceSmallPopupMenu = 2130903479;
+			
+			// aapt resource value: 0x7F0301B8
+			public const int textAppearanceSubtitle1 = 2130903480;
+			
+			// aapt resource value: 0x7F0301B9
+			public const int textAppearanceSubtitle2 = 2130903481;
+			
+			// aapt resource value: 0x7F0301BA
+			public const int textColorAlertDialogListItem = 2130903482;
+			
+			// aapt resource value: 0x7F0301BB
+			public const int textColorSearchUrl = 2130903483;
+			
+			// aapt resource value: 0x7F0301BC
+			public const int textEndPadding = 2130903484;
+			
+			// aapt resource value: 0x7F0301BD
+			public const int textInputStyle = 2130903485;
+			
+			// aapt resource value: 0x7F0301BE
+			public const int textStartPadding = 2130903486;
+			
+			// aapt resource value: 0x7F0301BF
+			public const int theme = 2130903487;
+			
+			// aapt resource value: 0x7F0301C0
+			public const int thickness = 2130903488;
+			
+			// aapt resource value: 0x7F0301C1
+			public const int thumbTextPadding = 2130903489;
+			
+			// aapt resource value: 0x7F0301C2
+			public const int thumbTint = 2130903490;
+			
+			// aapt resource value: 0x7F0301C3
+			public const int thumbTintMode = 2130903491;
+			
+			// aapt resource value: 0x7F0301C4
+			public const int tickMark = 2130903492;
+			
+			// aapt resource value: 0x7F0301C5
+			public const int tickMarkTint = 2130903493;
+			
+			// aapt resource value: 0x7F0301C6
+			public const int tickMarkTintMode = 2130903494;
+			
+			// aapt resource value: 0x7F0301C7
+			public const int tint = 2130903495;
+			
+			// aapt resource value: 0x7F0301C8
+			public const int tintMode = 2130903496;
+			
+			// aapt resource value: 0x7F0301C9
+			public const int title = 2130903497;
+			
+			// aapt resource value: 0x7F0301CA
+			public const int titleEnabled = 2130903498;
+			
+			// aapt resource value: 0x7F0301CB
+			public const int titleMargin = 2130903499;
+			
+			// aapt resource value: 0x7F0301CC
+			public const int titleMarginBottom = 2130903500;
+			
+			// aapt resource value: 0x7F0301CD
+			public const int titleMarginEnd = 2130903501;
+			
+			// aapt resource value: 0x7F0301D0
+			public const int titleMargins = 2130903504;
+			
+			// aapt resource value: 0x7F0301CE
+			public const int titleMarginStart = 2130903502;
+			
+			// aapt resource value: 0x7F0301CF
+			public const int titleMarginTop = 2130903503;
+			
+			// aapt resource value: 0x7F0301D1
+			public const int titleTextAppearance = 2130903505;
+			
+			// aapt resource value: 0x7F0301D2
+			public const int titleTextColor = 2130903506;
+			
+			// aapt resource value: 0x7F0301D3
+			public const int titleTextStyle = 2130903507;
+			
+			// aapt resource value: 0x7F0301D4
+			public const int toolbarId = 2130903508;
+			
+			// aapt resource value: 0x7F0301D5
+			public const int toolbarNavigationButtonStyle = 2130903509;
+			
+			// aapt resource value: 0x7F0301D6
+			public const int toolbarStyle = 2130903510;
+			
+			// aapt resource value: 0x7F0301D7
+			public const int tooltipForegroundColor = 2130903511;
+			
+			// aapt resource value: 0x7F0301D8
+			public const int tooltipFrameBackground = 2130903512;
+			
+			// aapt resource value: 0x7F0301D9
+			public const int tooltipText = 2130903513;
+			
+			// aapt resource value: 0x7F0301DA
+			public const int track = 2130903514;
+			
+			// aapt resource value: 0x7F0301DB
+			public const int trackTint = 2130903515;
+			
+			// aapt resource value: 0x7F0301DC
+			public const int trackTintMode = 2130903516;
+			
+			// aapt resource value: 0x7F0301DD
+			public const int ttcIndex = 2130903517;
+			
+			// aapt resource value: 0x7F0301DE
+			public const int useCompatPadding = 2130903518;
+			
+			// aapt resource value: 0x7F0301DF
+			public const int viewInflaterClass = 2130903519;
+			
+			// aapt resource value: 0x7F0301E0
+			public const int voiceIcon = 2130903520;
+			
+			// aapt resource value: 0x7F0301E1
+			public const int windowActionBar = 2130903521;
+			
+			// aapt resource value: 0x7F0301E2
+			public const int windowActionBarOverlay = 2130903522;
+			
+			// aapt resource value: 0x7F0301E3
+			public const int windowActionModeOverlay = 2130903523;
+			
+			// aapt resource value: 0x7F0301E4
+			public const int windowFixedHeightMajor = 2130903524;
+			
+			// aapt resource value: 0x7F0301E5
+			public const int windowFixedHeightMinor = 2130903525;
+			
+			// aapt resource value: 0x7F0301E6
+			public const int windowFixedWidthMajor = 2130903526;
+			
+			// aapt resource value: 0x7F0301E7
+			public const int windowFixedWidthMinor = 2130903527;
+			
+			// aapt resource value: 0x7F0301E8
+			public const int windowMinWidthMajor = 2130903528;
+			
+			// aapt resource value: 0x7F0301E9
+			public const int windowMinWidthMinor = 2130903529;
+			
+			// aapt resource value: 0x7F0301EA
+			public const int windowNoTitle = 2130903530;
 			
 			static Attribute()
 			{
@@ -3238,20 +4195,17 @@ namespace SextantSample.Droid
 		public partial class Boolean
 		{
 			
-			// aapt resource value: 0x7f0e0000
-			public const int abc_action_bar_embed_tabs = 2131623936;
+			// aapt resource value: 0x7F040000
+			public const int abc_action_bar_embed_tabs = 2130968576;
 			
-			// aapt resource value: 0x7f0e0001
-			public const int abc_allow_stacked_button_bar = 2131623937;
+			// aapt resource value: 0x7F040001
+			public const int abc_allow_stacked_button_bar = 2130968577;
 			
-			// aapt resource value: 0x7f0e0002
-			public const int abc_config_actionMenuItemAllCaps = 2131623938;
+			// aapt resource value: 0x7F040002
+			public const int abc_config_actionMenuItemAllCaps = 2130968578;
 			
-			// aapt resource value: 0x7f0e0003
-			public const int abc_config_closeDialogWhenTouchOutside = 2131623939;
-			
-			// aapt resource value: 0x7f0e0004
-			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131623940;
+			// aapt resource value: 0x7F040003
+			public const int mtrl_btn_textappearance_all_caps = 2130968579;
 			
 			static Boolean()
 			{
@@ -3266,314 +4220,413 @@ namespace SextantSample.Droid
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f0d004f
-			public const int abc_background_cache_hint_selector_material_dark = 2131558479;
+			// aapt resource value: 0x7F050000
+			public const int abc_background_cache_hint_selector_material_dark = 2131034112;
 			
-			// aapt resource value: 0x7f0d0050
-			public const int abc_background_cache_hint_selector_material_light = 2131558480;
+			// aapt resource value: 0x7F050001
+			public const int abc_background_cache_hint_selector_material_light = 2131034113;
 			
-			// aapt resource value: 0x7f0d0051
-			public const int abc_btn_colored_borderless_text_material = 2131558481;
+			// aapt resource value: 0x7F050002
+			public const int abc_btn_colored_borderless_text_material = 2131034114;
 			
-			// aapt resource value: 0x7f0d0052
-			public const int abc_btn_colored_text_material = 2131558482;
+			// aapt resource value: 0x7F050003
+			public const int abc_btn_colored_text_material = 2131034115;
 			
-			// aapt resource value: 0x7f0d0053
-			public const int abc_color_highlight_material = 2131558483;
+			// aapt resource value: 0x7F050004
+			public const int abc_color_highlight_material = 2131034116;
 			
-			// aapt resource value: 0x7f0d0054
-			public const int abc_hint_foreground_material_dark = 2131558484;
+			// aapt resource value: 0x7F050005
+			public const int abc_hint_foreground_material_dark = 2131034117;
 			
-			// aapt resource value: 0x7f0d0055
-			public const int abc_hint_foreground_material_light = 2131558485;
+			// aapt resource value: 0x7F050006
+			public const int abc_hint_foreground_material_light = 2131034118;
 			
-			// aapt resource value: 0x7f0d0004
-			public const int abc_input_method_navigation_guard = 2131558404;
+			// aapt resource value: 0x7F050007
+			public const int abc_input_method_navigation_guard = 2131034119;
 			
-			// aapt resource value: 0x7f0d0056
-			public const int abc_primary_text_disable_only_material_dark = 2131558486;
+			// aapt resource value: 0x7F050008
+			public const int abc_primary_text_disable_only_material_dark = 2131034120;
 			
-			// aapt resource value: 0x7f0d0057
-			public const int abc_primary_text_disable_only_material_light = 2131558487;
+			// aapt resource value: 0x7F050009
+			public const int abc_primary_text_disable_only_material_light = 2131034121;
 			
-			// aapt resource value: 0x7f0d0058
-			public const int abc_primary_text_material_dark = 2131558488;
+			// aapt resource value: 0x7F05000A
+			public const int abc_primary_text_material_dark = 2131034122;
 			
-			// aapt resource value: 0x7f0d0059
-			public const int abc_primary_text_material_light = 2131558489;
+			// aapt resource value: 0x7F05000B
+			public const int abc_primary_text_material_light = 2131034123;
 			
-			// aapt resource value: 0x7f0d005a
-			public const int abc_search_url_text = 2131558490;
+			// aapt resource value: 0x7F05000C
+			public const int abc_search_url_text = 2131034124;
 			
-			// aapt resource value: 0x7f0d0005
-			public const int abc_search_url_text_normal = 2131558405;
+			// aapt resource value: 0x7F05000D
+			public const int abc_search_url_text_normal = 2131034125;
 			
-			// aapt resource value: 0x7f0d0006
-			public const int abc_search_url_text_pressed = 2131558406;
+			// aapt resource value: 0x7F05000E
+			public const int abc_search_url_text_pressed = 2131034126;
 			
-			// aapt resource value: 0x7f0d0007
-			public const int abc_search_url_text_selected = 2131558407;
+			// aapt resource value: 0x7F05000F
+			public const int abc_search_url_text_selected = 2131034127;
 			
-			// aapt resource value: 0x7f0d005b
-			public const int abc_secondary_text_material_dark = 2131558491;
+			// aapt resource value: 0x7F050010
+			public const int abc_secondary_text_material_dark = 2131034128;
 			
-			// aapt resource value: 0x7f0d005c
-			public const int abc_secondary_text_material_light = 2131558492;
+			// aapt resource value: 0x7F050011
+			public const int abc_secondary_text_material_light = 2131034129;
 			
-			// aapt resource value: 0x7f0d005d
-			public const int abc_tint_btn_checkable = 2131558493;
+			// aapt resource value: 0x7F050012
+			public const int abc_tint_btn_checkable = 2131034130;
 			
-			// aapt resource value: 0x7f0d005e
-			public const int abc_tint_default = 2131558494;
+			// aapt resource value: 0x7F050013
+			public const int abc_tint_default = 2131034131;
 			
-			// aapt resource value: 0x7f0d005f
-			public const int abc_tint_edittext = 2131558495;
+			// aapt resource value: 0x7F050014
+			public const int abc_tint_edittext = 2131034132;
 			
-			// aapt resource value: 0x7f0d0060
-			public const int abc_tint_seek_thumb = 2131558496;
+			// aapt resource value: 0x7F050015
+			public const int abc_tint_seek_thumb = 2131034133;
 			
-			// aapt resource value: 0x7f0d0061
-			public const int abc_tint_spinner = 2131558497;
+			// aapt resource value: 0x7F050016
+			public const int abc_tint_spinner = 2131034134;
 			
-			// aapt resource value: 0x7f0d0062
-			public const int abc_tint_switch_track = 2131558498;
+			// aapt resource value: 0x7F050017
+			public const int abc_tint_switch_track = 2131034135;
 			
-			// aapt resource value: 0x7f0d0008
-			public const int accent_material_dark = 2131558408;
+			// aapt resource value: 0x7F050018
+			public const int accent_material_dark = 2131034136;
 			
-			// aapt resource value: 0x7f0d0009
-			public const int accent_material_light = 2131558409;
+			// aapt resource value: 0x7F050019
+			public const int accent_material_light = 2131034137;
 			
-			// aapt resource value: 0x7f0d000a
-			public const int background_floating_material_dark = 2131558410;
+			// aapt resource value: 0x7F05001A
+			public const int background_floating_material_dark = 2131034138;
 			
-			// aapt resource value: 0x7f0d000b
-			public const int background_floating_material_light = 2131558411;
+			// aapt resource value: 0x7F05001B
+			public const int background_floating_material_light = 2131034139;
 			
-			// aapt resource value: 0x7f0d000c
-			public const int background_material_dark = 2131558412;
+			// aapt resource value: 0x7F05001C
+			public const int background_material_dark = 2131034140;
 			
-			// aapt resource value: 0x7f0d000d
-			public const int background_material_light = 2131558413;
+			// aapt resource value: 0x7F05001D
+			public const int background_material_light = 2131034141;
 			
-			// aapt resource value: 0x7f0d000e
-			public const int bright_foreground_disabled_material_dark = 2131558414;
+			// aapt resource value: 0x7F05001E
+			public const int bright_foreground_disabled_material_dark = 2131034142;
 			
-			// aapt resource value: 0x7f0d000f
-			public const int bright_foreground_disabled_material_light = 2131558415;
+			// aapt resource value: 0x7F05001F
+			public const int bright_foreground_disabled_material_light = 2131034143;
 			
-			// aapt resource value: 0x7f0d0010
-			public const int bright_foreground_inverse_material_dark = 2131558416;
+			// aapt resource value: 0x7F050020
+			public const int bright_foreground_inverse_material_dark = 2131034144;
 			
-			// aapt resource value: 0x7f0d0011
-			public const int bright_foreground_inverse_material_light = 2131558417;
+			// aapt resource value: 0x7F050021
+			public const int bright_foreground_inverse_material_light = 2131034145;
 			
-			// aapt resource value: 0x7f0d0012
-			public const int bright_foreground_material_dark = 2131558418;
+			// aapt resource value: 0x7F050022
+			public const int bright_foreground_material_dark = 2131034146;
 			
-			// aapt resource value: 0x7f0d0013
-			public const int bright_foreground_material_light = 2131558419;
+			// aapt resource value: 0x7F050023
+			public const int bright_foreground_material_light = 2131034147;
 			
-			// aapt resource value: 0x7f0d0014
-			public const int button_material_dark = 2131558420;
+			// aapt resource value: 0x7F050024
+			public const int browser_actions_bg_grey = 2131034148;
 			
-			// aapt resource value: 0x7f0d0015
-			public const int button_material_light = 2131558421;
+			// aapt resource value: 0x7F050025
+			public const int browser_actions_divider_color = 2131034149;
 			
-			// aapt resource value: 0x7f0d0000
-			public const int cardview_dark_background = 2131558400;
+			// aapt resource value: 0x7F050026
+			public const int browser_actions_text_color = 2131034150;
 			
-			// aapt resource value: 0x7f0d0001
-			public const int cardview_light_background = 2131558401;
+			// aapt resource value: 0x7F050027
+			public const int browser_actions_title_color = 2131034151;
 			
-			// aapt resource value: 0x7f0d0002
-			public const int cardview_shadow_end_color = 2131558402;
+			// aapt resource value: 0x7F050028
+			public const int button_material_dark = 2131034152;
 			
-			// aapt resource value: 0x7f0d0003
-			public const int cardview_shadow_start_color = 2131558403;
+			// aapt resource value: 0x7F050029
+			public const int button_material_light = 2131034153;
 			
-			// aapt resource value: 0x7f0d004e
-			public const int colorAccent = 2131558478;
+			// aapt resource value: 0x7F05002A
+			public const int cardview_dark_background = 2131034154;
 			
-			// aapt resource value: 0x7f0d004c
-			public const int colorPrimary = 2131558476;
+			// aapt resource value: 0x7F05002B
+			public const int cardview_light_background = 2131034155;
 			
-			// aapt resource value: 0x7f0d004d
-			public const int colorPrimaryDark = 2131558477;
+			// aapt resource value: 0x7F05002C
+			public const int cardview_shadow_end_color = 2131034156;
 			
-			// aapt resource value: 0x7f0d0040
-			public const int design_bottom_navigation_shadow_color = 2131558464;
+			// aapt resource value: 0x7F05002D
+			public const int cardview_shadow_start_color = 2131034157;
 			
-			// aapt resource value: 0x7f0d0063
-			public const int design_error = 2131558499;
+			// aapt resource value: 0x7F05002E
+			public const int colorAccent = 2131034158;
 			
-			// aapt resource value: 0x7f0d0041
-			public const int design_fab_shadow_end_color = 2131558465;
+			// aapt resource value: 0x7F05002F
+			public const int colorPrimary = 2131034159;
 			
-			// aapt resource value: 0x7f0d0042
-			public const int design_fab_shadow_mid_color = 2131558466;
+			// aapt resource value: 0x7F050030
+			public const int colorPrimaryDark = 2131034160;
 			
-			// aapt resource value: 0x7f0d0043
-			public const int design_fab_shadow_start_color = 2131558467;
+			// aapt resource value: 0x7F050031
+			public const int design_bottom_navigation_shadow_color = 2131034161;
 			
-			// aapt resource value: 0x7f0d0044
-			public const int design_fab_stroke_end_inner_color = 2131558468;
+			// aapt resource value: 0x7F050032
+			public const int design_default_color_primary = 2131034162;
 			
-			// aapt resource value: 0x7f0d0045
-			public const int design_fab_stroke_end_outer_color = 2131558469;
+			// aapt resource value: 0x7F050033
+			public const int design_default_color_primary_dark = 2131034163;
 			
-			// aapt resource value: 0x7f0d0046
-			public const int design_fab_stroke_top_inner_color = 2131558470;
+			// aapt resource value: 0x7F050034
+			public const int design_error = 2131034164;
 			
-			// aapt resource value: 0x7f0d0047
-			public const int design_fab_stroke_top_outer_color = 2131558471;
+			// aapt resource value: 0x7F050035
+			public const int design_fab_shadow_end_color = 2131034165;
 			
-			// aapt resource value: 0x7f0d0048
-			public const int design_snackbar_background_color = 2131558472;
+			// aapt resource value: 0x7F050036
+			public const int design_fab_shadow_mid_color = 2131034166;
 			
-			// aapt resource value: 0x7f0d0064
-			public const int design_tint_password_toggle = 2131558500;
+			// aapt resource value: 0x7F050037
+			public const int design_fab_shadow_start_color = 2131034167;
 			
-			// aapt resource value: 0x7f0d0016
-			public const int dim_foreground_disabled_material_dark = 2131558422;
+			// aapt resource value: 0x7F050038
+			public const int design_fab_stroke_end_inner_color = 2131034168;
 			
-			// aapt resource value: 0x7f0d0017
-			public const int dim_foreground_disabled_material_light = 2131558423;
+			// aapt resource value: 0x7F050039
+			public const int design_fab_stroke_end_outer_color = 2131034169;
 			
-			// aapt resource value: 0x7f0d0018
-			public const int dim_foreground_material_dark = 2131558424;
+			// aapt resource value: 0x7F05003A
+			public const int design_fab_stroke_top_inner_color = 2131034170;
 			
-			// aapt resource value: 0x7f0d0019
-			public const int dim_foreground_material_light = 2131558425;
+			// aapt resource value: 0x7F05003B
+			public const int design_fab_stroke_top_outer_color = 2131034171;
 			
-			// aapt resource value: 0x7f0d001a
-			public const int error_color_material = 2131558426;
+			// aapt resource value: 0x7F05003C
+			public const int design_snackbar_background_color = 2131034172;
 			
-			// aapt resource value: 0x7f0d001b
-			public const int foreground_material_dark = 2131558427;
+			// aapt resource value: 0x7F05003D
+			public const int design_tint_password_toggle = 2131034173;
 			
-			// aapt resource value: 0x7f0d001c
-			public const int foreground_material_light = 2131558428;
+			// aapt resource value: 0x7F05003E
+			public const int dim_foreground_disabled_material_dark = 2131034174;
 			
-			// aapt resource value: 0x7f0d001d
-			public const int highlighted_text_material_dark = 2131558429;
+			// aapt resource value: 0x7F05003F
+			public const int dim_foreground_disabled_material_light = 2131034175;
 			
-			// aapt resource value: 0x7f0d001e
-			public const int highlighted_text_material_light = 2131558430;
+			// aapt resource value: 0x7F050040
+			public const int dim_foreground_material_dark = 2131034176;
 			
-			// aapt resource value: 0x7f0d004b
-			public const int launcher_background = 2131558475;
+			// aapt resource value: 0x7F050041
+			public const int dim_foreground_material_light = 2131034177;
 			
-			// aapt resource value: 0x7f0d001f
-			public const int material_blue_grey_800 = 2131558431;
+			// aapt resource value: 0x7F050042
+			public const int error_color_material_dark = 2131034178;
 			
-			// aapt resource value: 0x7f0d0020
-			public const int material_blue_grey_900 = 2131558432;
+			// aapt resource value: 0x7F050043
+			public const int error_color_material_light = 2131034179;
 			
-			// aapt resource value: 0x7f0d0021
-			public const int material_blue_grey_950 = 2131558433;
+			// aapt resource value: 0x7F050044
+			public const int foreground_material_dark = 2131034180;
 			
-			// aapt resource value: 0x7f0d0022
-			public const int material_deep_teal_200 = 2131558434;
+			// aapt resource value: 0x7F050045
+			public const int foreground_material_light = 2131034181;
 			
-			// aapt resource value: 0x7f0d0023
-			public const int material_deep_teal_500 = 2131558435;
+			// aapt resource value: 0x7F050046
+			public const int highlighted_text_material_dark = 2131034182;
 			
-			// aapt resource value: 0x7f0d0024
-			public const int material_grey_100 = 2131558436;
+			// aapt resource value: 0x7F050047
+			public const int highlighted_text_material_light = 2131034183;
 			
-			// aapt resource value: 0x7f0d0025
-			public const int material_grey_300 = 2131558437;
+			// aapt resource value: 0x7F050048
+			public const int launcher_background = 2131034184;
 			
-			// aapt resource value: 0x7f0d0026
-			public const int material_grey_50 = 2131558438;
+			// aapt resource value: 0x7F050049
+			public const int material_blue_grey_800 = 2131034185;
 			
-			// aapt resource value: 0x7f0d0027
-			public const int material_grey_600 = 2131558439;
+			// aapt resource value: 0x7F05004A
+			public const int material_blue_grey_900 = 2131034186;
 			
-			// aapt resource value: 0x7f0d0028
-			public const int material_grey_800 = 2131558440;
+			// aapt resource value: 0x7F05004B
+			public const int material_blue_grey_950 = 2131034187;
 			
-			// aapt resource value: 0x7f0d0029
-			public const int material_grey_850 = 2131558441;
+			// aapt resource value: 0x7F05004C
+			public const int material_deep_teal_200 = 2131034188;
 			
-			// aapt resource value: 0x7f0d002a
-			public const int material_grey_900 = 2131558442;
+			// aapt resource value: 0x7F05004D
+			public const int material_deep_teal_500 = 2131034189;
 			
-			// aapt resource value: 0x7f0d0049
-			public const int notification_action_color_filter = 2131558473;
+			// aapt resource value: 0x7F05004E
+			public const int material_grey_100 = 2131034190;
 			
-			// aapt resource value: 0x7f0d004a
-			public const int notification_icon_bg_color = 2131558474;
+			// aapt resource value: 0x7F05004F
+			public const int material_grey_300 = 2131034191;
 			
-			// aapt resource value: 0x7f0d003f
-			public const int notification_material_background_media_default_color = 2131558463;
+			// aapt resource value: 0x7F050050
+			public const int material_grey_50 = 2131034192;
 			
-			// aapt resource value: 0x7f0d002b
-			public const int primary_dark_material_dark = 2131558443;
+			// aapt resource value: 0x7F050051
+			public const int material_grey_600 = 2131034193;
 			
-			// aapt resource value: 0x7f0d002c
-			public const int primary_dark_material_light = 2131558444;
+			// aapt resource value: 0x7F050052
+			public const int material_grey_800 = 2131034194;
 			
-			// aapt resource value: 0x7f0d002d
-			public const int primary_material_dark = 2131558445;
+			// aapt resource value: 0x7F050053
+			public const int material_grey_850 = 2131034195;
 			
-			// aapt resource value: 0x7f0d002e
-			public const int primary_material_light = 2131558446;
+			// aapt resource value: 0x7F050054
+			public const int material_grey_900 = 2131034196;
 			
-			// aapt resource value: 0x7f0d002f
-			public const int primary_text_default_material_dark = 2131558447;
+			// aapt resource value: 0x7F050055
+			public const int mtrl_bottom_nav_colored_item_tint = 2131034197;
 			
-			// aapt resource value: 0x7f0d0030
-			public const int primary_text_default_material_light = 2131558448;
+			// aapt resource value: 0x7F050056
+			public const int mtrl_bottom_nav_item_tint = 2131034198;
 			
-			// aapt resource value: 0x7f0d0031
-			public const int primary_text_disabled_material_dark = 2131558449;
+			// aapt resource value: 0x7F050057
+			public const int mtrl_btn_bg_color_disabled = 2131034199;
 			
-			// aapt resource value: 0x7f0d0032
-			public const int primary_text_disabled_material_light = 2131558450;
+			// aapt resource value: 0x7F050058
+			public const int mtrl_btn_bg_color_selector = 2131034200;
 			
-			// aapt resource value: 0x7f0d0033
-			public const int ripple_material_dark = 2131558451;
+			// aapt resource value: 0x7F050059
+			public const int mtrl_btn_ripple_color = 2131034201;
 			
-			// aapt resource value: 0x7f0d0034
-			public const int ripple_material_light = 2131558452;
+			// aapt resource value: 0x7F05005A
+			public const int mtrl_btn_stroke_color_selector = 2131034202;
 			
-			// aapt resource value: 0x7f0d0035
-			public const int secondary_text_default_material_dark = 2131558453;
+			// aapt resource value: 0x7F05005B
+			public const int mtrl_btn_text_btn_ripple_color = 2131034203;
 			
-			// aapt resource value: 0x7f0d0036
-			public const int secondary_text_default_material_light = 2131558454;
+			// aapt resource value: 0x7F05005C
+			public const int mtrl_btn_text_color_disabled = 2131034204;
 			
-			// aapt resource value: 0x7f0d0037
-			public const int secondary_text_disabled_material_dark = 2131558455;
+			// aapt resource value: 0x7F05005D
+			public const int mtrl_btn_text_color_selector = 2131034205;
 			
-			// aapt resource value: 0x7f0d0038
-			public const int secondary_text_disabled_material_light = 2131558456;
+			// aapt resource value: 0x7F05005E
+			public const int mtrl_btn_transparent_bg_color = 2131034206;
 			
-			// aapt resource value: 0x7f0d0039
-			public const int switch_thumb_disabled_material_dark = 2131558457;
+			// aapt resource value: 0x7F05005F
+			public const int mtrl_chip_background_color = 2131034207;
 			
-			// aapt resource value: 0x7f0d003a
-			public const int switch_thumb_disabled_material_light = 2131558458;
+			// aapt resource value: 0x7F050060
+			public const int mtrl_chip_close_icon_tint = 2131034208;
 			
-			// aapt resource value: 0x7f0d0065
-			public const int switch_thumb_material_dark = 2131558501;
+			// aapt resource value: 0x7F050061
+			public const int mtrl_chip_ripple_color = 2131034209;
 			
-			// aapt resource value: 0x7f0d0066
-			public const int switch_thumb_material_light = 2131558502;
+			// aapt resource value: 0x7F050062
+			public const int mtrl_chip_text_color = 2131034210;
 			
-			// aapt resource value: 0x7f0d003b
-			public const int switch_thumb_normal_material_dark = 2131558459;
+			// aapt resource value: 0x7F050063
+			public const int mtrl_fab_ripple_color = 2131034211;
 			
-			// aapt resource value: 0x7f0d003c
-			public const int switch_thumb_normal_material_light = 2131558460;
+			// aapt resource value: 0x7F050064
+			public const int mtrl_scrim_color = 2131034212;
 			
-			// aapt resource value: 0x7f0d003d
-			public const int tooltip_background_dark = 2131558461;
+			// aapt resource value: 0x7F050065
+			public const int mtrl_tabs_colored_ripple_color = 2131034213;
 			
-			// aapt resource value: 0x7f0d003e
-			public const int tooltip_background_light = 2131558462;
+			// aapt resource value: 0x7F050066
+			public const int mtrl_tabs_icon_color_selector = 2131034214;
+			
+			// aapt resource value: 0x7F050067
+			public const int mtrl_tabs_icon_color_selector_colored = 2131034215;
+			
+			// aapt resource value: 0x7F050068
+			public const int mtrl_tabs_legacy_text_color_selector = 2131034216;
+			
+			// aapt resource value: 0x7F050069
+			public const int mtrl_tabs_ripple_color = 2131034217;
+			
+			// aapt resource value: 0x7F05006B
+			public const int mtrl_textinput_default_box_stroke_color = 2131034219;
+			
+			// aapt resource value: 0x7F05006C
+			public const int mtrl_textinput_disabled_color = 2131034220;
+			
+			// aapt resource value: 0x7F05006D
+			public const int mtrl_textinput_filled_box_default_background_color = 2131034221;
+			
+			// aapt resource value: 0x7F05006E
+			public const int mtrl_textinput_hovered_box_stroke_color = 2131034222;
+			
+			// aapt resource value: 0x7F05006A
+			public const int mtrl_text_btn_text_color_selector = 2131034218;
+			
+			// aapt resource value: 0x7F05006F
+			public const int notification_action_color_filter = 2131034223;
+			
+			// aapt resource value: 0x7F050070
+			public const int notification_icon_bg_color = 2131034224;
+			
+			// aapt resource value: 0x7F050071
+			public const int notification_material_background_media_default_color = 2131034225;
+			
+			// aapt resource value: 0x7F050072
+			public const int primary_dark_material_dark = 2131034226;
+			
+			// aapt resource value: 0x7F050073
+			public const int primary_dark_material_light = 2131034227;
+			
+			// aapt resource value: 0x7F050074
+			public const int primary_material_dark = 2131034228;
+			
+			// aapt resource value: 0x7F050075
+			public const int primary_material_light = 2131034229;
+			
+			// aapt resource value: 0x7F050076
+			public const int primary_text_default_material_dark = 2131034230;
+			
+			// aapt resource value: 0x7F050077
+			public const int primary_text_default_material_light = 2131034231;
+			
+			// aapt resource value: 0x7F050078
+			public const int primary_text_disabled_material_dark = 2131034232;
+			
+			// aapt resource value: 0x7F050079
+			public const int primary_text_disabled_material_light = 2131034233;
+			
+			// aapt resource value: 0x7F05007A
+			public const int ripple_material_dark = 2131034234;
+			
+			// aapt resource value: 0x7F05007B
+			public const int ripple_material_light = 2131034235;
+			
+			// aapt resource value: 0x7F05007C
+			public const int secondary_text_default_material_dark = 2131034236;
+			
+			// aapt resource value: 0x7F05007D
+			public const int secondary_text_default_material_light = 2131034237;
+			
+			// aapt resource value: 0x7F05007E
+			public const int secondary_text_disabled_material_dark = 2131034238;
+			
+			// aapt resource value: 0x7F05007F
+			public const int secondary_text_disabled_material_light = 2131034239;
+			
+			// aapt resource value: 0x7F050080
+			public const int switch_thumb_disabled_material_dark = 2131034240;
+			
+			// aapt resource value: 0x7F050081
+			public const int switch_thumb_disabled_material_light = 2131034241;
+			
+			// aapt resource value: 0x7F050082
+			public const int switch_thumb_material_dark = 2131034242;
+			
+			// aapt resource value: 0x7F050083
+			public const int switch_thumb_material_light = 2131034243;
+			
+			// aapt resource value: 0x7F050084
+			public const int switch_thumb_normal_material_dark = 2131034244;
+			
+			// aapt resource value: 0x7F050085
+			public const int switch_thumb_normal_material_light = 2131034245;
+			
+			// aapt resource value: 0x7F050086
+			public const int tooltip_background_dark = 2131034246;
+			
+			// aapt resource value: 0x7F050087
+			public const int tooltip_background_light = 2131034247;
 			
 			static Color()
 			{
@@ -3588,497 +4641,686 @@ namespace SextantSample.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f08001b
-			public const int abc_action_bar_content_inset_material = 2131230747;
+			// aapt resource value: 0x7F060000
+			public const int abc_action_bar_content_inset_material = 2131099648;
 			
-			// aapt resource value: 0x7f08001c
-			public const int abc_action_bar_content_inset_with_nav = 2131230748;
+			// aapt resource value: 0x7F060001
+			public const int abc_action_bar_content_inset_with_nav = 2131099649;
 			
-			// aapt resource value: 0x7f080010
-			public const int abc_action_bar_default_height_material = 2131230736;
+			// aapt resource value: 0x7F060002
+			public const int abc_action_bar_default_height_material = 2131099650;
 			
-			// aapt resource value: 0x7f08001d
-			public const int abc_action_bar_default_padding_end_material = 2131230749;
+			// aapt resource value: 0x7F060003
+			public const int abc_action_bar_default_padding_end_material = 2131099651;
 			
-			// aapt resource value: 0x7f08001e
-			public const int abc_action_bar_default_padding_start_material = 2131230750;
+			// aapt resource value: 0x7F060004
+			public const int abc_action_bar_default_padding_start_material = 2131099652;
 			
-			// aapt resource value: 0x7f080020
-			public const int abc_action_bar_elevation_material = 2131230752;
+			// aapt resource value: 0x7F060005
+			public const int abc_action_bar_elevation_material = 2131099653;
 			
-			// aapt resource value: 0x7f080021
-			public const int abc_action_bar_icon_vertical_padding_material = 2131230753;
+			// aapt resource value: 0x7F060006
+			public const int abc_action_bar_icon_vertical_padding_material = 2131099654;
 			
-			// aapt resource value: 0x7f080022
-			public const int abc_action_bar_overflow_padding_end_material = 2131230754;
+			// aapt resource value: 0x7F060007
+			public const int abc_action_bar_overflow_padding_end_material = 2131099655;
 			
-			// aapt resource value: 0x7f080023
-			public const int abc_action_bar_overflow_padding_start_material = 2131230755;
+			// aapt resource value: 0x7F060008
+			public const int abc_action_bar_overflow_padding_start_material = 2131099656;
 			
-			// aapt resource value: 0x7f080011
-			public const int abc_action_bar_progress_bar_size = 2131230737;
+			// aapt resource value: 0x7F060009
+			public const int abc_action_bar_stacked_max_height = 2131099657;
 			
-			// aapt resource value: 0x7f080024
-			public const int abc_action_bar_stacked_max_height = 2131230756;
+			// aapt resource value: 0x7F06000A
+			public const int abc_action_bar_stacked_tab_max_width = 2131099658;
 			
-			// aapt resource value: 0x7f080025
-			public const int abc_action_bar_stacked_tab_max_width = 2131230757;
+			// aapt resource value: 0x7F06000B
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131099659;
 			
-			// aapt resource value: 0x7f080026
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131230758;
+			// aapt resource value: 0x7F06000C
+			public const int abc_action_bar_subtitle_top_margin_material = 2131099660;
 			
-			// aapt resource value: 0x7f080027
-			public const int abc_action_bar_subtitle_top_margin_material = 2131230759;
+			// aapt resource value: 0x7F06000D
+			public const int abc_action_button_min_height_material = 2131099661;
 			
-			// aapt resource value: 0x7f080028
-			public const int abc_action_button_min_height_material = 2131230760;
+			// aapt resource value: 0x7F06000E
+			public const int abc_action_button_min_width_material = 2131099662;
 			
-			// aapt resource value: 0x7f080029
-			public const int abc_action_button_min_width_material = 2131230761;
+			// aapt resource value: 0x7F06000F
+			public const int abc_action_button_min_width_overflow_material = 2131099663;
 			
-			// aapt resource value: 0x7f08002a
-			public const int abc_action_button_min_width_overflow_material = 2131230762;
+			// aapt resource value: 0x7F060010
+			public const int abc_alert_dialog_button_bar_height = 2131099664;
 			
-			// aapt resource value: 0x7f08000f
-			public const int abc_alert_dialog_button_bar_height = 2131230735;
+			// aapt resource value: 0x7F060011
+			public const int abc_alert_dialog_button_dimen = 2131099665;
 			
-			// aapt resource value: 0x7f08002b
-			public const int abc_button_inset_horizontal_material = 2131230763;
+			// aapt resource value: 0x7F060012
+			public const int abc_button_inset_horizontal_material = 2131099666;
 			
-			// aapt resource value: 0x7f08002c
-			public const int abc_button_inset_vertical_material = 2131230764;
+			// aapt resource value: 0x7F060013
+			public const int abc_button_inset_vertical_material = 2131099667;
 			
-			// aapt resource value: 0x7f08002d
-			public const int abc_button_padding_horizontal_material = 2131230765;
+			// aapt resource value: 0x7F060014
+			public const int abc_button_padding_horizontal_material = 2131099668;
 			
-			// aapt resource value: 0x7f08002e
-			public const int abc_button_padding_vertical_material = 2131230766;
+			// aapt resource value: 0x7F060015
+			public const int abc_button_padding_vertical_material = 2131099669;
 			
-			// aapt resource value: 0x7f08002f
-			public const int abc_cascading_menus_min_smallest_width = 2131230767;
+			// aapt resource value: 0x7F060016
+			public const int abc_cascading_menus_min_smallest_width = 2131099670;
 			
-			// aapt resource value: 0x7f080014
-			public const int abc_config_prefDialogWidth = 2131230740;
+			// aapt resource value: 0x7F060017
+			public const int abc_config_prefDialogWidth = 2131099671;
 			
-			// aapt resource value: 0x7f080030
-			public const int abc_control_corner_material = 2131230768;
+			// aapt resource value: 0x7F060018
+			public const int abc_control_corner_material = 2131099672;
 			
-			// aapt resource value: 0x7f080031
-			public const int abc_control_inset_material = 2131230769;
+			// aapt resource value: 0x7F060019
+			public const int abc_control_inset_material = 2131099673;
 			
-			// aapt resource value: 0x7f080032
-			public const int abc_control_padding_material = 2131230770;
+			// aapt resource value: 0x7F06001A
+			public const int abc_control_padding_material = 2131099674;
 			
-			// aapt resource value: 0x7f080015
-			public const int abc_dialog_fixed_height_major = 2131230741;
+			// aapt resource value: 0x7F06001B
+			public const int abc_dialog_corner_radius_material = 2131099675;
 			
-			// aapt resource value: 0x7f080016
-			public const int abc_dialog_fixed_height_minor = 2131230742;
+			// aapt resource value: 0x7F06001C
+			public const int abc_dialog_fixed_height_major = 2131099676;
 			
-			// aapt resource value: 0x7f080017
-			public const int abc_dialog_fixed_width_major = 2131230743;
+			// aapt resource value: 0x7F06001D
+			public const int abc_dialog_fixed_height_minor = 2131099677;
 			
-			// aapt resource value: 0x7f080018
-			public const int abc_dialog_fixed_width_minor = 2131230744;
+			// aapt resource value: 0x7F06001E
+			public const int abc_dialog_fixed_width_major = 2131099678;
 			
-			// aapt resource value: 0x7f080033
-			public const int abc_dialog_list_padding_bottom_no_buttons = 2131230771;
+			// aapt resource value: 0x7F06001F
+			public const int abc_dialog_fixed_width_minor = 2131099679;
 			
-			// aapt resource value: 0x7f080034
-			public const int abc_dialog_list_padding_top_no_title = 2131230772;
+			// aapt resource value: 0x7F060020
+			public const int abc_dialog_list_padding_bottom_no_buttons = 2131099680;
 			
-			// aapt resource value: 0x7f080019
-			public const int abc_dialog_min_width_major = 2131230745;
+			// aapt resource value: 0x7F060021
+			public const int abc_dialog_list_padding_top_no_title = 2131099681;
 			
-			// aapt resource value: 0x7f08001a
-			public const int abc_dialog_min_width_minor = 2131230746;
+			// aapt resource value: 0x7F060022
+			public const int abc_dialog_min_width_major = 2131099682;
 			
-			// aapt resource value: 0x7f080035
-			public const int abc_dialog_padding_material = 2131230773;
+			// aapt resource value: 0x7F060023
+			public const int abc_dialog_min_width_minor = 2131099683;
 			
-			// aapt resource value: 0x7f080036
-			public const int abc_dialog_padding_top_material = 2131230774;
+			// aapt resource value: 0x7F060024
+			public const int abc_dialog_padding_material = 2131099684;
 			
-			// aapt resource value: 0x7f080037
-			public const int abc_dialog_title_divider_material = 2131230775;
+			// aapt resource value: 0x7F060025
+			public const int abc_dialog_padding_top_material = 2131099685;
 			
-			// aapt resource value: 0x7f080038
-			public const int abc_disabled_alpha_material_dark = 2131230776;
+			// aapt resource value: 0x7F060026
+			public const int abc_dialog_title_divider_material = 2131099686;
 			
-			// aapt resource value: 0x7f080039
-			public const int abc_disabled_alpha_material_light = 2131230777;
+			// aapt resource value: 0x7F060027
+			public const int abc_disabled_alpha_material_dark = 2131099687;
 			
-			// aapt resource value: 0x7f08003a
-			public const int abc_dropdownitem_icon_width = 2131230778;
+			// aapt resource value: 0x7F060028
+			public const int abc_disabled_alpha_material_light = 2131099688;
 			
-			// aapt resource value: 0x7f08003b
-			public const int abc_dropdownitem_text_padding_left = 2131230779;
+			// aapt resource value: 0x7F060029
+			public const int abc_dropdownitem_icon_width = 2131099689;
 			
-			// aapt resource value: 0x7f08003c
-			public const int abc_dropdownitem_text_padding_right = 2131230780;
+			// aapt resource value: 0x7F06002A
+			public const int abc_dropdownitem_text_padding_left = 2131099690;
 			
-			// aapt resource value: 0x7f08003d
-			public const int abc_edit_text_inset_bottom_material = 2131230781;
+			// aapt resource value: 0x7F06002B
+			public const int abc_dropdownitem_text_padding_right = 2131099691;
 			
-			// aapt resource value: 0x7f08003e
-			public const int abc_edit_text_inset_horizontal_material = 2131230782;
+			// aapt resource value: 0x7F06002C
+			public const int abc_edit_text_inset_bottom_material = 2131099692;
 			
-			// aapt resource value: 0x7f08003f
-			public const int abc_edit_text_inset_top_material = 2131230783;
+			// aapt resource value: 0x7F06002D
+			public const int abc_edit_text_inset_horizontal_material = 2131099693;
 			
-			// aapt resource value: 0x7f080040
-			public const int abc_floating_window_z = 2131230784;
+			// aapt resource value: 0x7F06002E
+			public const int abc_edit_text_inset_top_material = 2131099694;
 			
-			// aapt resource value: 0x7f080041
-			public const int abc_list_item_padding_horizontal_material = 2131230785;
+			// aapt resource value: 0x7F06002F
+			public const int abc_floating_window_z = 2131099695;
 			
-			// aapt resource value: 0x7f080042
-			public const int abc_panel_menu_list_width = 2131230786;
+			// aapt resource value: 0x7F060030
+			public const int abc_list_item_padding_horizontal_material = 2131099696;
 			
-			// aapt resource value: 0x7f080043
-			public const int abc_progress_bar_height_material = 2131230787;
+			// aapt resource value: 0x7F060031
+			public const int abc_panel_menu_list_width = 2131099697;
 			
-			// aapt resource value: 0x7f080044
-			public const int abc_search_view_preferred_height = 2131230788;
+			// aapt resource value: 0x7F060032
+			public const int abc_progress_bar_height_material = 2131099698;
 			
-			// aapt resource value: 0x7f080045
-			public const int abc_search_view_preferred_width = 2131230789;
+			// aapt resource value: 0x7F060033
+			public const int abc_search_view_preferred_height = 2131099699;
 			
-			// aapt resource value: 0x7f080046
-			public const int abc_seekbar_track_background_height_material = 2131230790;
+			// aapt resource value: 0x7F060034
+			public const int abc_search_view_preferred_width = 2131099700;
 			
-			// aapt resource value: 0x7f080047
-			public const int abc_seekbar_track_progress_height_material = 2131230791;
+			// aapt resource value: 0x7F060035
+			public const int abc_seekbar_track_background_height_material = 2131099701;
 			
-			// aapt resource value: 0x7f080048
-			public const int abc_select_dialog_padding_start_material = 2131230792;
+			// aapt resource value: 0x7F060036
+			public const int abc_seekbar_track_progress_height_material = 2131099702;
 			
-			// aapt resource value: 0x7f08001f
-			public const int abc_switch_padding = 2131230751;
+			// aapt resource value: 0x7F060037
+			public const int abc_select_dialog_padding_start_material = 2131099703;
 			
-			// aapt resource value: 0x7f080049
-			public const int abc_text_size_body_1_material = 2131230793;
+			// aapt resource value: 0x7F060038
+			public const int abc_switch_padding = 2131099704;
 			
-			// aapt resource value: 0x7f08004a
-			public const int abc_text_size_body_2_material = 2131230794;
+			// aapt resource value: 0x7F060039
+			public const int abc_text_size_body_1_material = 2131099705;
 			
-			// aapt resource value: 0x7f08004b
-			public const int abc_text_size_button_material = 2131230795;
+			// aapt resource value: 0x7F06003A
+			public const int abc_text_size_body_2_material = 2131099706;
 			
-			// aapt resource value: 0x7f08004c
-			public const int abc_text_size_caption_material = 2131230796;
+			// aapt resource value: 0x7F06003B
+			public const int abc_text_size_button_material = 2131099707;
 			
-			// aapt resource value: 0x7f08004d
-			public const int abc_text_size_display_1_material = 2131230797;
+			// aapt resource value: 0x7F06003C
+			public const int abc_text_size_caption_material = 2131099708;
 			
-			// aapt resource value: 0x7f08004e
-			public const int abc_text_size_display_2_material = 2131230798;
+			// aapt resource value: 0x7F06003D
+			public const int abc_text_size_display_1_material = 2131099709;
 			
-			// aapt resource value: 0x7f08004f
-			public const int abc_text_size_display_3_material = 2131230799;
+			// aapt resource value: 0x7F06003E
+			public const int abc_text_size_display_2_material = 2131099710;
 			
-			// aapt resource value: 0x7f080050
-			public const int abc_text_size_display_4_material = 2131230800;
+			// aapt resource value: 0x7F06003F
+			public const int abc_text_size_display_3_material = 2131099711;
 			
-			// aapt resource value: 0x7f080051
-			public const int abc_text_size_headline_material = 2131230801;
+			// aapt resource value: 0x7F060040
+			public const int abc_text_size_display_4_material = 2131099712;
 			
-			// aapt resource value: 0x7f080052
-			public const int abc_text_size_large_material = 2131230802;
+			// aapt resource value: 0x7F060041
+			public const int abc_text_size_headline_material = 2131099713;
 			
-			// aapt resource value: 0x7f080053
-			public const int abc_text_size_medium_material = 2131230803;
+			// aapt resource value: 0x7F060042
+			public const int abc_text_size_large_material = 2131099714;
 			
-			// aapt resource value: 0x7f080054
-			public const int abc_text_size_menu_header_material = 2131230804;
+			// aapt resource value: 0x7F060043
+			public const int abc_text_size_medium_material = 2131099715;
 			
-			// aapt resource value: 0x7f080055
-			public const int abc_text_size_menu_material = 2131230805;
+			// aapt resource value: 0x7F060044
+			public const int abc_text_size_menu_header_material = 2131099716;
 			
-			// aapt resource value: 0x7f080056
-			public const int abc_text_size_small_material = 2131230806;
+			// aapt resource value: 0x7F060045
+			public const int abc_text_size_menu_material = 2131099717;
 			
-			// aapt resource value: 0x7f080057
-			public const int abc_text_size_subhead_material = 2131230807;
+			// aapt resource value: 0x7F060046
+			public const int abc_text_size_small_material = 2131099718;
 			
-			// aapt resource value: 0x7f080012
-			public const int abc_text_size_subtitle_material_toolbar = 2131230738;
+			// aapt resource value: 0x7F060047
+			public const int abc_text_size_subhead_material = 2131099719;
 			
-			// aapt resource value: 0x7f080058
-			public const int abc_text_size_title_material = 2131230808;
+			// aapt resource value: 0x7F060048
+			public const int abc_text_size_subtitle_material_toolbar = 2131099720;
 			
-			// aapt resource value: 0x7f080013
-			public const int abc_text_size_title_material_toolbar = 2131230739;
+			// aapt resource value: 0x7F060049
+			public const int abc_text_size_title_material = 2131099721;
 			
-			// aapt resource value: 0x7f08000c
-			public const int cardview_compat_inset_shadow = 2131230732;
+			// aapt resource value: 0x7F06004A
+			public const int abc_text_size_title_material_toolbar = 2131099722;
 			
-			// aapt resource value: 0x7f08000d
-			public const int cardview_default_elevation = 2131230733;
+			// aapt resource value: 0x7F06004B
+			public const int browser_actions_context_menu_max_width = 2131099723;
 			
-			// aapt resource value: 0x7f08000e
-			public const int cardview_default_radius = 2131230734;
+			// aapt resource value: 0x7F06004C
+			public const int browser_actions_context_menu_min_padding = 2131099724;
 			
-			// aapt resource value: 0x7f080094
-			public const int compat_button_inset_horizontal_material = 2131230868;
+			// aapt resource value: 0x7F06004D
+			public const int cardview_compat_inset_shadow = 2131099725;
 			
-			// aapt resource value: 0x7f080095
-			public const int compat_button_inset_vertical_material = 2131230869;
+			// aapt resource value: 0x7F06004E
+			public const int cardview_default_elevation = 2131099726;
 			
-			// aapt resource value: 0x7f080096
-			public const int compat_button_padding_horizontal_material = 2131230870;
+			// aapt resource value: 0x7F06004F
+			public const int cardview_default_radius = 2131099727;
 			
-			// aapt resource value: 0x7f080097
-			public const int compat_button_padding_vertical_material = 2131230871;
+			// aapt resource value: 0x7F060050
+			public const int compat_button_inset_horizontal_material = 2131099728;
 			
-			// aapt resource value: 0x7f080098
-			public const int compat_control_corner_material = 2131230872;
+			// aapt resource value: 0x7F060051
+			public const int compat_button_inset_vertical_material = 2131099729;
 			
-			// aapt resource value: 0x7f080072
-			public const int design_appbar_elevation = 2131230834;
+			// aapt resource value: 0x7F060052
+			public const int compat_button_padding_horizontal_material = 2131099730;
 			
-			// aapt resource value: 0x7f080073
-			public const int design_bottom_navigation_active_item_max_width = 2131230835;
+			// aapt resource value: 0x7F060053
+			public const int compat_button_padding_vertical_material = 2131099731;
 			
-			// aapt resource value: 0x7f080074
-			public const int design_bottom_navigation_active_text_size = 2131230836;
+			// aapt resource value: 0x7F060054
+			public const int compat_control_corner_material = 2131099732;
 			
-			// aapt resource value: 0x7f080075
-			public const int design_bottom_navigation_elevation = 2131230837;
+			// aapt resource value: 0x7F060055
+			public const int compat_notification_large_icon_max_height = 2131099733;
 			
-			// aapt resource value: 0x7f080076
-			public const int design_bottom_navigation_height = 2131230838;
+			// aapt resource value: 0x7F060056
+			public const int compat_notification_large_icon_max_width = 2131099734;
 			
-			// aapt resource value: 0x7f080077
-			public const int design_bottom_navigation_item_max_width = 2131230839;
+			// aapt resource value: 0x7F060057
+			public const int design_appbar_elevation = 2131099735;
 			
-			// aapt resource value: 0x7f080078
-			public const int design_bottom_navigation_item_min_width = 2131230840;
+			// aapt resource value: 0x7F060058
+			public const int design_bottom_navigation_active_item_max_width = 2131099736;
 			
-			// aapt resource value: 0x7f080079
-			public const int design_bottom_navigation_margin = 2131230841;
+			// aapt resource value: 0x7F060059
+			public const int design_bottom_navigation_active_item_min_width = 2131099737;
 			
-			// aapt resource value: 0x7f08007a
-			public const int design_bottom_navigation_shadow_height = 2131230842;
+			// aapt resource value: 0x7F06005A
+			public const int design_bottom_navigation_active_text_size = 2131099738;
 			
-			// aapt resource value: 0x7f08007b
-			public const int design_bottom_navigation_text_size = 2131230843;
+			// aapt resource value: 0x7F06005B
+			public const int design_bottom_navigation_elevation = 2131099739;
 			
-			// aapt resource value: 0x7f08007c
-			public const int design_bottom_sheet_modal_elevation = 2131230844;
+			// aapt resource value: 0x7F06005C
+			public const int design_bottom_navigation_height = 2131099740;
 			
-			// aapt resource value: 0x7f08007d
-			public const int design_bottom_sheet_peek_height_min = 2131230845;
+			// aapt resource value: 0x7F06005D
+			public const int design_bottom_navigation_icon_size = 2131099741;
 			
-			// aapt resource value: 0x7f08007e
-			public const int design_fab_border_width = 2131230846;
+			// aapt resource value: 0x7F06005E
+			public const int design_bottom_navigation_item_max_width = 2131099742;
 			
-			// aapt resource value: 0x7f08007f
-			public const int design_fab_elevation = 2131230847;
+			// aapt resource value: 0x7F06005F
+			public const int design_bottom_navigation_item_min_width = 2131099743;
 			
-			// aapt resource value: 0x7f080080
-			public const int design_fab_image_size = 2131230848;
+			// aapt resource value: 0x7F060060
+			public const int design_bottom_navigation_margin = 2131099744;
 			
-			// aapt resource value: 0x7f080081
-			public const int design_fab_size_mini = 2131230849;
+			// aapt resource value: 0x7F060061
+			public const int design_bottom_navigation_shadow_height = 2131099745;
 			
-			// aapt resource value: 0x7f080082
-			public const int design_fab_size_normal = 2131230850;
+			// aapt resource value: 0x7F060062
+			public const int design_bottom_navigation_text_size = 2131099746;
 			
-			// aapt resource value: 0x7f080083
-			public const int design_fab_translation_z_pressed = 2131230851;
+			// aapt resource value: 0x7F060063
+			public const int design_bottom_sheet_modal_elevation = 2131099747;
 			
-			// aapt resource value: 0x7f080084
-			public const int design_navigation_elevation = 2131230852;
+			// aapt resource value: 0x7F060064
+			public const int design_bottom_sheet_peek_height_min = 2131099748;
 			
-			// aapt resource value: 0x7f080085
-			public const int design_navigation_icon_padding = 2131230853;
+			// aapt resource value: 0x7F060065
+			public const int design_fab_border_width = 2131099749;
 			
-			// aapt resource value: 0x7f080086
-			public const int design_navigation_icon_size = 2131230854;
+			// aapt resource value: 0x7F060066
+			public const int design_fab_elevation = 2131099750;
 			
-			// aapt resource value: 0x7f08006a
-			public const int design_navigation_max_width = 2131230826;
+			// aapt resource value: 0x7F060067
+			public const int design_fab_image_size = 2131099751;
 			
-			// aapt resource value: 0x7f080087
-			public const int design_navigation_padding_bottom = 2131230855;
+			// aapt resource value: 0x7F060068
+			public const int design_fab_size_mini = 2131099752;
 			
-			// aapt resource value: 0x7f080088
-			public const int design_navigation_separator_vertical_padding = 2131230856;
+			// aapt resource value: 0x7F060069
+			public const int design_fab_size_normal = 2131099753;
 			
-			// aapt resource value: 0x7f08006b
-			public const int design_snackbar_action_inline_max_width = 2131230827;
+			// aapt resource value: 0x7F06006A
+			public const int design_fab_translation_z_hovered_focused = 2131099754;
 			
-			// aapt resource value: 0x7f08006c
-			public const int design_snackbar_background_corner_radius = 2131230828;
+			// aapt resource value: 0x7F06006B
+			public const int design_fab_translation_z_pressed = 2131099755;
 			
-			// aapt resource value: 0x7f080089
-			public const int design_snackbar_elevation = 2131230857;
+			// aapt resource value: 0x7F06006C
+			public const int design_navigation_elevation = 2131099756;
 			
-			// aapt resource value: 0x7f08006d
-			public const int design_snackbar_extra_spacing_horizontal = 2131230829;
+			// aapt resource value: 0x7F06006D
+			public const int design_navigation_icon_padding = 2131099757;
 			
-			// aapt resource value: 0x7f08006e
-			public const int design_snackbar_max_width = 2131230830;
+			// aapt resource value: 0x7F06006E
+			public const int design_navigation_icon_size = 2131099758;
 			
-			// aapt resource value: 0x7f08006f
-			public const int design_snackbar_min_width = 2131230831;
+			// aapt resource value: 0x7F06006F
+			public const int design_navigation_item_horizontal_padding = 2131099759;
 			
-			// aapt resource value: 0x7f08008a
-			public const int design_snackbar_padding_horizontal = 2131230858;
+			// aapt resource value: 0x7F060070
+			public const int design_navigation_item_icon_padding = 2131099760;
 			
-			// aapt resource value: 0x7f08008b
-			public const int design_snackbar_padding_vertical = 2131230859;
+			// aapt resource value: 0x7F060071
+			public const int design_navigation_max_width = 2131099761;
 			
-			// aapt resource value: 0x7f080070
-			public const int design_snackbar_padding_vertical_2lines = 2131230832;
+			// aapt resource value: 0x7F060072
+			public const int design_navigation_padding_bottom = 2131099762;
 			
-			// aapt resource value: 0x7f08008c
-			public const int design_snackbar_text_size = 2131230860;
+			// aapt resource value: 0x7F060073
+			public const int design_navigation_separator_vertical_padding = 2131099763;
 			
-			// aapt resource value: 0x7f08008d
-			public const int design_tab_max_width = 2131230861;
+			// aapt resource value: 0x7F060074
+			public const int design_snackbar_action_inline_max_width = 2131099764;
 			
-			// aapt resource value: 0x7f080071
-			public const int design_tab_scrollable_min_width = 2131230833;
+			// aapt resource value: 0x7F060075
+			public const int design_snackbar_background_corner_radius = 2131099765;
 			
-			// aapt resource value: 0x7f08008e
-			public const int design_tab_text_size = 2131230862;
+			// aapt resource value: 0x7F060076
+			public const int design_snackbar_elevation = 2131099766;
 			
-			// aapt resource value: 0x7f08008f
-			public const int design_tab_text_size_2line = 2131230863;
+			// aapt resource value: 0x7F060077
+			public const int design_snackbar_extra_spacing_horizontal = 2131099767;
 			
-			// aapt resource value: 0x7f080059
-			public const int disabled_alpha_material_dark = 2131230809;
+			// aapt resource value: 0x7F060078
+			public const int design_snackbar_max_width = 2131099768;
 			
-			// aapt resource value: 0x7f08005a
-			public const int disabled_alpha_material_light = 2131230810;
+			// aapt resource value: 0x7F060079
+			public const int design_snackbar_min_width = 2131099769;
 			
-			// aapt resource value: 0x7f080000
-			public const int fastscroll_default_thickness = 2131230720;
+			// aapt resource value: 0x7F06007A
+			public const int design_snackbar_padding_horizontal = 2131099770;
 			
-			// aapt resource value: 0x7f080001
-			public const int fastscroll_margin = 2131230721;
+			// aapt resource value: 0x7F06007B
+			public const int design_snackbar_padding_vertical = 2131099771;
 			
-			// aapt resource value: 0x7f080002
-			public const int fastscroll_minimum_range = 2131230722;
+			// aapt resource value: 0x7F06007C
+			public const int design_snackbar_padding_vertical_2lines = 2131099772;
 			
-			// aapt resource value: 0x7f08005b
-			public const int highlight_alpha_material_colored = 2131230811;
+			// aapt resource value: 0x7F06007D
+			public const int design_snackbar_text_size = 2131099773;
 			
-			// aapt resource value: 0x7f08005c
-			public const int highlight_alpha_material_dark = 2131230812;
+			// aapt resource value: 0x7F06007E
+			public const int design_tab_max_width = 2131099774;
 			
-			// aapt resource value: 0x7f08005d
-			public const int highlight_alpha_material_light = 2131230813;
+			// aapt resource value: 0x7F06007F
+			public const int design_tab_scrollable_min_width = 2131099775;
 			
-			// aapt resource value: 0x7f08005e
-			public const int hint_alpha_material_dark = 2131230814;
+			// aapt resource value: 0x7F060080
+			public const int design_tab_text_size = 2131099776;
 			
-			// aapt resource value: 0x7f08005f
-			public const int hint_alpha_material_light = 2131230815;
+			// aapt resource value: 0x7F060081
+			public const int design_tab_text_size_2line = 2131099777;
 			
-			// aapt resource value: 0x7f080060
-			public const int hint_pressed_alpha_material_dark = 2131230816;
+			// aapt resource value: 0x7F060082
+			public const int design_textinput_caption_translate_y = 2131099778;
 			
-			// aapt resource value: 0x7f080061
-			public const int hint_pressed_alpha_material_light = 2131230817;
+			// aapt resource value: 0x7F060083
+			public const int disabled_alpha_material_dark = 2131099779;
 			
-			// aapt resource value: 0x7f080003
-			public const int item_touch_helper_max_drag_scroll_per_frame = 2131230723;
+			// aapt resource value: 0x7F060084
+			public const int disabled_alpha_material_light = 2131099780;
 			
-			// aapt resource value: 0x7f080004
-			public const int item_touch_helper_swipe_escape_max_velocity = 2131230724;
+			// aapt resource value: 0x7F060085
+			public const int fastscroll_default_thickness = 2131099781;
 			
-			// aapt resource value: 0x7f080005
-			public const int item_touch_helper_swipe_escape_velocity = 2131230725;
+			// aapt resource value: 0x7F060086
+			public const int fastscroll_margin = 2131099782;
 			
-			// aapt resource value: 0x7f080006
-			public const int mr_controller_volume_group_list_item_height = 2131230726;
+			// aapt resource value: 0x7F060087
+			public const int fastscroll_minimum_range = 2131099783;
 			
-			// aapt resource value: 0x7f080007
-			public const int mr_controller_volume_group_list_item_icon_size = 2131230727;
+			// aapt resource value: 0x7F060088
+			public const int highlight_alpha_material_colored = 2131099784;
 			
-			// aapt resource value: 0x7f080008
-			public const int mr_controller_volume_group_list_max_height = 2131230728;
+			// aapt resource value: 0x7F060089
+			public const int highlight_alpha_material_dark = 2131099785;
 			
-			// aapt resource value: 0x7f08000b
-			public const int mr_controller_volume_group_list_padding_top = 2131230731;
+			// aapt resource value: 0x7F06008A
+			public const int highlight_alpha_material_light = 2131099786;
 			
-			// aapt resource value: 0x7f080009
-			public const int mr_dialog_fixed_width_major = 2131230729;
+			// aapt resource value: 0x7F06008B
+			public const int hint_alpha_material_dark = 2131099787;
 			
-			// aapt resource value: 0x7f08000a
-			public const int mr_dialog_fixed_width_minor = 2131230730;
+			// aapt resource value: 0x7F06008C
+			public const int hint_alpha_material_light = 2131099788;
 			
-			// aapt resource value: 0x7f080099
-			public const int notification_action_icon_size = 2131230873;
+			// aapt resource value: 0x7F06008D
+			public const int hint_pressed_alpha_material_dark = 2131099789;
 			
-			// aapt resource value: 0x7f08009a
-			public const int notification_action_text_size = 2131230874;
+			// aapt resource value: 0x7F06008E
+			public const int hint_pressed_alpha_material_light = 2131099790;
 			
-			// aapt resource value: 0x7f08009b
-			public const int notification_big_circle_margin = 2131230875;
+			// aapt resource value: 0x7F06008F
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131099791;
 			
-			// aapt resource value: 0x7f080091
-			public const int notification_content_margin_start = 2131230865;
+			// aapt resource value: 0x7F060090
+			public const int item_touch_helper_swipe_escape_max_velocity = 2131099792;
 			
-			// aapt resource value: 0x7f08009c
-			public const int notification_large_icon_height = 2131230876;
+			// aapt resource value: 0x7F060091
+			public const int item_touch_helper_swipe_escape_velocity = 2131099793;
 			
-			// aapt resource value: 0x7f08009d
-			public const int notification_large_icon_width = 2131230877;
+			// aapt resource value: 0x7F060092
+			public const int mr_controller_volume_group_list_item_height = 2131099794;
 			
-			// aapt resource value: 0x7f080092
-			public const int notification_main_column_padding_top = 2131230866;
+			// aapt resource value: 0x7F060093
+			public const int mr_controller_volume_group_list_item_icon_size = 2131099795;
 			
-			// aapt resource value: 0x7f080093
-			public const int notification_media_narrow_margin = 2131230867;
+			// aapt resource value: 0x7F060094
+			public const int mr_controller_volume_group_list_max_height = 2131099796;
 			
-			// aapt resource value: 0x7f08009e
-			public const int notification_right_icon_size = 2131230878;
+			// aapt resource value: 0x7F060095
+			public const int mr_controller_volume_group_list_padding_top = 2131099797;
 			
-			// aapt resource value: 0x7f080090
-			public const int notification_right_side_padding_top = 2131230864;
+			// aapt resource value: 0x7F060096
+			public const int mr_dialog_fixed_width_major = 2131099798;
 			
-			// aapt resource value: 0x7f08009f
-			public const int notification_small_icon_background_padding = 2131230879;
+			// aapt resource value: 0x7F060097
+			public const int mr_dialog_fixed_width_minor = 2131099799;
 			
-			// aapt resource value: 0x7f0800a0
-			public const int notification_small_icon_size_as_large = 2131230880;
+			// aapt resource value: 0x7F060098
+			public const int mtrl_bottomappbar_fabOffsetEndMode = 2131099800;
 			
-			// aapt resource value: 0x7f0800a1
-			public const int notification_subtext_size = 2131230881;
+			// aapt resource value: 0x7F060099
+			public const int mtrl_bottomappbar_fab_cradle_margin = 2131099801;
 			
-			// aapt resource value: 0x7f0800a2
-			public const int notification_top_pad = 2131230882;
+			// aapt resource value: 0x7F06009A
+			public const int mtrl_bottomappbar_fab_cradle_rounded_corner_radius = 2131099802;
 			
-			// aapt resource value: 0x7f0800a3
-			public const int notification_top_pad_large_text = 2131230883;
+			// aapt resource value: 0x7F06009B
+			public const int mtrl_bottomappbar_fab_cradle_vertical_offset = 2131099803;
 			
-			// aapt resource value: 0x7f080062
-			public const int tooltip_corner_radius = 2131230818;
+			// aapt resource value: 0x7F06009C
+			public const int mtrl_bottomappbar_height = 2131099804;
 			
-			// aapt resource value: 0x7f080063
-			public const int tooltip_horizontal_padding = 2131230819;
+			// aapt resource value: 0x7F06009D
+			public const int mtrl_btn_corner_radius = 2131099805;
 			
-			// aapt resource value: 0x7f080064
-			public const int tooltip_margin = 2131230820;
+			// aapt resource value: 0x7F06009E
+			public const int mtrl_btn_dialog_btn_min_width = 2131099806;
 			
-			// aapt resource value: 0x7f080065
-			public const int tooltip_precise_anchor_extra_offset = 2131230821;
+			// aapt resource value: 0x7F06009F
+			public const int mtrl_btn_disabled_elevation = 2131099807;
 			
-			// aapt resource value: 0x7f080066
-			public const int tooltip_precise_anchor_threshold = 2131230822;
+			// aapt resource value: 0x7F0600A0
+			public const int mtrl_btn_disabled_z = 2131099808;
 			
-			// aapt resource value: 0x7f080067
-			public const int tooltip_vertical_padding = 2131230823;
+			// aapt resource value: 0x7F0600A1
+			public const int mtrl_btn_elevation = 2131099809;
 			
-			// aapt resource value: 0x7f080068
-			public const int tooltip_y_offset_non_touch = 2131230824;
+			// aapt resource value: 0x7F0600A2
+			public const int mtrl_btn_focused_z = 2131099810;
 			
-			// aapt resource value: 0x7f080069
-			public const int tooltip_y_offset_touch = 2131230825;
+			// aapt resource value: 0x7F0600A3
+			public const int mtrl_btn_hovered_z = 2131099811;
+			
+			// aapt resource value: 0x7F0600A4
+			public const int mtrl_btn_icon_btn_padding_left = 2131099812;
+			
+			// aapt resource value: 0x7F0600A5
+			public const int mtrl_btn_icon_padding = 2131099813;
+			
+			// aapt resource value: 0x7F0600A6
+			public const int mtrl_btn_inset = 2131099814;
+			
+			// aapt resource value: 0x7F0600A7
+			public const int mtrl_btn_letter_spacing = 2131099815;
+			
+			// aapt resource value: 0x7F0600A8
+			public const int mtrl_btn_padding_bottom = 2131099816;
+			
+			// aapt resource value: 0x7F0600A9
+			public const int mtrl_btn_padding_left = 2131099817;
+			
+			// aapt resource value: 0x7F0600AA
+			public const int mtrl_btn_padding_right = 2131099818;
+			
+			// aapt resource value: 0x7F0600AB
+			public const int mtrl_btn_padding_top = 2131099819;
+			
+			// aapt resource value: 0x7F0600AC
+			public const int mtrl_btn_pressed_z = 2131099820;
+			
+			// aapt resource value: 0x7F0600AD
+			public const int mtrl_btn_stroke_size = 2131099821;
+			
+			// aapt resource value: 0x7F0600AE
+			public const int mtrl_btn_text_btn_icon_padding = 2131099822;
+			
+			// aapt resource value: 0x7F0600AF
+			public const int mtrl_btn_text_btn_padding_left = 2131099823;
+			
+			// aapt resource value: 0x7F0600B0
+			public const int mtrl_btn_text_btn_padding_right = 2131099824;
+			
+			// aapt resource value: 0x7F0600B1
+			public const int mtrl_btn_text_size = 2131099825;
+			
+			// aapt resource value: 0x7F0600B2
+			public const int mtrl_btn_z = 2131099826;
+			
+			// aapt resource value: 0x7F0600B3
+			public const int mtrl_card_elevation = 2131099827;
+			
+			// aapt resource value: 0x7F0600B4
+			public const int mtrl_card_spacing = 2131099828;
+			
+			// aapt resource value: 0x7F0600B5
+			public const int mtrl_chip_pressed_translation_z = 2131099829;
+			
+			// aapt resource value: 0x7F0600B6
+			public const int mtrl_chip_text_size = 2131099830;
+			
+			// aapt resource value: 0x7F0600B7
+			public const int mtrl_fab_elevation = 2131099831;
+			
+			// aapt resource value: 0x7F0600B8
+			public const int mtrl_fab_translation_z_hovered_focused = 2131099832;
+			
+			// aapt resource value: 0x7F0600B9
+			public const int mtrl_fab_translation_z_pressed = 2131099833;
+			
+			// aapt resource value: 0x7F0600BA
+			public const int mtrl_navigation_elevation = 2131099834;
+			
+			// aapt resource value: 0x7F0600BB
+			public const int mtrl_navigation_item_horizontal_padding = 2131099835;
+			
+			// aapt resource value: 0x7F0600BC
+			public const int mtrl_navigation_item_icon_padding = 2131099836;
+			
+			// aapt resource value: 0x7F0600BD
+			public const int mtrl_snackbar_background_corner_radius = 2131099837;
+			
+			// aapt resource value: 0x7F0600BE
+			public const int mtrl_snackbar_margin = 2131099838;
+			
+			// aapt resource value: 0x7F0600BF
+			public const int mtrl_textinput_box_bottom_offset = 2131099839;
+			
+			// aapt resource value: 0x7F0600C0
+			public const int mtrl_textinput_box_corner_radius_medium = 2131099840;
+			
+			// aapt resource value: 0x7F0600C1
+			public const int mtrl_textinput_box_corner_radius_small = 2131099841;
+			
+			// aapt resource value: 0x7F0600C2
+			public const int mtrl_textinput_box_label_cutout_padding = 2131099842;
+			
+			// aapt resource value: 0x7F0600C3
+			public const int mtrl_textinput_box_padding_end = 2131099843;
+			
+			// aapt resource value: 0x7F0600C4
+			public const int mtrl_textinput_box_stroke_width_default = 2131099844;
+			
+			// aapt resource value: 0x7F0600C5
+			public const int mtrl_textinput_box_stroke_width_focused = 2131099845;
+			
+			// aapt resource value: 0x7F0600C6
+			public const int mtrl_textinput_outline_box_expanded_padding = 2131099846;
+			
+			// aapt resource value: 0x7F0600C7
+			public const int mtrl_toolbar_default_height = 2131099847;
+			
+			// aapt resource value: 0x7F0600C8
+			public const int notification_action_icon_size = 2131099848;
+			
+			// aapt resource value: 0x7F0600C9
+			public const int notification_action_text_size = 2131099849;
+			
+			// aapt resource value: 0x7F0600CA
+			public const int notification_big_circle_margin = 2131099850;
+			
+			// aapt resource value: 0x7F0600CB
+			public const int notification_content_margin_start = 2131099851;
+			
+			// aapt resource value: 0x7F0600CC
+			public const int notification_large_icon_height = 2131099852;
+			
+			// aapt resource value: 0x7F0600CD
+			public const int notification_large_icon_width = 2131099853;
+			
+			// aapt resource value: 0x7F0600CE
+			public const int notification_main_column_padding_top = 2131099854;
+			
+			// aapt resource value: 0x7F0600CF
+			public const int notification_media_narrow_margin = 2131099855;
+			
+			// aapt resource value: 0x7F0600D0
+			public const int notification_right_icon_size = 2131099856;
+			
+			// aapt resource value: 0x7F0600D1
+			public const int notification_right_side_padding_top = 2131099857;
+			
+			// aapt resource value: 0x7F0600D2
+			public const int notification_small_icon_background_padding = 2131099858;
+			
+			// aapt resource value: 0x7F0600D3
+			public const int notification_small_icon_size_as_large = 2131099859;
+			
+			// aapt resource value: 0x7F0600D4
+			public const int notification_subtext_size = 2131099860;
+			
+			// aapt resource value: 0x7F0600D5
+			public const int notification_top_pad = 2131099861;
+			
+			// aapt resource value: 0x7F0600D6
+			public const int notification_top_pad_large_text = 2131099862;
+			
+			// aapt resource value: 0x7F0600D7
+			public const int subtitle_corner_radius = 2131099863;
+			
+			// aapt resource value: 0x7F0600D8
+			public const int subtitle_outline_width = 2131099864;
+			
+			// aapt resource value: 0x7F0600D9
+			public const int subtitle_shadow_offset = 2131099865;
+			
+			// aapt resource value: 0x7F0600DA
+			public const int subtitle_shadow_radius = 2131099866;
+			
+			// aapt resource value: 0x7F0600DB
+			public const int tooltip_corner_radius = 2131099867;
+			
+			// aapt resource value: 0x7F0600DC
+			public const int tooltip_horizontal_padding = 2131099868;
+			
+			// aapt resource value: 0x7F0600DD
+			public const int tooltip_margin = 2131099869;
+			
+			// aapt resource value: 0x7F0600DE
+			public const int tooltip_precise_anchor_extra_offset = 2131099870;
+			
+			// aapt resource value: 0x7F0600DF
+			public const int tooltip_precise_anchor_threshold = 2131099871;
+			
+			// aapt resource value: 0x7F0600E0
+			public const int tooltip_vertical_padding = 2131099872;
+			
+			// aapt resource value: 0x7F0600E1
+			public const int tooltip_y_offset_non_touch = 2131099873;
+			
+			// aapt resource value: 0x7F0600E2
+			public const int tooltip_y_offset_touch = 2131099874;
 			
 			static Dimension()
 			{
@@ -4093,932 +5335,932 @@ namespace SextantSample.Droid
 		public partial class Drawable
 		{
 			
-			// aapt resource value: 0x7f020000
-			public const int abc_ab_share_pack_mtrl_alpha = 2130837504;
+			// aapt resource value: 0x7F070006
+			public const int abc_ab_share_pack_mtrl_alpha = 2131165190;
 			
-			// aapt resource value: 0x7f020001
-			public const int abc_action_bar_item_background_material = 2130837505;
+			// aapt resource value: 0x7F070007
+			public const int abc_action_bar_item_background_material = 2131165191;
 			
-			// aapt resource value: 0x7f020002
-			public const int abc_btn_borderless_material = 2130837506;
+			// aapt resource value: 0x7F070008
+			public const int abc_btn_borderless_material = 2131165192;
 			
-			// aapt resource value: 0x7f020003
-			public const int abc_btn_check_material = 2130837507;
+			// aapt resource value: 0x7F070009
+			public const int abc_btn_check_material = 2131165193;
 			
-			// aapt resource value: 0x7f020004
-			public const int abc_btn_check_to_on_mtrl_000 = 2130837508;
+			// aapt resource value: 0x7F07000A
+			public const int abc_btn_check_to_on_mtrl_000 = 2131165194;
 			
-			// aapt resource value: 0x7f020005
-			public const int abc_btn_check_to_on_mtrl_015 = 2130837509;
+			// aapt resource value: 0x7F07000B
+			public const int abc_btn_check_to_on_mtrl_015 = 2131165195;
 			
-			// aapt resource value: 0x7f020006
-			public const int abc_btn_colored_material = 2130837510;
+			// aapt resource value: 0x7F07000C
+			public const int abc_btn_colored_material = 2131165196;
 			
-			// aapt resource value: 0x7f020007
-			public const int abc_btn_default_mtrl_shape = 2130837511;
+			// aapt resource value: 0x7F07000D
+			public const int abc_btn_default_mtrl_shape = 2131165197;
 			
-			// aapt resource value: 0x7f020008
-			public const int abc_btn_radio_material = 2130837512;
+			// aapt resource value: 0x7F07000E
+			public const int abc_btn_radio_material = 2131165198;
 			
-			// aapt resource value: 0x7f020009
-			public const int abc_btn_radio_to_on_mtrl_000 = 2130837513;
+			// aapt resource value: 0x7F07000F
+			public const int abc_btn_radio_to_on_mtrl_000 = 2131165199;
 			
-			// aapt resource value: 0x7f02000a
-			public const int abc_btn_radio_to_on_mtrl_015 = 2130837514;
+			// aapt resource value: 0x7F070010
+			public const int abc_btn_radio_to_on_mtrl_015 = 2131165200;
 			
-			// aapt resource value: 0x7f02000b
-			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837515;
+			// aapt resource value: 0x7F070011
+			public const int abc_btn_switch_to_on_mtrl_00001 = 2131165201;
 			
-			// aapt resource value: 0x7f02000c
-			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837516;
+			// aapt resource value: 0x7F070012
+			public const int abc_btn_switch_to_on_mtrl_00012 = 2131165202;
 			
-			// aapt resource value: 0x7f02000d
-			public const int abc_cab_background_internal_bg = 2130837517;
+			// aapt resource value: 0x7F070013
+			public const int abc_cab_background_internal_bg = 2131165203;
 			
-			// aapt resource value: 0x7f02000e
-			public const int abc_cab_background_top_material = 2130837518;
+			// aapt resource value: 0x7F070014
+			public const int abc_cab_background_top_material = 2131165204;
 			
-			// aapt resource value: 0x7f02000f
-			public const int abc_cab_background_top_mtrl_alpha = 2130837519;
+			// aapt resource value: 0x7F070015
+			public const int abc_cab_background_top_mtrl_alpha = 2131165205;
 			
-			// aapt resource value: 0x7f020010
-			public const int abc_control_background_material = 2130837520;
+			// aapt resource value: 0x7F070016
+			public const int abc_control_background_material = 2131165206;
 			
-			// aapt resource value: 0x7f020011
-			public const int abc_dialog_material_background = 2130837521;
+			// aapt resource value: 0x7F070017
+			public const int abc_dialog_material_background = 2131165207;
 			
-			// aapt resource value: 0x7f020012
-			public const int abc_edit_text_material = 2130837522;
+			// aapt resource value: 0x7F070018
+			public const int abc_edit_text_material = 2131165208;
 			
-			// aapt resource value: 0x7f020013
-			public const int abc_ic_ab_back_material = 2130837523;
+			// aapt resource value: 0x7F070019
+			public const int abc_ic_ab_back_material = 2131165209;
 			
-			// aapt resource value: 0x7f020014
-			public const int abc_ic_arrow_drop_right_black_24dp = 2130837524;
+			// aapt resource value: 0x7F07001A
+			public const int abc_ic_arrow_drop_right_black_24dp = 2131165210;
 			
-			// aapt resource value: 0x7f020015
-			public const int abc_ic_clear_material = 2130837525;
+			// aapt resource value: 0x7F07001B
+			public const int abc_ic_clear_material = 2131165211;
 			
-			// aapt resource value: 0x7f020016
-			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837526;
+			// aapt resource value: 0x7F07001C
+			public const int abc_ic_commit_search_api_mtrl_alpha = 2131165212;
 			
-			// aapt resource value: 0x7f020017
-			public const int abc_ic_go_search_api_material = 2130837527;
+			// aapt resource value: 0x7F07001D
+			public const int abc_ic_go_search_api_material = 2131165213;
 			
-			// aapt resource value: 0x7f020018
-			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837528;
+			// aapt resource value: 0x7F07001E
+			public const int abc_ic_menu_copy_mtrl_am_alpha = 2131165214;
 			
-			// aapt resource value: 0x7f020019
-			public const int abc_ic_menu_cut_mtrl_alpha = 2130837529;
+			// aapt resource value: 0x7F07001F
+			public const int abc_ic_menu_cut_mtrl_alpha = 2131165215;
 			
-			// aapt resource value: 0x7f02001a
-			public const int abc_ic_menu_overflow_material = 2130837530;
+			// aapt resource value: 0x7F070020
+			public const int abc_ic_menu_overflow_material = 2131165216;
 			
-			// aapt resource value: 0x7f02001b
-			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837531;
+			// aapt resource value: 0x7F070021
+			public const int abc_ic_menu_paste_mtrl_am_alpha = 2131165217;
 			
-			// aapt resource value: 0x7f02001c
-			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837532;
+			// aapt resource value: 0x7F070022
+			public const int abc_ic_menu_selectall_mtrl_alpha = 2131165218;
 			
-			// aapt resource value: 0x7f02001d
-			public const int abc_ic_menu_share_mtrl_alpha = 2130837533;
+			// aapt resource value: 0x7F070023
+			public const int abc_ic_menu_share_mtrl_alpha = 2131165219;
 			
-			// aapt resource value: 0x7f02001e
-			public const int abc_ic_search_api_material = 2130837534;
+			// aapt resource value: 0x7F070024
+			public const int abc_ic_search_api_material = 2131165220;
 			
-			// aapt resource value: 0x7f02001f
-			public const int abc_ic_star_black_16dp = 2130837535;
+			// aapt resource value: 0x7F070025
+			public const int abc_ic_star_black_16dp = 2131165221;
 			
-			// aapt resource value: 0x7f020020
-			public const int abc_ic_star_black_36dp = 2130837536;
+			// aapt resource value: 0x7F070026
+			public const int abc_ic_star_black_36dp = 2131165222;
 			
-			// aapt resource value: 0x7f020021
-			public const int abc_ic_star_black_48dp = 2130837537;
+			// aapt resource value: 0x7F070027
+			public const int abc_ic_star_black_48dp = 2131165223;
 			
-			// aapt resource value: 0x7f020022
-			public const int abc_ic_star_half_black_16dp = 2130837538;
+			// aapt resource value: 0x7F070028
+			public const int abc_ic_star_half_black_16dp = 2131165224;
 			
-			// aapt resource value: 0x7f020023
-			public const int abc_ic_star_half_black_36dp = 2130837539;
+			// aapt resource value: 0x7F070029
+			public const int abc_ic_star_half_black_36dp = 2131165225;
 			
-			// aapt resource value: 0x7f020024
-			public const int abc_ic_star_half_black_48dp = 2130837540;
+			// aapt resource value: 0x7F07002A
+			public const int abc_ic_star_half_black_48dp = 2131165226;
 			
-			// aapt resource value: 0x7f020025
-			public const int abc_ic_voice_search_api_material = 2130837541;
+			// aapt resource value: 0x7F07002B
+			public const int abc_ic_voice_search_api_material = 2131165227;
 			
-			// aapt resource value: 0x7f020026
-			public const int abc_item_background_holo_dark = 2130837542;
+			// aapt resource value: 0x7F07002C
+			public const int abc_item_background_holo_dark = 2131165228;
 			
-			// aapt resource value: 0x7f020027
-			public const int abc_item_background_holo_light = 2130837543;
+			// aapt resource value: 0x7F07002D
+			public const int abc_item_background_holo_light = 2131165229;
 			
-			// aapt resource value: 0x7f020028
-			public const int abc_list_divider_mtrl_alpha = 2130837544;
+			// aapt resource value: 0x7F07002E
+			public const int abc_list_divider_material = 2131165230;
 			
-			// aapt resource value: 0x7f020029
-			public const int abc_list_focused_holo = 2130837545;
+			// aapt resource value: 0x7F07002F
+			public const int abc_list_divider_mtrl_alpha = 2131165231;
 			
-			// aapt resource value: 0x7f02002a
-			public const int abc_list_longpressed_holo = 2130837546;
+			// aapt resource value: 0x7F070030
+			public const int abc_list_focused_holo = 2131165232;
 			
-			// aapt resource value: 0x7f02002b
-			public const int abc_list_pressed_holo_dark = 2130837547;
+			// aapt resource value: 0x7F070031
+			public const int abc_list_longpressed_holo = 2131165233;
 			
-			// aapt resource value: 0x7f02002c
-			public const int abc_list_pressed_holo_light = 2130837548;
+			// aapt resource value: 0x7F070032
+			public const int abc_list_pressed_holo_dark = 2131165234;
 			
-			// aapt resource value: 0x7f02002d
-			public const int abc_list_selector_background_transition_holo_dark = 2130837549;
+			// aapt resource value: 0x7F070033
+			public const int abc_list_pressed_holo_light = 2131165235;
 			
-			// aapt resource value: 0x7f02002e
-			public const int abc_list_selector_background_transition_holo_light = 2130837550;
+			// aapt resource value: 0x7F070034
+			public const int abc_list_selector_background_transition_holo_dark = 2131165236;
 			
-			// aapt resource value: 0x7f02002f
-			public const int abc_list_selector_disabled_holo_dark = 2130837551;
+			// aapt resource value: 0x7F070035
+			public const int abc_list_selector_background_transition_holo_light = 2131165237;
 			
-			// aapt resource value: 0x7f020030
-			public const int abc_list_selector_disabled_holo_light = 2130837552;
+			// aapt resource value: 0x7F070036
+			public const int abc_list_selector_disabled_holo_dark = 2131165238;
 			
-			// aapt resource value: 0x7f020031
-			public const int abc_list_selector_holo_dark = 2130837553;
+			// aapt resource value: 0x7F070037
+			public const int abc_list_selector_disabled_holo_light = 2131165239;
 			
-			// aapt resource value: 0x7f020032
-			public const int abc_list_selector_holo_light = 2130837554;
+			// aapt resource value: 0x7F070038
+			public const int abc_list_selector_holo_dark = 2131165240;
 			
-			// aapt resource value: 0x7f020033
-			public const int abc_menu_hardkey_panel_mtrl_mult = 2130837555;
+			// aapt resource value: 0x7F070039
+			public const int abc_list_selector_holo_light = 2131165241;
 			
-			// aapt resource value: 0x7f020034
-			public const int abc_popup_background_mtrl_mult = 2130837556;
+			// aapt resource value: 0x7F07003A
+			public const int abc_menu_hardkey_panel_mtrl_mult = 2131165242;
 			
-			// aapt resource value: 0x7f020035
-			public const int abc_ratingbar_indicator_material = 2130837557;
+			// aapt resource value: 0x7F07003B
+			public const int abc_popup_background_mtrl_mult = 2131165243;
 			
-			// aapt resource value: 0x7f020036
-			public const int abc_ratingbar_material = 2130837558;
+			// aapt resource value: 0x7F07003C
+			public const int abc_ratingbar_indicator_material = 2131165244;
 			
-			// aapt resource value: 0x7f020037
-			public const int abc_ratingbar_small_material = 2130837559;
+			// aapt resource value: 0x7F07003D
+			public const int abc_ratingbar_material = 2131165245;
 			
-			// aapt resource value: 0x7f020038
-			public const int abc_scrubber_control_off_mtrl_alpha = 2130837560;
+			// aapt resource value: 0x7F07003E
+			public const int abc_ratingbar_small_material = 2131165246;
 			
-			// aapt resource value: 0x7f020039
-			public const int abc_scrubber_control_to_pressed_mtrl_000 = 2130837561;
+			// aapt resource value: 0x7F07003F
+			public const int abc_scrubber_control_off_mtrl_alpha = 2131165247;
 			
-			// aapt resource value: 0x7f02003a
-			public const int abc_scrubber_control_to_pressed_mtrl_005 = 2130837562;
+			// aapt resource value: 0x7F070040
+			public const int abc_scrubber_control_to_pressed_mtrl_000 = 2131165248;
 			
-			// aapt resource value: 0x7f02003b
-			public const int abc_scrubber_primary_mtrl_alpha = 2130837563;
+			// aapt resource value: 0x7F070041
+			public const int abc_scrubber_control_to_pressed_mtrl_005 = 2131165249;
 			
-			// aapt resource value: 0x7f02003c
-			public const int abc_scrubber_track_mtrl_alpha = 2130837564;
+			// aapt resource value: 0x7F070042
+			public const int abc_scrubber_primary_mtrl_alpha = 2131165250;
 			
-			// aapt resource value: 0x7f02003d
-			public const int abc_seekbar_thumb_material = 2130837565;
+			// aapt resource value: 0x7F070043
+			public const int abc_scrubber_track_mtrl_alpha = 2131165251;
 			
-			// aapt resource value: 0x7f02003e
-			public const int abc_seekbar_tick_mark_material = 2130837566;
+			// aapt resource value: 0x7F070044
+			public const int abc_seekbar_thumb_material = 2131165252;
 			
-			// aapt resource value: 0x7f02003f
-			public const int abc_seekbar_track_material = 2130837567;
+			// aapt resource value: 0x7F070045
+			public const int abc_seekbar_tick_mark_material = 2131165253;
 			
-			// aapt resource value: 0x7f020040
-			public const int abc_spinner_mtrl_am_alpha = 2130837568;
+			// aapt resource value: 0x7F070046
+			public const int abc_seekbar_track_material = 2131165254;
 			
-			// aapt resource value: 0x7f020041
-			public const int abc_spinner_textfield_background_material = 2130837569;
+			// aapt resource value: 0x7F070047
+			public const int abc_spinner_mtrl_am_alpha = 2131165255;
 			
-			// aapt resource value: 0x7f020042
-			public const int abc_switch_thumb_material = 2130837570;
+			// aapt resource value: 0x7F070048
+			public const int abc_spinner_textfield_background_material = 2131165256;
 			
-			// aapt resource value: 0x7f020043
-			public const int abc_switch_track_mtrl_alpha = 2130837571;
+			// aapt resource value: 0x7F070049
+			public const int abc_switch_thumb_material = 2131165257;
 			
-			// aapt resource value: 0x7f020044
-			public const int abc_tab_indicator_material = 2130837572;
+			// aapt resource value: 0x7F07004A
+			public const int abc_switch_track_mtrl_alpha = 2131165258;
 			
-			// aapt resource value: 0x7f020045
-			public const int abc_tab_indicator_mtrl_alpha = 2130837573;
+			// aapt resource value: 0x7F07004B
+			public const int abc_tab_indicator_material = 2131165259;
 			
-			// aapt resource value: 0x7f020046
-			public const int abc_text_cursor_material = 2130837574;
+			// aapt resource value: 0x7F07004C
+			public const int abc_tab_indicator_mtrl_alpha = 2131165260;
 			
-			// aapt resource value: 0x7f020047
-			public const int abc_text_select_handle_left_mtrl_dark = 2130837575;
+			// aapt resource value: 0x7F070054
+			public const int abc_textfield_activated_mtrl_alpha = 2131165268;
 			
-			// aapt resource value: 0x7f020048
-			public const int abc_text_select_handle_left_mtrl_light = 2130837576;
+			// aapt resource value: 0x7F070055
+			public const int abc_textfield_default_mtrl_alpha = 2131165269;
 			
-			// aapt resource value: 0x7f020049
-			public const int abc_text_select_handle_middle_mtrl_dark = 2130837577;
+			// aapt resource value: 0x7F070056
+			public const int abc_textfield_search_activated_mtrl_alpha = 2131165270;
 			
-			// aapt resource value: 0x7f02004a
-			public const int abc_text_select_handle_middle_mtrl_light = 2130837578;
+			// aapt resource value: 0x7F070057
+			public const int abc_textfield_search_default_mtrl_alpha = 2131165271;
 			
-			// aapt resource value: 0x7f02004b
-			public const int abc_text_select_handle_right_mtrl_dark = 2130837579;
+			// aapt resource value: 0x7F070058
+			public const int abc_textfield_search_material = 2131165272;
 			
-			// aapt resource value: 0x7f02004c
-			public const int abc_text_select_handle_right_mtrl_light = 2130837580;
+			// aapt resource value: 0x7F07004D
+			public const int abc_text_cursor_material = 2131165261;
 			
-			// aapt resource value: 0x7f02004d
-			public const int abc_textfield_activated_mtrl_alpha = 2130837581;
+			// aapt resource value: 0x7F07004E
+			public const int abc_text_select_handle_left_mtrl_dark = 2131165262;
 			
-			// aapt resource value: 0x7f02004e
-			public const int abc_textfield_default_mtrl_alpha = 2130837582;
+			// aapt resource value: 0x7F07004F
+			public const int abc_text_select_handle_left_mtrl_light = 2131165263;
 			
-			// aapt resource value: 0x7f02004f
-			public const int abc_textfield_search_activated_mtrl_alpha = 2130837583;
+			// aapt resource value: 0x7F070050
+			public const int abc_text_select_handle_middle_mtrl_dark = 2131165264;
 			
-			// aapt resource value: 0x7f020050
-			public const int abc_textfield_search_default_mtrl_alpha = 2130837584;
+			// aapt resource value: 0x7F070051
+			public const int abc_text_select_handle_middle_mtrl_light = 2131165265;
 			
-			// aapt resource value: 0x7f020051
-			public const int abc_textfield_search_material = 2130837585;
+			// aapt resource value: 0x7F070052
+			public const int abc_text_select_handle_right_mtrl_dark = 2131165266;
 			
-			// aapt resource value: 0x7f020052
-			public const int abc_vector_test = 2130837586;
+			// aapt resource value: 0x7F070053
+			public const int abc_text_select_handle_right_mtrl_light = 2131165267;
 			
-			// aapt resource value: 0x7f020053
-			public const int avd_hide_password = 2130837587;
+			// aapt resource value: 0x7F070059
+			public const int abc_vector_test = 2131165273;
 			
-			// aapt resource value: 0x7f02012f
-			public const int avd_hide_password_1 = 2130837807;
+			// aapt resource value: 0x7F07005A
+			public const int avd_hide_password = 2131165274;
 			
-			// aapt resource value: 0x7f020130
-			public const int avd_hide_password_2 = 2130837808;
+			// aapt resource value: 0x7F07005B
+			public const int avd_show_password = 2131165275;
 			
-			// aapt resource value: 0x7f020131
-			public const int avd_hide_password_3 = 2130837809;
+			// aapt resource value: 0x7F07005C
+			public const int design_bottom_navigation_item_background = 2131165276;
 			
-			// aapt resource value: 0x7f020054
-			public const int avd_show_password = 2130837588;
+			// aapt resource value: 0x7F07005D
+			public const int design_fab_background = 2131165277;
 			
-			// aapt resource value: 0x7f020132
-			public const int avd_show_password_1 = 2130837810;
+			// aapt resource value: 0x7F07005E
+			public const int design_ic_visibility = 2131165278;
 			
-			// aapt resource value: 0x7f020133
-			public const int avd_show_password_2 = 2130837811;
+			// aapt resource value: 0x7F07005F
+			public const int design_ic_visibility_off = 2131165279;
 			
-			// aapt resource value: 0x7f020134
-			public const int avd_show_password_3 = 2130837812;
+			// aapt resource value: 0x7F070060
+			public const int design_password_eye = 2131165280;
 			
-			// aapt resource value: 0x7f020055
-			public const int design_bottom_navigation_item_background = 2130837589;
+			// aapt resource value: 0x7F070061
+			public const int design_snackbar_background = 2131165281;
 			
-			// aapt resource value: 0x7f020056
-			public const int design_fab_background = 2130837590;
+			// aapt resource value: 0x7F070062
+			public const int ic_audiotrack_dark = 2131165282;
 			
-			// aapt resource value: 0x7f020057
-			public const int design_ic_visibility = 2130837591;
+			// aapt resource value: 0x7F070063
+			public const int ic_audiotrack_light = 2131165283;
 			
-			// aapt resource value: 0x7f020058
-			public const int design_ic_visibility_off = 2130837592;
+			// aapt resource value: 0x7F070064
+			public const int ic_dialog_close_dark = 2131165284;
 			
-			// aapt resource value: 0x7f020059
-			public const int design_password_eye = 2130837593;
+			// aapt resource value: 0x7F070065
+			public const int ic_dialog_close_light = 2131165285;
 			
-			// aapt resource value: 0x7f02005a
-			public const int design_snackbar_background = 2130837594;
+			// aapt resource value: 0x7F070066
+			public const int ic_group_collapse_00 = 2131165286;
 			
-			// aapt resource value: 0x7f02005b
-			public const int ic_audiotrack_dark = 2130837595;
+			// aapt resource value: 0x7F070067
+			public const int ic_group_collapse_01 = 2131165287;
 			
-			// aapt resource value: 0x7f02005c
-			public const int ic_audiotrack_light = 2130837596;
+			// aapt resource value: 0x7F070068
+			public const int ic_group_collapse_02 = 2131165288;
 			
-			// aapt resource value: 0x7f02005d
-			public const int ic_dialog_close_dark = 2130837597;
+			// aapt resource value: 0x7F070069
+			public const int ic_group_collapse_03 = 2131165289;
 			
-			// aapt resource value: 0x7f02005e
-			public const int ic_dialog_close_light = 2130837598;
+			// aapt resource value: 0x7F07006A
+			public const int ic_group_collapse_04 = 2131165290;
 			
-			// aapt resource value: 0x7f02005f
-			public const int ic_group_collapse_00 = 2130837599;
+			// aapt resource value: 0x7F07006B
+			public const int ic_group_collapse_05 = 2131165291;
 			
-			// aapt resource value: 0x7f020060
-			public const int ic_group_collapse_01 = 2130837600;
+			// aapt resource value: 0x7F07006C
+			public const int ic_group_collapse_06 = 2131165292;
 			
-			// aapt resource value: 0x7f020061
-			public const int ic_group_collapse_02 = 2130837601;
+			// aapt resource value: 0x7F07006D
+			public const int ic_group_collapse_07 = 2131165293;
 			
-			// aapt resource value: 0x7f020062
-			public const int ic_group_collapse_03 = 2130837602;
+			// aapt resource value: 0x7F07006E
+			public const int ic_group_collapse_08 = 2131165294;
 			
-			// aapt resource value: 0x7f020063
-			public const int ic_group_collapse_04 = 2130837603;
+			// aapt resource value: 0x7F07006F
+			public const int ic_group_collapse_09 = 2131165295;
 			
-			// aapt resource value: 0x7f020064
-			public const int ic_group_collapse_05 = 2130837604;
+			// aapt resource value: 0x7F070070
+			public const int ic_group_collapse_10 = 2131165296;
 			
-			// aapt resource value: 0x7f020065
-			public const int ic_group_collapse_06 = 2130837605;
+			// aapt resource value: 0x7F070071
+			public const int ic_group_collapse_11 = 2131165297;
 			
-			// aapt resource value: 0x7f020066
-			public const int ic_group_collapse_07 = 2130837606;
+			// aapt resource value: 0x7F070072
+			public const int ic_group_collapse_12 = 2131165298;
 			
-			// aapt resource value: 0x7f020067
-			public const int ic_group_collapse_08 = 2130837607;
+			// aapt resource value: 0x7F070073
+			public const int ic_group_collapse_13 = 2131165299;
 			
-			// aapt resource value: 0x7f020068
-			public const int ic_group_collapse_09 = 2130837608;
+			// aapt resource value: 0x7F070074
+			public const int ic_group_collapse_14 = 2131165300;
 			
-			// aapt resource value: 0x7f020069
-			public const int ic_group_collapse_10 = 2130837609;
+			// aapt resource value: 0x7F070075
+			public const int ic_group_collapse_15 = 2131165301;
 			
-			// aapt resource value: 0x7f02006a
-			public const int ic_group_collapse_11 = 2130837610;
+			// aapt resource value: 0x7F070076
+			public const int ic_group_expand_00 = 2131165302;
 			
-			// aapt resource value: 0x7f02006b
-			public const int ic_group_collapse_12 = 2130837611;
+			// aapt resource value: 0x7F070077
+			public const int ic_group_expand_01 = 2131165303;
 			
-			// aapt resource value: 0x7f02006c
-			public const int ic_group_collapse_13 = 2130837612;
+			// aapt resource value: 0x7F070078
+			public const int ic_group_expand_02 = 2131165304;
 			
-			// aapt resource value: 0x7f02006d
-			public const int ic_group_collapse_14 = 2130837613;
+			// aapt resource value: 0x7F070079
+			public const int ic_group_expand_03 = 2131165305;
 			
-			// aapt resource value: 0x7f02006e
-			public const int ic_group_collapse_15 = 2130837614;
+			// aapt resource value: 0x7F07007A
+			public const int ic_group_expand_04 = 2131165306;
 			
-			// aapt resource value: 0x7f02006f
-			public const int ic_group_expand_00 = 2130837615;
+			// aapt resource value: 0x7F07007B
+			public const int ic_group_expand_05 = 2131165307;
 			
-			// aapt resource value: 0x7f020070
-			public const int ic_group_expand_01 = 2130837616;
+			// aapt resource value: 0x7F07007C
+			public const int ic_group_expand_06 = 2131165308;
 			
-			// aapt resource value: 0x7f020071
-			public const int ic_group_expand_02 = 2130837617;
+			// aapt resource value: 0x7F07007D
+			public const int ic_group_expand_07 = 2131165309;
 			
-			// aapt resource value: 0x7f020072
-			public const int ic_group_expand_03 = 2130837618;
+			// aapt resource value: 0x7F07007E
+			public const int ic_group_expand_08 = 2131165310;
 			
-			// aapt resource value: 0x7f020073
-			public const int ic_group_expand_04 = 2130837619;
+			// aapt resource value: 0x7F07007F
+			public const int ic_group_expand_09 = 2131165311;
 			
-			// aapt resource value: 0x7f020074
-			public const int ic_group_expand_05 = 2130837620;
+			// aapt resource value: 0x7F070080
+			public const int ic_group_expand_10 = 2131165312;
 			
-			// aapt resource value: 0x7f020075
-			public const int ic_group_expand_06 = 2130837621;
+			// aapt resource value: 0x7F070081
+			public const int ic_group_expand_11 = 2131165313;
 			
-			// aapt resource value: 0x7f020076
-			public const int ic_group_expand_07 = 2130837622;
+			// aapt resource value: 0x7F070082
+			public const int ic_group_expand_12 = 2131165314;
 			
-			// aapt resource value: 0x7f020077
-			public const int ic_group_expand_08 = 2130837623;
+			// aapt resource value: 0x7F070083
+			public const int ic_group_expand_13 = 2131165315;
 			
-			// aapt resource value: 0x7f020078
-			public const int ic_group_expand_09 = 2130837624;
+			// aapt resource value: 0x7F070084
+			public const int ic_group_expand_14 = 2131165316;
 			
-			// aapt resource value: 0x7f020079
-			public const int ic_group_expand_10 = 2130837625;
+			// aapt resource value: 0x7F070085
+			public const int ic_group_expand_15 = 2131165317;
 			
-			// aapt resource value: 0x7f02007a
-			public const int ic_group_expand_11 = 2130837626;
+			// aapt resource value: 0x7F070086
+			public const int ic_media_pause_dark = 2131165318;
 			
-			// aapt resource value: 0x7f02007b
-			public const int ic_group_expand_12 = 2130837627;
+			// aapt resource value: 0x7F070087
+			public const int ic_media_pause_light = 2131165319;
 			
-			// aapt resource value: 0x7f02007c
-			public const int ic_group_expand_13 = 2130837628;
+			// aapt resource value: 0x7F070088
+			public const int ic_media_play_dark = 2131165320;
 			
-			// aapt resource value: 0x7f02007d
-			public const int ic_group_expand_14 = 2130837629;
+			// aapt resource value: 0x7F070089
+			public const int ic_media_play_light = 2131165321;
 			
-			// aapt resource value: 0x7f02007e
-			public const int ic_group_expand_15 = 2130837630;
+			// aapt resource value: 0x7F07008A
+			public const int ic_media_stop_dark = 2131165322;
 			
-			// aapt resource value: 0x7f02007f
-			public const int ic_media_pause_dark = 2130837631;
+			// aapt resource value: 0x7F07008B
+			public const int ic_media_stop_light = 2131165323;
 			
-			// aapt resource value: 0x7f020080
-			public const int ic_media_pause_light = 2130837632;
+			// aapt resource value: 0x7F07008C
+			public const int ic_mr_button_connected_00_dark = 2131165324;
 			
-			// aapt resource value: 0x7f020081
-			public const int ic_media_play_dark = 2130837633;
+			// aapt resource value: 0x7F07008D
+			public const int ic_mr_button_connected_00_light = 2131165325;
 			
-			// aapt resource value: 0x7f020082
-			public const int ic_media_play_light = 2130837634;
+			// aapt resource value: 0x7F07008E
+			public const int ic_mr_button_connected_01_dark = 2131165326;
 			
-			// aapt resource value: 0x7f020083
-			public const int ic_media_stop_dark = 2130837635;
+			// aapt resource value: 0x7F07008F
+			public const int ic_mr_button_connected_01_light = 2131165327;
 			
-			// aapt resource value: 0x7f020084
-			public const int ic_media_stop_light = 2130837636;
+			// aapt resource value: 0x7F070090
+			public const int ic_mr_button_connected_02_dark = 2131165328;
 			
-			// aapt resource value: 0x7f020085
-			public const int ic_mr_button_connected_00_dark = 2130837637;
+			// aapt resource value: 0x7F070091
+			public const int ic_mr_button_connected_02_light = 2131165329;
 			
-			// aapt resource value: 0x7f020086
-			public const int ic_mr_button_connected_00_light = 2130837638;
+			// aapt resource value: 0x7F070092
+			public const int ic_mr_button_connected_03_dark = 2131165330;
 			
-			// aapt resource value: 0x7f020087
-			public const int ic_mr_button_connected_01_dark = 2130837639;
+			// aapt resource value: 0x7F070093
+			public const int ic_mr_button_connected_03_light = 2131165331;
 			
-			// aapt resource value: 0x7f020088
-			public const int ic_mr_button_connected_01_light = 2130837640;
+			// aapt resource value: 0x7F070094
+			public const int ic_mr_button_connected_04_dark = 2131165332;
 			
-			// aapt resource value: 0x7f020089
-			public const int ic_mr_button_connected_02_dark = 2130837641;
+			// aapt resource value: 0x7F070095
+			public const int ic_mr_button_connected_04_light = 2131165333;
 			
-			// aapt resource value: 0x7f02008a
-			public const int ic_mr_button_connected_02_light = 2130837642;
+			// aapt resource value: 0x7F070096
+			public const int ic_mr_button_connected_05_dark = 2131165334;
 			
-			// aapt resource value: 0x7f02008b
-			public const int ic_mr_button_connected_03_dark = 2130837643;
+			// aapt resource value: 0x7F070097
+			public const int ic_mr_button_connected_05_light = 2131165335;
 			
-			// aapt resource value: 0x7f02008c
-			public const int ic_mr_button_connected_03_light = 2130837644;
+			// aapt resource value: 0x7F070098
+			public const int ic_mr_button_connected_06_dark = 2131165336;
 			
-			// aapt resource value: 0x7f02008d
-			public const int ic_mr_button_connected_04_dark = 2130837645;
+			// aapt resource value: 0x7F070099
+			public const int ic_mr_button_connected_06_light = 2131165337;
 			
-			// aapt resource value: 0x7f02008e
-			public const int ic_mr_button_connected_04_light = 2130837646;
+			// aapt resource value: 0x7F07009A
+			public const int ic_mr_button_connected_07_dark = 2131165338;
 			
-			// aapt resource value: 0x7f02008f
-			public const int ic_mr_button_connected_05_dark = 2130837647;
+			// aapt resource value: 0x7F07009B
+			public const int ic_mr_button_connected_07_light = 2131165339;
 			
-			// aapt resource value: 0x7f020090
-			public const int ic_mr_button_connected_05_light = 2130837648;
+			// aapt resource value: 0x7F07009C
+			public const int ic_mr_button_connected_08_dark = 2131165340;
 			
-			// aapt resource value: 0x7f020091
-			public const int ic_mr_button_connected_06_dark = 2130837649;
+			// aapt resource value: 0x7F07009D
+			public const int ic_mr_button_connected_08_light = 2131165341;
 			
-			// aapt resource value: 0x7f020092
-			public const int ic_mr_button_connected_06_light = 2130837650;
+			// aapt resource value: 0x7F07009E
+			public const int ic_mr_button_connected_09_dark = 2131165342;
 			
-			// aapt resource value: 0x7f020093
-			public const int ic_mr_button_connected_07_dark = 2130837651;
+			// aapt resource value: 0x7F07009F
+			public const int ic_mr_button_connected_09_light = 2131165343;
 			
-			// aapt resource value: 0x7f020094
-			public const int ic_mr_button_connected_07_light = 2130837652;
+			// aapt resource value: 0x7F0700A0
+			public const int ic_mr_button_connected_10_dark = 2131165344;
 			
-			// aapt resource value: 0x7f020095
-			public const int ic_mr_button_connected_08_dark = 2130837653;
+			// aapt resource value: 0x7F0700A1
+			public const int ic_mr_button_connected_10_light = 2131165345;
 			
-			// aapt resource value: 0x7f020096
-			public const int ic_mr_button_connected_08_light = 2130837654;
+			// aapt resource value: 0x7F0700A2
+			public const int ic_mr_button_connected_11_dark = 2131165346;
 			
-			// aapt resource value: 0x7f020097
-			public const int ic_mr_button_connected_09_dark = 2130837655;
+			// aapt resource value: 0x7F0700A3
+			public const int ic_mr_button_connected_11_light = 2131165347;
 			
-			// aapt resource value: 0x7f020098
-			public const int ic_mr_button_connected_09_light = 2130837656;
+			// aapt resource value: 0x7F0700A4
+			public const int ic_mr_button_connected_12_dark = 2131165348;
 			
-			// aapt resource value: 0x7f020099
-			public const int ic_mr_button_connected_10_dark = 2130837657;
+			// aapt resource value: 0x7F0700A5
+			public const int ic_mr_button_connected_12_light = 2131165349;
 			
-			// aapt resource value: 0x7f02009a
-			public const int ic_mr_button_connected_10_light = 2130837658;
+			// aapt resource value: 0x7F0700A6
+			public const int ic_mr_button_connected_13_dark = 2131165350;
 			
-			// aapt resource value: 0x7f02009b
-			public const int ic_mr_button_connected_11_dark = 2130837659;
+			// aapt resource value: 0x7F0700A7
+			public const int ic_mr_button_connected_13_light = 2131165351;
 			
-			// aapt resource value: 0x7f02009c
-			public const int ic_mr_button_connected_11_light = 2130837660;
+			// aapt resource value: 0x7F0700A8
+			public const int ic_mr_button_connected_14_dark = 2131165352;
 			
-			// aapt resource value: 0x7f02009d
-			public const int ic_mr_button_connected_12_dark = 2130837661;
+			// aapt resource value: 0x7F0700A9
+			public const int ic_mr_button_connected_14_light = 2131165353;
 			
-			// aapt resource value: 0x7f02009e
-			public const int ic_mr_button_connected_12_light = 2130837662;
+			// aapt resource value: 0x7F0700AA
+			public const int ic_mr_button_connected_15_dark = 2131165354;
 			
-			// aapt resource value: 0x7f02009f
-			public const int ic_mr_button_connected_13_dark = 2130837663;
+			// aapt resource value: 0x7F0700AB
+			public const int ic_mr_button_connected_15_light = 2131165355;
 			
-			// aapt resource value: 0x7f0200a0
-			public const int ic_mr_button_connected_13_light = 2130837664;
+			// aapt resource value: 0x7F0700AC
+			public const int ic_mr_button_connected_16_dark = 2131165356;
 			
-			// aapt resource value: 0x7f0200a1
-			public const int ic_mr_button_connected_14_dark = 2130837665;
+			// aapt resource value: 0x7F0700AD
+			public const int ic_mr_button_connected_16_light = 2131165357;
 			
-			// aapt resource value: 0x7f0200a2
-			public const int ic_mr_button_connected_14_light = 2130837666;
+			// aapt resource value: 0x7F0700AE
+			public const int ic_mr_button_connected_17_dark = 2131165358;
 			
-			// aapt resource value: 0x7f0200a3
-			public const int ic_mr_button_connected_15_dark = 2130837667;
+			// aapt resource value: 0x7F0700AF
+			public const int ic_mr_button_connected_17_light = 2131165359;
 			
-			// aapt resource value: 0x7f0200a4
-			public const int ic_mr_button_connected_15_light = 2130837668;
+			// aapt resource value: 0x7F0700B0
+			public const int ic_mr_button_connected_18_dark = 2131165360;
 			
-			// aapt resource value: 0x7f0200a5
-			public const int ic_mr_button_connected_16_dark = 2130837669;
+			// aapt resource value: 0x7F0700B1
+			public const int ic_mr_button_connected_18_light = 2131165361;
 			
-			// aapt resource value: 0x7f0200a6
-			public const int ic_mr_button_connected_16_light = 2130837670;
+			// aapt resource value: 0x7F0700B2
+			public const int ic_mr_button_connected_19_dark = 2131165362;
 			
-			// aapt resource value: 0x7f0200a7
-			public const int ic_mr_button_connected_17_dark = 2130837671;
+			// aapt resource value: 0x7F0700B3
+			public const int ic_mr_button_connected_19_light = 2131165363;
 			
-			// aapt resource value: 0x7f0200a8
-			public const int ic_mr_button_connected_17_light = 2130837672;
+			// aapt resource value: 0x7F0700B4
+			public const int ic_mr_button_connected_20_dark = 2131165364;
 			
-			// aapt resource value: 0x7f0200a9
-			public const int ic_mr_button_connected_18_dark = 2130837673;
+			// aapt resource value: 0x7F0700B5
+			public const int ic_mr_button_connected_20_light = 2131165365;
 			
-			// aapt resource value: 0x7f0200aa
-			public const int ic_mr_button_connected_18_light = 2130837674;
+			// aapt resource value: 0x7F0700B6
+			public const int ic_mr_button_connected_21_dark = 2131165366;
 			
-			// aapt resource value: 0x7f0200ab
-			public const int ic_mr_button_connected_19_dark = 2130837675;
+			// aapt resource value: 0x7F0700B7
+			public const int ic_mr_button_connected_21_light = 2131165367;
 			
-			// aapt resource value: 0x7f0200ac
-			public const int ic_mr_button_connected_19_light = 2130837676;
+			// aapt resource value: 0x7F0700B8
+			public const int ic_mr_button_connected_22_dark = 2131165368;
 			
-			// aapt resource value: 0x7f0200ad
-			public const int ic_mr_button_connected_20_dark = 2130837677;
+			// aapt resource value: 0x7F0700B9
+			public const int ic_mr_button_connected_22_light = 2131165369;
 			
-			// aapt resource value: 0x7f0200ae
-			public const int ic_mr_button_connected_20_light = 2130837678;
+			// aapt resource value: 0x7F0700BA
+			public const int ic_mr_button_connected_23_dark = 2131165370;
 			
-			// aapt resource value: 0x7f0200af
-			public const int ic_mr_button_connected_21_dark = 2130837679;
+			// aapt resource value: 0x7F0700BB
+			public const int ic_mr_button_connected_23_light = 2131165371;
 			
-			// aapt resource value: 0x7f0200b0
-			public const int ic_mr_button_connected_21_light = 2130837680;
+			// aapt resource value: 0x7F0700BC
+			public const int ic_mr_button_connected_24_dark = 2131165372;
 			
-			// aapt resource value: 0x7f0200b1
-			public const int ic_mr_button_connected_22_dark = 2130837681;
+			// aapt resource value: 0x7F0700BD
+			public const int ic_mr_button_connected_24_light = 2131165373;
 			
-			// aapt resource value: 0x7f0200b2
-			public const int ic_mr_button_connected_22_light = 2130837682;
+			// aapt resource value: 0x7F0700BE
+			public const int ic_mr_button_connected_25_dark = 2131165374;
 			
-			// aapt resource value: 0x7f0200b3
-			public const int ic_mr_button_connected_23_dark = 2130837683;
+			// aapt resource value: 0x7F0700BF
+			public const int ic_mr_button_connected_25_light = 2131165375;
 			
-			// aapt resource value: 0x7f0200b4
-			public const int ic_mr_button_connected_23_light = 2130837684;
+			// aapt resource value: 0x7F0700C0
+			public const int ic_mr_button_connected_26_dark = 2131165376;
 			
-			// aapt resource value: 0x7f0200b5
-			public const int ic_mr_button_connected_24_dark = 2130837685;
+			// aapt resource value: 0x7F0700C1
+			public const int ic_mr_button_connected_26_light = 2131165377;
 			
-			// aapt resource value: 0x7f0200b6
-			public const int ic_mr_button_connected_24_light = 2130837686;
+			// aapt resource value: 0x7F0700C2
+			public const int ic_mr_button_connected_27_dark = 2131165378;
 			
-			// aapt resource value: 0x7f0200b7
-			public const int ic_mr_button_connected_25_dark = 2130837687;
+			// aapt resource value: 0x7F0700C3
+			public const int ic_mr_button_connected_27_light = 2131165379;
 			
-			// aapt resource value: 0x7f0200b8
-			public const int ic_mr_button_connected_25_light = 2130837688;
+			// aapt resource value: 0x7F0700C4
+			public const int ic_mr_button_connected_28_dark = 2131165380;
 			
-			// aapt resource value: 0x7f0200b9
-			public const int ic_mr_button_connected_26_dark = 2130837689;
+			// aapt resource value: 0x7F0700C5
+			public const int ic_mr_button_connected_28_light = 2131165381;
 			
-			// aapt resource value: 0x7f0200ba
-			public const int ic_mr_button_connected_26_light = 2130837690;
+			// aapt resource value: 0x7F0700C6
+			public const int ic_mr_button_connected_29_dark = 2131165382;
 			
-			// aapt resource value: 0x7f0200bb
-			public const int ic_mr_button_connected_27_dark = 2130837691;
+			// aapt resource value: 0x7F0700C7
+			public const int ic_mr_button_connected_29_light = 2131165383;
 			
-			// aapt resource value: 0x7f0200bc
-			public const int ic_mr_button_connected_27_light = 2130837692;
+			// aapt resource value: 0x7F0700C8
+			public const int ic_mr_button_connected_30_dark = 2131165384;
 			
-			// aapt resource value: 0x7f0200bd
-			public const int ic_mr_button_connected_28_dark = 2130837693;
+			// aapt resource value: 0x7F0700C9
+			public const int ic_mr_button_connected_30_light = 2131165385;
 			
-			// aapt resource value: 0x7f0200be
-			public const int ic_mr_button_connected_28_light = 2130837694;
+			// aapt resource value: 0x7F0700CA
+			public const int ic_mr_button_connecting_00_dark = 2131165386;
 			
-			// aapt resource value: 0x7f0200bf
-			public const int ic_mr_button_connected_29_dark = 2130837695;
+			// aapt resource value: 0x7F0700CB
+			public const int ic_mr_button_connecting_00_light = 2131165387;
 			
-			// aapt resource value: 0x7f0200c0
-			public const int ic_mr_button_connected_29_light = 2130837696;
+			// aapt resource value: 0x7F0700CC
+			public const int ic_mr_button_connecting_01_dark = 2131165388;
 			
-			// aapt resource value: 0x7f0200c1
-			public const int ic_mr_button_connected_30_dark = 2130837697;
+			// aapt resource value: 0x7F0700CD
+			public const int ic_mr_button_connecting_01_light = 2131165389;
 			
-			// aapt resource value: 0x7f0200c2
-			public const int ic_mr_button_connected_30_light = 2130837698;
+			// aapt resource value: 0x7F0700CE
+			public const int ic_mr_button_connecting_02_dark = 2131165390;
 			
-			// aapt resource value: 0x7f0200c3
-			public const int ic_mr_button_connecting_00_dark = 2130837699;
+			// aapt resource value: 0x7F0700CF
+			public const int ic_mr_button_connecting_02_light = 2131165391;
 			
-			// aapt resource value: 0x7f0200c4
-			public const int ic_mr_button_connecting_00_light = 2130837700;
+			// aapt resource value: 0x7F0700D0
+			public const int ic_mr_button_connecting_03_dark = 2131165392;
 			
-			// aapt resource value: 0x7f0200c5
-			public const int ic_mr_button_connecting_01_dark = 2130837701;
+			// aapt resource value: 0x7F0700D1
+			public const int ic_mr_button_connecting_03_light = 2131165393;
 			
-			// aapt resource value: 0x7f0200c6
-			public const int ic_mr_button_connecting_01_light = 2130837702;
+			// aapt resource value: 0x7F0700D2
+			public const int ic_mr_button_connecting_04_dark = 2131165394;
 			
-			// aapt resource value: 0x7f0200c7
-			public const int ic_mr_button_connecting_02_dark = 2130837703;
+			// aapt resource value: 0x7F0700D3
+			public const int ic_mr_button_connecting_04_light = 2131165395;
 			
-			// aapt resource value: 0x7f0200c8
-			public const int ic_mr_button_connecting_02_light = 2130837704;
+			// aapt resource value: 0x7F0700D4
+			public const int ic_mr_button_connecting_05_dark = 2131165396;
 			
-			// aapt resource value: 0x7f0200c9
-			public const int ic_mr_button_connecting_03_dark = 2130837705;
+			// aapt resource value: 0x7F0700D5
+			public const int ic_mr_button_connecting_05_light = 2131165397;
 			
-			// aapt resource value: 0x7f0200ca
-			public const int ic_mr_button_connecting_03_light = 2130837706;
+			// aapt resource value: 0x7F0700D6
+			public const int ic_mr_button_connecting_06_dark = 2131165398;
 			
-			// aapt resource value: 0x7f0200cb
-			public const int ic_mr_button_connecting_04_dark = 2130837707;
+			// aapt resource value: 0x7F0700D7
+			public const int ic_mr_button_connecting_06_light = 2131165399;
 			
-			// aapt resource value: 0x7f0200cc
-			public const int ic_mr_button_connecting_04_light = 2130837708;
+			// aapt resource value: 0x7F0700D8
+			public const int ic_mr_button_connecting_07_dark = 2131165400;
 			
-			// aapt resource value: 0x7f0200cd
-			public const int ic_mr_button_connecting_05_dark = 2130837709;
+			// aapt resource value: 0x7F0700D9
+			public const int ic_mr_button_connecting_07_light = 2131165401;
 			
-			// aapt resource value: 0x7f0200ce
-			public const int ic_mr_button_connecting_05_light = 2130837710;
+			// aapt resource value: 0x7F0700DA
+			public const int ic_mr_button_connecting_08_dark = 2131165402;
 			
-			// aapt resource value: 0x7f0200cf
-			public const int ic_mr_button_connecting_06_dark = 2130837711;
+			// aapt resource value: 0x7F0700DB
+			public const int ic_mr_button_connecting_08_light = 2131165403;
 			
-			// aapt resource value: 0x7f0200d0
-			public const int ic_mr_button_connecting_06_light = 2130837712;
+			// aapt resource value: 0x7F0700DC
+			public const int ic_mr_button_connecting_09_dark = 2131165404;
 			
-			// aapt resource value: 0x7f0200d1
-			public const int ic_mr_button_connecting_07_dark = 2130837713;
+			// aapt resource value: 0x7F0700DD
+			public const int ic_mr_button_connecting_09_light = 2131165405;
 			
-			// aapt resource value: 0x7f0200d2
-			public const int ic_mr_button_connecting_07_light = 2130837714;
+			// aapt resource value: 0x7F0700DE
+			public const int ic_mr_button_connecting_10_dark = 2131165406;
 			
-			// aapt resource value: 0x7f0200d3
-			public const int ic_mr_button_connecting_08_dark = 2130837715;
+			// aapt resource value: 0x7F0700DF
+			public const int ic_mr_button_connecting_10_light = 2131165407;
 			
-			// aapt resource value: 0x7f0200d4
-			public const int ic_mr_button_connecting_08_light = 2130837716;
+			// aapt resource value: 0x7F0700E0
+			public const int ic_mr_button_connecting_11_dark = 2131165408;
 			
-			// aapt resource value: 0x7f0200d5
-			public const int ic_mr_button_connecting_09_dark = 2130837717;
+			// aapt resource value: 0x7F0700E1
+			public const int ic_mr_button_connecting_11_light = 2131165409;
 			
-			// aapt resource value: 0x7f0200d6
-			public const int ic_mr_button_connecting_09_light = 2130837718;
+			// aapt resource value: 0x7F0700E2
+			public const int ic_mr_button_connecting_12_dark = 2131165410;
 			
-			// aapt resource value: 0x7f0200d7
-			public const int ic_mr_button_connecting_10_dark = 2130837719;
+			// aapt resource value: 0x7F0700E3
+			public const int ic_mr_button_connecting_12_light = 2131165411;
 			
-			// aapt resource value: 0x7f0200d8
-			public const int ic_mr_button_connecting_10_light = 2130837720;
+			// aapt resource value: 0x7F0700E4
+			public const int ic_mr_button_connecting_13_dark = 2131165412;
 			
-			// aapt resource value: 0x7f0200d9
-			public const int ic_mr_button_connecting_11_dark = 2130837721;
+			// aapt resource value: 0x7F0700E5
+			public const int ic_mr_button_connecting_13_light = 2131165413;
 			
-			// aapt resource value: 0x7f0200da
-			public const int ic_mr_button_connecting_11_light = 2130837722;
+			// aapt resource value: 0x7F0700E6
+			public const int ic_mr_button_connecting_14_dark = 2131165414;
 			
-			// aapt resource value: 0x7f0200db
-			public const int ic_mr_button_connecting_12_dark = 2130837723;
+			// aapt resource value: 0x7F0700E7
+			public const int ic_mr_button_connecting_14_light = 2131165415;
 			
-			// aapt resource value: 0x7f0200dc
-			public const int ic_mr_button_connecting_12_light = 2130837724;
+			// aapt resource value: 0x7F0700E8
+			public const int ic_mr_button_connecting_15_dark = 2131165416;
 			
-			// aapt resource value: 0x7f0200dd
-			public const int ic_mr_button_connecting_13_dark = 2130837725;
+			// aapt resource value: 0x7F0700E9
+			public const int ic_mr_button_connecting_15_light = 2131165417;
 			
-			// aapt resource value: 0x7f0200de
-			public const int ic_mr_button_connecting_13_light = 2130837726;
+			// aapt resource value: 0x7F0700EA
+			public const int ic_mr_button_connecting_16_dark = 2131165418;
 			
-			// aapt resource value: 0x7f0200df
-			public const int ic_mr_button_connecting_14_dark = 2130837727;
+			// aapt resource value: 0x7F0700EB
+			public const int ic_mr_button_connecting_16_light = 2131165419;
 			
-			// aapt resource value: 0x7f0200e0
-			public const int ic_mr_button_connecting_14_light = 2130837728;
+			// aapt resource value: 0x7F0700EC
+			public const int ic_mr_button_connecting_17_dark = 2131165420;
 			
-			// aapt resource value: 0x7f0200e1
-			public const int ic_mr_button_connecting_15_dark = 2130837729;
+			// aapt resource value: 0x7F0700ED
+			public const int ic_mr_button_connecting_17_light = 2131165421;
 			
-			// aapt resource value: 0x7f0200e2
-			public const int ic_mr_button_connecting_15_light = 2130837730;
+			// aapt resource value: 0x7F0700EE
+			public const int ic_mr_button_connecting_18_dark = 2131165422;
 			
-			// aapt resource value: 0x7f0200e3
-			public const int ic_mr_button_connecting_16_dark = 2130837731;
+			// aapt resource value: 0x7F0700EF
+			public const int ic_mr_button_connecting_18_light = 2131165423;
 			
-			// aapt resource value: 0x7f0200e4
-			public const int ic_mr_button_connecting_16_light = 2130837732;
+			// aapt resource value: 0x7F0700F0
+			public const int ic_mr_button_connecting_19_dark = 2131165424;
 			
-			// aapt resource value: 0x7f0200e5
-			public const int ic_mr_button_connecting_17_dark = 2130837733;
+			// aapt resource value: 0x7F0700F1
+			public const int ic_mr_button_connecting_19_light = 2131165425;
 			
-			// aapt resource value: 0x7f0200e6
-			public const int ic_mr_button_connecting_17_light = 2130837734;
+			// aapt resource value: 0x7F0700F2
+			public const int ic_mr_button_connecting_20_dark = 2131165426;
 			
-			// aapt resource value: 0x7f0200e7
-			public const int ic_mr_button_connecting_18_dark = 2130837735;
+			// aapt resource value: 0x7F0700F3
+			public const int ic_mr_button_connecting_20_light = 2131165427;
 			
-			// aapt resource value: 0x7f0200e8
-			public const int ic_mr_button_connecting_18_light = 2130837736;
+			// aapt resource value: 0x7F0700F4
+			public const int ic_mr_button_connecting_21_dark = 2131165428;
 			
-			// aapt resource value: 0x7f0200e9
-			public const int ic_mr_button_connecting_19_dark = 2130837737;
+			// aapt resource value: 0x7F0700F5
+			public const int ic_mr_button_connecting_21_light = 2131165429;
 			
-			// aapt resource value: 0x7f0200ea
-			public const int ic_mr_button_connecting_19_light = 2130837738;
+			// aapt resource value: 0x7F0700F6
+			public const int ic_mr_button_connecting_22_dark = 2131165430;
 			
-			// aapt resource value: 0x7f0200eb
-			public const int ic_mr_button_connecting_20_dark = 2130837739;
+			// aapt resource value: 0x7F0700F7
+			public const int ic_mr_button_connecting_22_light = 2131165431;
 			
-			// aapt resource value: 0x7f0200ec
-			public const int ic_mr_button_connecting_20_light = 2130837740;
+			// aapt resource value: 0x7F0700F8
+			public const int ic_mr_button_connecting_23_dark = 2131165432;
 			
-			// aapt resource value: 0x7f0200ed
-			public const int ic_mr_button_connecting_21_dark = 2130837741;
+			// aapt resource value: 0x7F0700F9
+			public const int ic_mr_button_connecting_23_light = 2131165433;
 			
-			// aapt resource value: 0x7f0200ee
-			public const int ic_mr_button_connecting_21_light = 2130837742;
+			// aapt resource value: 0x7F0700FA
+			public const int ic_mr_button_connecting_24_dark = 2131165434;
 			
-			// aapt resource value: 0x7f0200ef
-			public const int ic_mr_button_connecting_22_dark = 2130837743;
+			// aapt resource value: 0x7F0700FB
+			public const int ic_mr_button_connecting_24_light = 2131165435;
 			
-			// aapt resource value: 0x7f0200f0
-			public const int ic_mr_button_connecting_22_light = 2130837744;
+			// aapt resource value: 0x7F0700FC
+			public const int ic_mr_button_connecting_25_dark = 2131165436;
 			
-			// aapt resource value: 0x7f0200f1
-			public const int ic_mr_button_connecting_23_dark = 2130837745;
+			// aapt resource value: 0x7F0700FD
+			public const int ic_mr_button_connecting_25_light = 2131165437;
 			
-			// aapt resource value: 0x7f0200f2
-			public const int ic_mr_button_connecting_23_light = 2130837746;
+			// aapt resource value: 0x7F0700FE
+			public const int ic_mr_button_connecting_26_dark = 2131165438;
 			
-			// aapt resource value: 0x7f0200f3
-			public const int ic_mr_button_connecting_24_dark = 2130837747;
+			// aapt resource value: 0x7F0700FF
+			public const int ic_mr_button_connecting_26_light = 2131165439;
 			
-			// aapt resource value: 0x7f0200f4
-			public const int ic_mr_button_connecting_24_light = 2130837748;
+			// aapt resource value: 0x7F070100
+			public const int ic_mr_button_connecting_27_dark = 2131165440;
 			
-			// aapt resource value: 0x7f0200f5
-			public const int ic_mr_button_connecting_25_dark = 2130837749;
+			// aapt resource value: 0x7F070101
+			public const int ic_mr_button_connecting_27_light = 2131165441;
 			
-			// aapt resource value: 0x7f0200f6
-			public const int ic_mr_button_connecting_25_light = 2130837750;
+			// aapt resource value: 0x7F070102
+			public const int ic_mr_button_connecting_28_dark = 2131165442;
 			
-			// aapt resource value: 0x7f0200f7
-			public const int ic_mr_button_connecting_26_dark = 2130837751;
+			// aapt resource value: 0x7F070103
+			public const int ic_mr_button_connecting_28_light = 2131165443;
 			
-			// aapt resource value: 0x7f0200f8
-			public const int ic_mr_button_connecting_26_light = 2130837752;
+			// aapt resource value: 0x7F070104
+			public const int ic_mr_button_connecting_29_dark = 2131165444;
 			
-			// aapt resource value: 0x7f0200f9
-			public const int ic_mr_button_connecting_27_dark = 2130837753;
+			// aapt resource value: 0x7F070105
+			public const int ic_mr_button_connecting_29_light = 2131165445;
 			
-			// aapt resource value: 0x7f0200fa
-			public const int ic_mr_button_connecting_27_light = 2130837754;
+			// aapt resource value: 0x7F070106
+			public const int ic_mr_button_connecting_30_dark = 2131165446;
 			
-			// aapt resource value: 0x7f0200fb
-			public const int ic_mr_button_connecting_28_dark = 2130837755;
+			// aapt resource value: 0x7F070107
+			public const int ic_mr_button_connecting_30_light = 2131165447;
 			
-			// aapt resource value: 0x7f0200fc
-			public const int ic_mr_button_connecting_28_light = 2130837756;
+			// aapt resource value: 0x7F070108
+			public const int ic_mr_button_disabled_dark = 2131165448;
 			
-			// aapt resource value: 0x7f0200fd
-			public const int ic_mr_button_connecting_29_dark = 2130837757;
+			// aapt resource value: 0x7F070109
+			public const int ic_mr_button_disabled_light = 2131165449;
 			
-			// aapt resource value: 0x7f0200fe
-			public const int ic_mr_button_connecting_29_light = 2130837758;
+			// aapt resource value: 0x7F07010A
+			public const int ic_mr_button_disconnected_dark = 2131165450;
 			
-			// aapt resource value: 0x7f0200ff
-			public const int ic_mr_button_connecting_30_dark = 2130837759;
+			// aapt resource value: 0x7F07010B
+			public const int ic_mr_button_disconnected_light = 2131165451;
 			
-			// aapt resource value: 0x7f020100
-			public const int ic_mr_button_connecting_30_light = 2130837760;
+			// aapt resource value: 0x7F07010C
+			public const int ic_mr_button_grey = 2131165452;
 			
-			// aapt resource value: 0x7f020101
-			public const int ic_mr_button_disabled_dark = 2130837761;
+			// aapt resource value: 0x7F07010D
+			public const int ic_mtrl_chip_checked_black = 2131165453;
 			
-			// aapt resource value: 0x7f020102
-			public const int ic_mr_button_disabled_light = 2130837762;
+			// aapt resource value: 0x7F07010E
+			public const int ic_mtrl_chip_checked_circle = 2131165454;
 			
-			// aapt resource value: 0x7f020103
-			public const int ic_mr_button_disconnected_dark = 2130837763;
+			// aapt resource value: 0x7F07010F
+			public const int ic_mtrl_chip_close_circle = 2131165455;
 			
-			// aapt resource value: 0x7f020104
-			public const int ic_mr_button_disconnected_light = 2130837764;
+			// aapt resource value: 0x7F070110
+			public const int ic_vol_type_speaker_dark = 2131165456;
 			
-			// aapt resource value: 0x7f020105
-			public const int ic_mr_button_grey = 2130837765;
+			// aapt resource value: 0x7F070111
+			public const int ic_vol_type_speaker_group_dark = 2131165457;
 			
-			// aapt resource value: 0x7f020106
-			public const int ic_vol_type_speaker_dark = 2130837766;
+			// aapt resource value: 0x7F070112
+			public const int ic_vol_type_speaker_group_light = 2131165458;
 			
-			// aapt resource value: 0x7f020107
-			public const int ic_vol_type_speaker_group_dark = 2130837767;
+			// aapt resource value: 0x7F070113
+			public const int ic_vol_type_speaker_light = 2131165459;
 			
-			// aapt resource value: 0x7f020108
-			public const int ic_vol_type_speaker_group_light = 2130837768;
+			// aapt resource value: 0x7F070114
+			public const int ic_vol_type_tv_dark = 2131165460;
 			
-			// aapt resource value: 0x7f020109
-			public const int ic_vol_type_speaker_light = 2130837769;
+			// aapt resource value: 0x7F070115
+			public const int ic_vol_type_tv_light = 2131165461;
 			
-			// aapt resource value: 0x7f02010a
-			public const int ic_vol_type_tv_dark = 2130837770;
+			// aapt resource value: 0x7F070116
+			public const int mr_button_connected_dark = 2131165462;
 			
-			// aapt resource value: 0x7f02010b
-			public const int ic_vol_type_tv_light = 2130837771;
+			// aapt resource value: 0x7F070117
+			public const int mr_button_connected_light = 2131165463;
 			
-			// aapt resource value: 0x7f02010c
-			public const int mr_button_connected_dark = 2130837772;
+			// aapt resource value: 0x7F070118
+			public const int mr_button_connecting_dark = 2131165464;
 			
-			// aapt resource value: 0x7f02010d
-			public const int mr_button_connected_light = 2130837773;
+			// aapt resource value: 0x7F070119
+			public const int mr_button_connecting_light = 2131165465;
 			
-			// aapt resource value: 0x7f02010e
-			public const int mr_button_connecting_dark = 2130837774;
+			// aapt resource value: 0x7F07011A
+			public const int mr_button_dark = 2131165466;
 			
-			// aapt resource value: 0x7f02010f
-			public const int mr_button_connecting_light = 2130837775;
+			// aapt resource value: 0x7F07011B
+			public const int mr_button_light = 2131165467;
 			
-			// aapt resource value: 0x7f020110
-			public const int mr_button_dark = 2130837776;
+			// aapt resource value: 0x7F07011C
+			public const int mr_dialog_close_dark = 2131165468;
 			
-			// aapt resource value: 0x7f020111
-			public const int mr_button_light = 2130837777;
+			// aapt resource value: 0x7F07011D
+			public const int mr_dialog_close_light = 2131165469;
 			
-			// aapt resource value: 0x7f020112
-			public const int mr_dialog_close_dark = 2130837778;
+			// aapt resource value: 0x7F07011E
+			public const int mr_dialog_material_background_dark = 2131165470;
 			
-			// aapt resource value: 0x7f020113
-			public const int mr_dialog_close_light = 2130837779;
+			// aapt resource value: 0x7F07011F
+			public const int mr_dialog_material_background_light = 2131165471;
 			
-			// aapt resource value: 0x7f020114
-			public const int mr_dialog_material_background_dark = 2130837780;
+			// aapt resource value: 0x7F070120
+			public const int mr_group_collapse = 2131165472;
 			
-			// aapt resource value: 0x7f020115
-			public const int mr_dialog_material_background_light = 2130837781;
+			// aapt resource value: 0x7F070121
+			public const int mr_group_expand = 2131165473;
 			
-			// aapt resource value: 0x7f020116
-			public const int mr_group_collapse = 2130837782;
+			// aapt resource value: 0x7F070122
+			public const int mr_media_pause_dark = 2131165474;
 			
-			// aapt resource value: 0x7f020117
-			public const int mr_group_expand = 2130837783;
+			// aapt resource value: 0x7F070123
+			public const int mr_media_pause_light = 2131165475;
 			
-			// aapt resource value: 0x7f020118
-			public const int mr_media_pause_dark = 2130837784;
+			// aapt resource value: 0x7F070124
+			public const int mr_media_play_dark = 2131165476;
 			
-			// aapt resource value: 0x7f020119
-			public const int mr_media_pause_light = 2130837785;
+			// aapt resource value: 0x7F070125
+			public const int mr_media_play_light = 2131165477;
 			
-			// aapt resource value: 0x7f02011a
-			public const int mr_media_play_dark = 2130837786;
+			// aapt resource value: 0x7F070126
+			public const int mr_media_stop_dark = 2131165478;
 			
-			// aapt resource value: 0x7f02011b
-			public const int mr_media_play_light = 2130837787;
+			// aapt resource value: 0x7F070127
+			public const int mr_media_stop_light = 2131165479;
 			
-			// aapt resource value: 0x7f02011c
-			public const int mr_media_stop_dark = 2130837788;
+			// aapt resource value: 0x7F070128
+			public const int mr_vol_type_audiotrack_dark = 2131165480;
 			
-			// aapt resource value: 0x7f02011d
-			public const int mr_media_stop_light = 2130837789;
+			// aapt resource value: 0x7F070129
+			public const int mr_vol_type_audiotrack_light = 2131165481;
 			
-			// aapt resource value: 0x7f02011e
-			public const int mr_vol_type_audiotrack_dark = 2130837790;
+			// aapt resource value: 0x7F07012A
+			public const int mtrl_snackbar_background = 2131165482;
 			
-			// aapt resource value: 0x7f02011f
-			public const int mr_vol_type_audiotrack_light = 2130837791;
+			// aapt resource value: 0x7F07012B
+			public const int mtrl_tabs_default_indicator = 2131165483;
 			
-			// aapt resource value: 0x7f020120
-			public const int navigation_empty_icon = 2130837792;
+			// aapt resource value: 0x7F07012C
+			public const int navigation_empty_icon = 2131165484;
 			
-			// aapt resource value: 0x7f020121
-			public const int notification_action_background = 2130837793;
+			// aapt resource value: 0x7F07012D
+			public const int notification_action_background = 2131165485;
 			
-			// aapt resource value: 0x7f020122
-			public const int notification_bg = 2130837794;
+			// aapt resource value: 0x7F07012E
+			public const int notification_bg = 2131165486;
 			
-			// aapt resource value: 0x7f020123
-			public const int notification_bg_low = 2130837795;
+			// aapt resource value: 0x7F07012F
+			public const int notification_bg_low = 2131165487;
 			
-			// aapt resource value: 0x7f020124
-			public const int notification_bg_low_normal = 2130837796;
+			// aapt resource value: 0x7F070130
+			public const int notification_bg_low_normal = 2131165488;
 			
-			// aapt resource value: 0x7f020125
-			public const int notification_bg_low_pressed = 2130837797;
+			// aapt resource value: 0x7F070131
+			public const int notification_bg_low_pressed = 2131165489;
 			
-			// aapt resource value: 0x7f020126
-			public const int notification_bg_normal = 2130837798;
+			// aapt resource value: 0x7F070132
+			public const int notification_bg_normal = 2131165490;
 			
-			// aapt resource value: 0x7f020127
-			public const int notification_bg_normal_pressed = 2130837799;
+			// aapt resource value: 0x7F070133
+			public const int notification_bg_normal_pressed = 2131165491;
 			
-			// aapt resource value: 0x7f020128
-			public const int notification_icon_background = 2130837800;
+			// aapt resource value: 0x7F070134
+			public const int notification_icon_background = 2131165492;
 			
-			// aapt resource value: 0x7f02012d
-			public const int notification_template_icon_bg = 2130837805;
+			// aapt resource value: 0x7F070135
+			public const int notification_template_icon_bg = 2131165493;
 			
-			// aapt resource value: 0x7f02012e
-			public const int notification_template_icon_low_bg = 2130837806;
+			// aapt resource value: 0x7F070136
+			public const int notification_template_icon_low_bg = 2131165494;
 			
-			// aapt resource value: 0x7f020129
-			public const int notification_tile_bg = 2130837801;
+			// aapt resource value: 0x7F070137
+			public const int notification_tile_bg = 2131165495;
 			
-			// aapt resource value: 0x7f02012a
-			public const int notify_panel_notification_icon_bg = 2130837802;
+			// aapt resource value: 0x7F070138
+			public const int notify_panel_notification_icon_bg = 2131165496;
 			
-			// aapt resource value: 0x7f02012b
-			public const int tooltip_frame_dark = 2130837803;
+			// aapt resource value: 0x7F070139
+			public const int tooltip_frame_dark = 2131165497;
 			
-			// aapt resource value: 0x7f02012c
-			public const int tooltip_frame_light = 2130837804;
+			// aapt resource value: 0x7F07013A
+			public const int tooltip_frame_light = 2131165498;
 			
 			static Drawable()
 			{
@@ -5033,647 +6275,767 @@ namespace SextantSample.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f090032
-			public const int ALT = 2131296306;
+			// aapt resource value: 0x7F080006
+			public const int action0 = 2131230726;
 			
-			// aapt resource value: 0x7f090033
-			public const int CTRL = 2131296307;
+			// aapt resource value: 0x7F080018
+			public const int actions = 2131230744;
 			
-			// aapt resource value: 0x7f090034
-			public const int FUNCTION = 2131296308;
+			// aapt resource value: 0x7F080007
+			public const int action_bar = 2131230727;
 			
-			// aapt resource value: 0x7f090035
-			public const int META = 2131296309;
+			// aapt resource value: 0x7F080008
+			public const int action_bar_activity_content = 2131230728;
 			
-			// aapt resource value: 0x7f090036
-			public const int SHIFT = 2131296310;
+			// aapt resource value: 0x7F080009
+			public const int action_bar_container = 2131230729;
 			
-			// aapt resource value: 0x7f090037
-			public const int SYM = 2131296311;
+			// aapt resource value: 0x7F08000A
+			public const int action_bar_root = 2131230730;
 			
-			// aapt resource value: 0x7f0900ba
-			public const int action0 = 2131296442;
+			// aapt resource value: 0x7F08000B
+			public const int action_bar_spinner = 2131230731;
 			
-			// aapt resource value: 0x7f09007c
-			public const int action_bar = 2131296380;
+			// aapt resource value: 0x7F08000C
+			public const int action_bar_subtitle = 2131230732;
 			
-			// aapt resource value: 0x7f090001
-			public const int action_bar_activity_content = 2131296257;
+			// aapt resource value: 0x7F08000D
+			public const int action_bar_title = 2131230733;
 			
-			// aapt resource value: 0x7f09007b
-			public const int action_bar_container = 2131296379;
+			// aapt resource value: 0x7F08000E
+			public const int action_container = 2131230734;
 			
-			// aapt resource value: 0x7f090077
-			public const int action_bar_root = 2131296375;
+			// aapt resource value: 0x7F08000F
+			public const int action_context_bar = 2131230735;
 			
-			// aapt resource value: 0x7f090002
-			public const int action_bar_spinner = 2131296258;
+			// aapt resource value: 0x7F080010
+			public const int action_divider = 2131230736;
 			
-			// aapt resource value: 0x7f09005b
-			public const int action_bar_subtitle = 2131296347;
+			// aapt resource value: 0x7F080011
+			public const int action_image = 2131230737;
 			
-			// aapt resource value: 0x7f09005a
-			public const int action_bar_title = 2131296346;
+			// aapt resource value: 0x7F080012
+			public const int action_menu_divider = 2131230738;
 			
-			// aapt resource value: 0x7f0900b7
-			public const int action_container = 2131296439;
+			// aapt resource value: 0x7F080013
+			public const int action_menu_presenter = 2131230739;
 			
-			// aapt resource value: 0x7f09007d
-			public const int action_context_bar = 2131296381;
+			// aapt resource value: 0x7F080014
+			public const int action_mode_bar = 2131230740;
 			
-			// aapt resource value: 0x7f0900be
-			public const int action_divider = 2131296446;
+			// aapt resource value: 0x7F080015
+			public const int action_mode_bar_stub = 2131230741;
 			
-			// aapt resource value: 0x7f0900b8
-			public const int action_image = 2131296440;
+			// aapt resource value: 0x7F080016
+			public const int action_mode_close_button = 2131230742;
 			
-			// aapt resource value: 0x7f090003
-			public const int action_menu_divider = 2131296259;
+			// aapt resource value: 0x7F080017
+			public const int action_text = 2131230743;
 			
-			// aapt resource value: 0x7f090004
-			public const int action_menu_presenter = 2131296260;
+			// aapt resource value: 0x7F080019
+			public const int activity_chooser_view_content = 2131230745;
 			
-			// aapt resource value: 0x7f090079
-			public const int action_mode_bar = 2131296377;
+			// aapt resource value: 0x7F08001A
+			public const int add = 2131230746;
 			
-			// aapt resource value: 0x7f090078
-			public const int action_mode_bar_stub = 2131296376;
+			// aapt resource value: 0x7F08001B
+			public const int alertTitle = 2131230747;
 			
-			// aapt resource value: 0x7f09005c
-			public const int action_mode_close_button = 2131296348;
+			// aapt resource value: 0x7F08001C
+			public const int all = 2131230748;
 			
-			// aapt resource value: 0x7f0900b9
-			public const int action_text = 2131296441;
+			// aapt resource value: 0x7F080000
+			public const int ALT = 2131230720;
 			
-			// aapt resource value: 0x7f0900c7
-			public const int actions = 2131296455;
+			// aapt resource value: 0x7F08001D
+			public const int always = 2131230749;
 			
-			// aapt resource value: 0x7f09005d
-			public const int activity_chooser_view_content = 2131296349;
+			// aapt resource value: 0x7F08001E
+			public const int async = 2131230750;
 			
-			// aapt resource value: 0x7f090027
-			public const int add = 2131296295;
+			// aapt resource value: 0x7F08001F
+			public const int auto = 2131230751;
 			
-			// aapt resource value: 0x7f090070
-			public const int alertTitle = 2131296368;
+			// aapt resource value: 0x7F080020
+			public const int beginning = 2131230752;
 			
-			// aapt resource value: 0x7f090052
-			public const int all = 2131296338;
+			// aapt resource value: 0x7F080021
+			public const int blocking = 2131230753;
 			
-			// aapt resource value: 0x7f090038
-			public const int always = 2131296312;
+			// aapt resource value: 0x7F080022
+			public const int bottom = 2131230754;
 			
-			// aapt resource value: 0x7f090056
-			public const int async = 2131296342;
+			// aapt resource value: 0x7F080023
+			public const int bottomtab_navarea = 2131230755;
 			
-			// aapt resource value: 0x7f090044
-			public const int auto = 2131296324;
+			// aapt resource value: 0x7F080024
+			public const int bottomtab_tabbar = 2131230756;
 			
-			// aapt resource value: 0x7f09002f
-			public const int beginning = 2131296303;
+			// aapt resource value: 0x7F080025
+			public const int browser_actions_header_text = 2131230757;
 			
-			// aapt resource value: 0x7f090057
-			public const int blocking = 2131296343;
+			// aapt resource value: 0x7F080028
+			public const int browser_actions_menu_items = 2131230760;
 			
-			// aapt resource value: 0x7f09003d
-			public const int bottom = 2131296317;
+			// aapt resource value: 0x7F080026
+			public const int browser_actions_menu_item_icon = 2131230758;
 			
-			// aapt resource value: 0x7f09008b
-			public const int bottomtab_navarea = 2131296395;
+			// aapt resource value: 0x7F080027
+			public const int browser_actions_menu_item_text = 2131230759;
 			
-			// aapt resource value: 0x7f09008c
-			public const int bottomtab_tabbar = 2131296396;
+			// aapt resource value: 0x7F080029
+			public const int browser_actions_menu_view = 2131230761;
 			
-			// aapt resource value: 0x7f090063
-			public const int buttonPanel = 2131296355;
+			// aapt resource value: 0x7F08002A
+			public const int buttonPanel = 2131230762;
 			
-			// aapt resource value: 0x7f0900bb
-			public const int cancel_action = 2131296443;
+			// aapt resource value: 0x7F08002B
+			public const int cancel_action = 2131230763;
 			
-			// aapt resource value: 0x7f090045
-			public const int center = 2131296325;
+			// aapt resource value: 0x7F08002C
+			public const int center = 2131230764;
 			
-			// aapt resource value: 0x7f090046
-			public const int center_horizontal = 2131296326;
+			// aapt resource value: 0x7F08002D
+			public const int center_horizontal = 2131230765;
 			
-			// aapt resource value: 0x7f090047
-			public const int center_vertical = 2131296327;
+			// aapt resource value: 0x7F08002E
+			public const int center_vertical = 2131230766;
 			
-			// aapt resource value: 0x7f090073
-			public const int checkbox = 2131296371;
+			// aapt resource value: 0x7F08002F
+			public const int checkbox = 2131230767;
 			
-			// aapt resource value: 0x7f0900c3
-			public const int chronometer = 2131296451;
+			// aapt resource value: 0x7F080030
+			public const int chronometer = 2131230768;
 			
-			// aapt resource value: 0x7f09004e
-			public const int clip_horizontal = 2131296334;
+			// aapt resource value: 0x7F080031
+			public const int clip_horizontal = 2131230769;
 			
-			// aapt resource value: 0x7f09004f
-			public const int clip_vertical = 2131296335;
+			// aapt resource value: 0x7F080032
+			public const int clip_vertical = 2131230770;
 			
-			// aapt resource value: 0x7f090039
-			public const int collapseActionView = 2131296313;
+			// aapt resource value: 0x7F080033
+			public const int collapseActionView = 2131230771;
 			
-			// aapt resource value: 0x7f09008f
-			public const int container = 2131296399;
+			// aapt resource value: 0x7F080034
+			public const int container = 2131230772;
 			
-			// aapt resource value: 0x7f090066
-			public const int contentPanel = 2131296358;
+			// aapt resource value: 0x7F080035
+			public const int content = 2131230773;
 			
-			// aapt resource value: 0x7f090090
-			public const int coordinator = 2131296400;
+			// aapt resource value: 0x7F080036
+			public const int contentPanel = 2131230774;
 			
-			// aapt resource value: 0x7f09006d
-			public const int custom = 2131296365;
+			// aapt resource value: 0x7F080037
+			public const int coordinator = 2131230775;
 			
-			// aapt resource value: 0x7f09006c
-			public const int customPanel = 2131296364;
+			// aapt resource value: 0x7F080001
+			public const int CTRL = 2131230721;
 			
-			// aapt resource value: 0x7f09007a
-			public const int decor_content_parent = 2131296378;
+			// aapt resource value: 0x7F080038
+			public const int custom = 2131230776;
 			
-			// aapt resource value: 0x7f090060
-			public const int default_activity_button = 2131296352;
+			// aapt resource value: 0x7F080039
+			public const int customPanel = 2131230777;
 			
-			// aapt resource value: 0x7f090092
-			public const int design_bottom_sheet = 2131296402;
+			// aapt resource value: 0x7F08003A
+			public const int decor_content_parent = 2131230778;
 			
-			// aapt resource value: 0x7f090099
-			public const int design_menu_item_action_area = 2131296409;
+			// aapt resource value: 0x7F08003B
+			public const int default_activity_button = 2131230779;
 			
-			// aapt resource value: 0x7f090098
-			public const int design_menu_item_action_area_stub = 2131296408;
+			// aapt resource value: 0x7F08003C
+			public const int design_bottom_sheet = 2131230780;
 			
-			// aapt resource value: 0x7f090097
-			public const int design_menu_item_text = 2131296407;
+			// aapt resource value: 0x7F08003D
+			public const int design_menu_item_action_area = 2131230781;
 			
-			// aapt resource value: 0x7f090096
-			public const int design_navigation_view = 2131296406;
+			// aapt resource value: 0x7F08003E
+			public const int design_menu_item_action_area_stub = 2131230782;
 			
-			// aapt resource value: 0x7f090020
-			public const int disableHome = 2131296288;
+			// aapt resource value: 0x7F08003F
+			public const int design_menu_item_text = 2131230783;
 			
-			// aapt resource value: 0x7f09007e
-			public const int edit_query = 2131296382;
+			// aapt resource value: 0x7F080040
+			public const int design_navigation_view = 2131230784;
 			
-			// aapt resource value: 0x7f090030
-			public const int end = 2131296304;
+			// aapt resource value: 0x7F080041
+			public const int disableHome = 2131230785;
 			
-			// aapt resource value: 0x7f0900c9
-			public const int end_padder = 2131296457;
+			// aapt resource value: 0x7F080042
+			public const int edit_query = 2131230786;
 			
-			// aapt resource value: 0x7f09003f
-			public const int enterAlways = 2131296319;
+			// aapt resource value: 0x7F080043
+			public const int end = 2131230787;
 			
-			// aapt resource value: 0x7f090040
-			public const int enterAlwaysCollapsed = 2131296320;
+			// aapt resource value: 0x7F080044
+			public const int end_padder = 2131230788;
 			
-			// aapt resource value: 0x7f090041
-			public const int exitUntilCollapsed = 2131296321;
+			// aapt resource value: 0x7F080045
+			public const int enterAlways = 2131230789;
 			
-			// aapt resource value: 0x7f09005e
-			public const int expand_activities_button = 2131296350;
+			// aapt resource value: 0x7F080046
+			public const int enterAlwaysCollapsed = 2131230790;
 			
-			// aapt resource value: 0x7f090072
-			public const int expanded_menu = 2131296370;
+			// aapt resource value: 0x7F080047
+			public const int exitUntilCollapsed = 2131230791;
 			
-			// aapt resource value: 0x7f090050
-			public const int fill = 2131296336;
+			// aapt resource value: 0x7F080049
+			public const int expanded_menu = 2131230793;
 			
-			// aapt resource value: 0x7f090051
-			public const int fill_horizontal = 2131296337;
+			// aapt resource value: 0x7F080048
+			public const int expand_activities_button = 2131230792;
 			
-			// aapt resource value: 0x7f090048
-			public const int fill_vertical = 2131296328;
+			// aapt resource value: 0x7F08004A
+			public const int fill = 2131230794;
 			
-			// aapt resource value: 0x7f090054
-			public const int @fixed = 2131296340;
+			// aapt resource value: 0x7F08004D
+			public const int filled = 2131230797;
 			
-			// aapt resource value: 0x7f09009b
-			public const int flyoutcontent_appbar = 2131296411;
+			// aapt resource value: 0x7F08004B
+			public const int fill_horizontal = 2131230795;
 			
-			// aapt resource value: 0x7f09009c
-			public const int flyoutcontent_recycler = 2131296412;
+			// aapt resource value: 0x7F08004C
+			public const int fill_vertical = 2131230796;
 			
-			// aapt resource value: 0x7f090058
-			public const int forever = 2131296344;
+			// aapt resource value: 0x7F08004E
+			public const int @fixed = 2131230798;
 			
-			// aapt resource value: 0x7f09000a
-			public const int ghost_view = 2131296266;
+			// aapt resource value: 0x7F08004F
+			public const int flyoutcontent_appbar = 2131230799;
 			
-			// aapt resource value: 0x7f090005
-			public const int home = 2131296261;
+			// aapt resource value: 0x7F080050
+			public const int flyoutcontent_recycler = 2131230800;
 			
-			// aapt resource value: 0x7f090021
-			public const int homeAsUp = 2131296289;
+			// aapt resource value: 0x7F080051
+			public const int forever = 2131230801;
 			
-			// aapt resource value: 0x7f090062
-			public const int icon = 2131296354;
+			// aapt resource value: 0x7F080002
+			public const int FUNCTION = 2131230722;
 			
-			// aapt resource value: 0x7f0900c8
-			public const int icon_group = 2131296456;
+			// aapt resource value: 0x7F080052
+			public const int ghost_view = 2131230802;
 			
-			// aapt resource value: 0x7f09003a
-			public const int ifRoom = 2131296314;
+			// aapt resource value: 0x7F080053
+			public const int group_divider = 2131230803;
 			
-			// aapt resource value: 0x7f09005f
-			public const int image = 2131296351;
+			// aapt resource value: 0x7F080054
+			public const int home = 2131230804;
 			
-			// aapt resource value: 0x7f0900c4
-			public const int info = 2131296452;
+			// aapt resource value: 0x7F080055
+			public const int homeAsUp = 2131230805;
 			
-			// aapt resource value: 0x7f090059
-			public const int italic = 2131296345;
+			// aapt resource value: 0x7F080056
+			public const int icon = 2131230806;
 			
-			// aapt resource value: 0x7f090000
-			public const int item_touch_helper_previous_elevation = 2131296256;
+			// aapt resource value: 0x7F080057
+			public const int icon_group = 2131230807;
 			
-			// aapt resource value: 0x7f09008e
-			public const int largeLabel = 2131296398;
+			// aapt resource value: 0x7F080058
+			public const int ifRoom = 2131230808;
 			
-			// aapt resource value: 0x7f090049
-			public const int left = 2131296329;
+			// aapt resource value: 0x7F080059
+			public const int image = 2131230809;
 			
-			// aapt resource value: 0x7f090017
-			public const int line1 = 2131296279;
+			// aapt resource value: 0x7F08005A
+			public const int info = 2131230810;
 			
-			// aapt resource value: 0x7f090018
-			public const int line3 = 2131296280;
+			// aapt resource value: 0x7F08005B
+			public const int italic = 2131230811;
 			
-			// aapt resource value: 0x7f09001d
-			public const int listMode = 2131296285;
+			// aapt resource value: 0x7F08005C
+			public const int item_touch_helper_previous_elevation = 2131230812;
 			
-			// aapt resource value: 0x7f090061
-			public const int list_item = 2131296353;
+			// aapt resource value: 0x7F08005D
+			public const int labeled = 2131230813;
 			
-			// aapt resource value: 0x7f0900ca
-			public const int main_appbar = 2131296458;
+			// aapt resource value: 0x7F08005E
+			public const int largeLabel = 2131230814;
 			
-			// aapt resource value: 0x7f0900cd
-			public const int main_scrollview = 2131296461;
+			// aapt resource value: 0x7F08005F
+			public const int left = 2131230815;
 			
-			// aapt resource value: 0x7f0900cc
-			public const int main_tablayout = 2131296460;
+			// aapt resource value: 0x7F080060
+			public const int line1 = 2131230816;
 			
-			// aapt resource value: 0x7f0900cb
-			public const int main_toolbar = 2131296459;
+			// aapt resource value: 0x7F080061
+			public const int line3 = 2131230817;
 			
-			// aapt resource value: 0x7f0900d5
-			public const int masked = 2131296469;
+			// aapt resource value: 0x7F080062
+			public const int listMode = 2131230818;
 			
-			// aapt resource value: 0x7f0900bd
-			public const int media_actions = 2131296445;
+			// aapt resource value: 0x7F080063
+			public const int list_item = 2131230819;
 			
-			// aapt resource value: 0x7f0900d3
-			public const int message = 2131296467;
+			// aapt resource value: 0x7F080064
+			public const int main_appbar = 2131230820;
 			
-			// aapt resource value: 0x7f090031
-			public const int middle = 2131296305;
+			// aapt resource value: 0x7F080065
+			public const int main_tablayout = 2131230821;
 			
-			// aapt resource value: 0x7f090053
-			public const int mini = 2131296339;
+			// aapt resource value: 0x7F080066
+			public const int main_toolbar = 2131230822;
 			
-			// aapt resource value: 0x7f0900a9
-			public const int mr_art = 2131296425;
+			// aapt resource value: 0x7F080067
+			public const int main_viewpager = 2131230823;
 			
-			// aapt resource value: 0x7f09009e
-			public const int mr_chooser_list = 2131296414;
+			// aapt resource value: 0x7F080068
+			public const int masked = 2131230824;
 			
-			// aapt resource value: 0x7f0900a1
-			public const int mr_chooser_route_desc = 2131296417;
+			// aapt resource value: 0x7F080069
+			public const int media_actions = 2131230825;
 			
-			// aapt resource value: 0x7f09009f
-			public const int mr_chooser_route_icon = 2131296415;
+			// aapt resource value: 0x7F08006A
+			public const int message = 2131230826;
 			
-			// aapt resource value: 0x7f0900a0
-			public const int mr_chooser_route_name = 2131296416;
+			// aapt resource value: 0x7F080003
+			public const int META = 2131230723;
 			
-			// aapt resource value: 0x7f09009d
-			public const int mr_chooser_title = 2131296413;
+			// aapt resource value: 0x7F08006B
+			public const int middle = 2131230827;
 			
-			// aapt resource value: 0x7f0900a6
-			public const int mr_close = 2131296422;
+			// aapt resource value: 0x7F08006C
+			public const int mini = 2131230828;
 			
-			// aapt resource value: 0x7f0900ac
-			public const int mr_control_divider = 2131296428;
+			// aapt resource value: 0x7F08006D
+			public const int mr_art = 2131230829;
 			
-			// aapt resource value: 0x7f0900b2
-			public const int mr_control_playback_ctrl = 2131296434;
+			// aapt resource value: 0x7F08006E
+			public const int mr_cast_checkbox = 2131230830;
 			
-			// aapt resource value: 0x7f0900b5
-			public const int mr_control_subtitle = 2131296437;
+			// aapt resource value: 0x7F08006F
+			public const int mr_cast_close_button = 2131230831;
 			
-			// aapt resource value: 0x7f0900b4
-			public const int mr_control_title = 2131296436;
+			// aapt resource value: 0x7F080070
+			public const int mr_cast_group_icon = 2131230832;
 			
-			// aapt resource value: 0x7f0900b3
-			public const int mr_control_title_container = 2131296435;
+			// aapt resource value: 0x7F080071
+			public const int mr_cast_group_name = 2131230833;
 			
-			// aapt resource value: 0x7f0900a7
-			public const int mr_custom_control = 2131296423;
+			// aapt resource value: 0x7F080072
+			public const int mr_cast_list = 2131230834;
 			
-			// aapt resource value: 0x7f0900a8
-			public const int mr_default_control = 2131296424;
+			// aapt resource value: 0x7F080073
+			public const int mr_cast_meta = 2131230835;
 			
-			// aapt resource value: 0x7f0900a3
-			public const int mr_dialog_area = 2131296419;
+			// aapt resource value: 0x7F080074
+			public const int mr_cast_meta_art = 2131230836;
 			
-			// aapt resource value: 0x7f0900a2
-			public const int mr_expandable_area = 2131296418;
+			// aapt resource value: 0x7F080075
+			public const int mr_cast_meta_subtitle = 2131230837;
 			
-			// aapt resource value: 0x7f0900b6
-			public const int mr_group_expand_collapse = 2131296438;
+			// aapt resource value: 0x7F080076
+			public const int mr_cast_meta_title = 2131230838;
 			
-			// aapt resource value: 0x7f0900aa
-			public const int mr_media_main_control = 2131296426;
+			// aapt resource value: 0x7F080077
+			public const int mr_cast_route_icon = 2131230839;
 			
-			// aapt resource value: 0x7f0900a5
-			public const int mr_name = 2131296421;
+			// aapt resource value: 0x7F080078
+			public const int mr_cast_route_name = 2131230840;
 			
-			// aapt resource value: 0x7f0900ab
-			public const int mr_playback_control = 2131296427;
+			// aapt resource value: 0x7F080079
+			public const int mr_cast_stop_button = 2131230841;
 			
-			// aapt resource value: 0x7f0900a4
-			public const int mr_title_bar = 2131296420;
+			// aapt resource value: 0x7F08007A
+			public const int mr_cast_volume_layout = 2131230842;
 			
-			// aapt resource value: 0x7f0900ad
-			public const int mr_volume_control = 2131296429;
+			// aapt resource value: 0x7F08007B
+			public const int mr_cast_volume_slider = 2131230843;
 			
-			// aapt resource value: 0x7f0900ae
-			public const int mr_volume_group_list = 2131296430;
+			// aapt resource value: 0x7F08007C
+			public const int mr_chooser_list = 2131230844;
 			
-			// aapt resource value: 0x7f0900b0
-			public const int mr_volume_item_icon = 2131296432;
+			// aapt resource value: 0x7F08007D
+			public const int mr_chooser_route_desc = 2131230845;
 			
-			// aapt resource value: 0x7f0900b1
-			public const int mr_volume_slider = 2131296433;
+			// aapt resource value: 0x7F08007E
+			public const int mr_chooser_route_icon = 2131230846;
 			
-			// aapt resource value: 0x7f090028
-			public const int multiply = 2131296296;
+			// aapt resource value: 0x7F08007F
+			public const int mr_chooser_route_name = 2131230847;
 			
-			// aapt resource value: 0x7f090095
-			public const int navigation_header_container = 2131296405;
+			// aapt resource value: 0x7F080080
+			public const int mr_chooser_title = 2131230848;
 			
-			// aapt resource value: 0x7f09003b
-			public const int never = 2131296315;
+			// aapt resource value: 0x7F080081
+			public const int mr_close = 2131230849;
 			
-			// aapt resource value: 0x7f090022
-			public const int none = 2131296290;
+			// aapt resource value: 0x7F080082
+			public const int mr_control_divider = 2131230850;
 			
-			// aapt resource value: 0x7f09001e
-			public const int normal = 2131296286;
+			// aapt resource value: 0x7F080083
+			public const int mr_control_playback_ctrl = 2131230851;
 			
-			// aapt resource value: 0x7f0900c6
-			public const int notification_background = 2131296454;
+			// aapt resource value: 0x7F080084
+			public const int mr_control_subtitle = 2131230852;
 			
-			// aapt resource value: 0x7f0900c0
-			public const int notification_main_column = 2131296448;
+			// aapt resource value: 0x7F080085
+			public const int mr_control_title = 2131230853;
 			
-			// aapt resource value: 0x7f0900bf
-			public const int notification_main_column_container = 2131296447;
+			// aapt resource value: 0x7F080086
+			public const int mr_control_title_container = 2131230854;
 			
-			// aapt resource value: 0x7f09004c
-			public const int parallax = 2131296332;
+			// aapt resource value: 0x7F080087
+			public const int mr_custom_control = 2131230855;
 			
-			// aapt resource value: 0x7f090065
-			public const int parentPanel = 2131296357;
+			// aapt resource value: 0x7F080088
+			public const int mr_default_control = 2131230856;
 			
-			// aapt resource value: 0x7f09000b
-			public const int parent_matrix = 2131296267;
+			// aapt resource value: 0x7F080089
+			public const int mr_dialog_area = 2131230857;
 			
-			// aapt resource value: 0x7f09004d
-			public const int pin = 2131296333;
+			// aapt resource value: 0x7F08008A
+			public const int mr_dialog_header_name = 2131230858;
 			
-			// aapt resource value: 0x7f090006
-			public const int progress_circular = 2131296262;
+			// aapt resource value: 0x7F08008B
+			public const int mr_expandable_area = 2131230859;
 			
-			// aapt resource value: 0x7f090007
-			public const int progress_horizontal = 2131296263;
+			// aapt resource value: 0x7F08008C
+			public const int mr_group_expand_collapse = 2131230860;
 			
-			// aapt resource value: 0x7f090075
-			public const int radio = 2131296373;
+			// aapt resource value: 0x7F08008D
+			public const int mr_group_volume_route_name = 2131230861;
 			
-			// aapt resource value: 0x7f09004a
-			public const int right = 2131296330;
+			// aapt resource value: 0x7F08008E
+			public const int mr_group_volume_slider = 2131230862;
 			
-			// aapt resource value: 0x7f0900c5
-			public const int right_icon = 2131296453;
+			// aapt resource value: 0x7F08008F
+			public const int mr_media_main_control = 2131230863;
 			
-			// aapt resource value: 0x7f0900c1
-			public const int right_side = 2131296449;
+			// aapt resource value: 0x7F080090
+			public const int mr_name = 2131230864;
 			
-			// aapt resource value: 0x7f09000c
-			public const int save_image_matrix = 2131296268;
+			// aapt resource value: 0x7F080091
+			public const int mr_picker_close_button = 2131230865;
 			
-			// aapt resource value: 0x7f09000d
-			public const int save_non_transition_alpha = 2131296269;
+			// aapt resource value: 0x7F080092
+			public const int mr_picker_list = 2131230866;
 			
-			// aapt resource value: 0x7f09000e
-			public const int save_scale_type = 2131296270;
+			// aapt resource value: 0x7F080093
+			public const int mr_picker_route_icon = 2131230867;
 			
-			// aapt resource value: 0x7f090029
-			public const int screen = 2131296297;
+			// aapt resource value: 0x7F080094
+			public const int mr_picker_route_name = 2131230868;
 			
-			// aapt resource value: 0x7f090042
-			public const int scroll = 2131296322;
+			// aapt resource value: 0x7F080095
+			public const int mr_playback_control = 2131230869;
 			
-			// aapt resource value: 0x7f09006b
-			public const int scrollIndicatorDown = 2131296363;
+			// aapt resource value: 0x7F080096
+			public const int mr_title_bar = 2131230870;
 			
-			// aapt resource value: 0x7f090067
-			public const int scrollIndicatorUp = 2131296359;
+			// aapt resource value: 0x7F080097
+			public const int mr_volume_control = 2131230871;
 			
-			// aapt resource value: 0x7f090068
-			public const int scrollView = 2131296360;
+			// aapt resource value: 0x7F080098
+			public const int mr_volume_group_list = 2131230872;
 			
-			// aapt resource value: 0x7f090055
-			public const int scrollable = 2131296341;
+			// aapt resource value: 0x7F080099
+			public const int mr_volume_item_icon = 2131230873;
 			
-			// aapt resource value: 0x7f090080
-			public const int search_badge = 2131296384;
+			// aapt resource value: 0x7F08009A
+			public const int mr_volume_slider = 2131230874;
 			
-			// aapt resource value: 0x7f09007f
-			public const int search_bar = 2131296383;
+			// aapt resource value: 0x7F08009B
+			public const int mtrl_child_content_container = 2131230875;
 			
-			// aapt resource value: 0x7f090081
-			public const int search_button = 2131296385;
+			// aapt resource value: 0x7F08009C
+			public const int mtrl_internal_children_alpha_tag = 2131230876;
 			
-			// aapt resource value: 0x7f090086
-			public const int search_close_btn = 2131296390;
+			// aapt resource value: 0x7F08009D
+			public const int multiply = 2131230877;
 			
-			// aapt resource value: 0x7f090082
-			public const int search_edit_frame = 2131296386;
+			// aapt resource value: 0x7F08009E
+			public const int navigation_header_container = 2131230878;
 			
-			// aapt resource value: 0x7f090088
-			public const int search_go_btn = 2131296392;
+			// aapt resource value: 0x7F08009F
+			public const int never = 2131230879;
 			
-			// aapt resource value: 0x7f090083
-			public const int search_mag_icon = 2131296387;
+			// aapt resource value: 0x7F0800A0
+			public const int none = 2131230880;
 			
-			// aapt resource value: 0x7f090084
-			public const int search_plate = 2131296388;
+			// aapt resource value: 0x7F0800A1
+			public const int normal = 2131230881;
 			
-			// aapt resource value: 0x7f090085
-			public const int search_src_text = 2131296389;
+			// aapt resource value: 0x7F0800A2
+			public const int notification_background = 2131230882;
 			
-			// aapt resource value: 0x7f090089
-			public const int search_voice_btn = 2131296393;
+			// aapt resource value: 0x7F0800A3
+			public const int notification_main_column = 2131230883;
 			
-			// aapt resource value: 0x7f09008a
-			public const int select_dialog_listview = 2131296394;
+			// aapt resource value: 0x7F0800A4
+			public const int notification_main_column_container = 2131230884;
 			
-			// aapt resource value: 0x7f0900ce
-			public const int shellcontent_appbar = 2131296462;
+			// aapt resource value: 0x7F0800A5
+			public const int outline = 2131230885;
 			
-			// aapt resource value: 0x7f0900d0
-			public const int shellcontent_scrollview = 2131296464;
+			// aapt resource value: 0x7F0800A6
+			public const int parallax = 2131230886;
 			
-			// aapt resource value: 0x7f0900cf
-			public const int shellcontent_toolbar = 2131296463;
+			// aapt resource value: 0x7F0800A7
+			public const int parentPanel = 2131230887;
 			
-			// aapt resource value: 0x7f090074
-			public const int shortcut = 2131296372;
+			// aapt resource value: 0x7F0800A8
+			public const int parent_matrix = 2131230888;
 			
-			// aapt resource value: 0x7f090023
-			public const int showCustom = 2131296291;
+			// aapt resource value: 0x7F0800A9
+			public const int pin = 2131230889;
 			
-			// aapt resource value: 0x7f090024
-			public const int showHome = 2131296292;
+			// aapt resource value: 0x7F0800AA
+			public const int progress_circular = 2131230890;
 			
-			// aapt resource value: 0x7f090025
-			public const int showTitle = 2131296293;
+			// aapt resource value: 0x7F0800AB
+			public const int progress_horizontal = 2131230891;
 			
-			// aapt resource value: 0x7f0900d1
-			public const int sliding_tabs = 2131296465;
+			// aapt resource value: 0x7F0800AC
+			public const int radio = 2131230892;
 			
-			// aapt resource value: 0x7f09008d
-			public const int smallLabel = 2131296397;
+			// aapt resource value: 0x7F0800AD
+			public const int right = 2131230893;
 			
-			// aapt resource value: 0x7f090094
-			public const int snackbar_action = 2131296404;
+			// aapt resource value: 0x7F0800AE
+			public const int right_icon = 2131230894;
 			
-			// aapt resource value: 0x7f090093
-			public const int snackbar_text = 2131296403;
+			// aapt resource value: 0x7F0800AF
+			public const int right_side = 2131230895;
 			
-			// aapt resource value: 0x7f090043
-			public const int snap = 2131296323;
+			// aapt resource value: 0x7F0800B0
+			public const int save_image_matrix = 2131230896;
 			
-			// aapt resource value: 0x7f090064
-			public const int spacer = 2131296356;
+			// aapt resource value: 0x7F0800B1
+			public const int save_non_transition_alpha = 2131230897;
 			
-			// aapt resource value: 0x7f090008
-			public const int split_action_bar = 2131296264;
+			// aapt resource value: 0x7F0800B2
+			public const int save_scale_type = 2131230898;
 			
-			// aapt resource value: 0x7f09002a
-			public const int src_atop = 2131296298;
+			// aapt resource value: 0x7F0800B3
+			public const int screen = 2131230899;
 			
-			// aapt resource value: 0x7f09002b
-			public const int src_in = 2131296299;
+			// aapt resource value: 0x7F0800B4
+			public const int scroll = 2131230900;
 			
-			// aapt resource value: 0x7f09002c
-			public const int src_over = 2131296300;
+			// aapt resource value: 0x7F0800B8
+			public const int scrollable = 2131230904;
 			
-			// aapt resource value: 0x7f09004b
-			public const int start = 2131296331;
+			// aapt resource value: 0x7F0800B5
+			public const int scrollIndicatorDown = 2131230901;
 			
-			// aapt resource value: 0x7f0900bc
-			public const int status_bar_latest_event_content = 2131296444;
+			// aapt resource value: 0x7F0800B6
+			public const int scrollIndicatorUp = 2131230902;
 			
-			// aapt resource value: 0x7f090076
-			public const int submenuarrow = 2131296374;
+			// aapt resource value: 0x7F0800B7
+			public const int scrollView = 2131230903;
 			
-			// aapt resource value: 0x7f090087
-			public const int submit_area = 2131296391;
+			// aapt resource value: 0x7F0800B9
+			public const int search_badge = 2131230905;
 			
-			// aapt resource value: 0x7f09001f
-			public const int tabMode = 2131296287;
+			// aapt resource value: 0x7F0800BA
+			public const int search_bar = 2131230906;
 			
-			// aapt resource value: 0x7f090019
-			public const int tag_transition_group = 2131296281;
+			// aapt resource value: 0x7F0800BB
+			public const int search_button = 2131230907;
 			
-			// aapt resource value: 0x7f09001a
-			public const int text = 2131296282;
+			// aapt resource value: 0x7F0800BC
+			public const int search_close_btn = 2131230908;
 			
-			// aapt resource value: 0x7f09001b
-			public const int text2 = 2131296283;
+			// aapt resource value: 0x7F0800BD
+			public const int search_edit_frame = 2131230909;
 			
-			// aapt resource value: 0x7f09006a
-			public const int textSpacerNoButtons = 2131296362;
+			// aapt resource value: 0x7F0800BE
+			public const int search_go_btn = 2131230910;
 			
-			// aapt resource value: 0x7f090069
-			public const int textSpacerNoTitle = 2131296361;
+			// aapt resource value: 0x7F0800BF
+			public const int search_mag_icon = 2131230911;
 			
-			// aapt resource value: 0x7f09009a
-			public const int text_input_password_toggle = 2131296410;
+			// aapt resource value: 0x7F0800C0
+			public const int search_plate = 2131230912;
 			
-			// aapt resource value: 0x7f090014
-			public const int textinput_counter = 2131296276;
+			// aapt resource value: 0x7F0800C1
+			public const int search_src_text = 2131230913;
 			
-			// aapt resource value: 0x7f090015
-			public const int textinput_error = 2131296277;
+			// aapt resource value: 0x7F0800C2
+			public const int search_voice_btn = 2131230914;
 			
-			// aapt resource value: 0x7f0900c2
-			public const int time = 2131296450;
+			// aapt resource value: 0x7F0800C4
+			public const int selected = 2131230916;
 			
-			// aapt resource value: 0x7f09001c
-			public const int title = 2131296284;
+			// aapt resource value: 0x7F0800C3
+			public const int select_dialog_listview = 2131230915;
 			
-			// aapt resource value: 0x7f090071
-			public const int titleDividerNoCustom = 2131296369;
+			// aapt resource value: 0x7F0800C5
+			public const int shellcontent_appbar = 2131230917;
 			
-			// aapt resource value: 0x7f09006f
-			public const int title_template = 2131296367;
+			// aapt resource value: 0x7F0800C6
+			public const int shellcontent_toolbar = 2131230918;
 			
-			// aapt resource value: 0x7f0900d2
-			public const int toolbar = 2131296466;
+			// aapt resource value: 0x7F080004
+			public const int SHIFT = 2131230724;
 			
-			// aapt resource value: 0x7f09003e
-			public const int top = 2131296318;
+			// aapt resource value: 0x7F0800C7
+			public const int shortcut = 2131230919;
 			
-			// aapt resource value: 0x7f09006e
-			public const int topPanel = 2131296366;
+			// aapt resource value: 0x7F0800C8
+			public const int showCustom = 2131230920;
 			
-			// aapt resource value: 0x7f090091
-			public const int touch_outside = 2131296401;
+			// aapt resource value: 0x7F0800C9
+			public const int showHome = 2131230921;
 			
-			// aapt resource value: 0x7f09000f
-			public const int transition_current_scene = 2131296271;
+			// aapt resource value: 0x7F0800CA
+			public const int showTitle = 2131230922;
 			
-			// aapt resource value: 0x7f090010
-			public const int transition_layout_save = 2131296272;
+			// aapt resource value: 0x7F0800CB
+			public const int sliding_tabs = 2131230923;
 			
-			// aapt resource value: 0x7f090011
-			public const int transition_position = 2131296273;
+			// aapt resource value: 0x7F0800CC
+			public const int smallLabel = 2131230924;
 			
-			// aapt resource value: 0x7f090012
-			public const int transition_scene_layoutid_cache = 2131296274;
+			// aapt resource value: 0x7F0800CD
+			public const int snackbar_action = 2131230925;
 			
-			// aapt resource value: 0x7f090013
-			public const int transition_transform = 2131296275;
+			// aapt resource value: 0x7F0800CE
+			public const int snackbar_text = 2131230926;
 			
-			// aapt resource value: 0x7f09002d
-			public const int uniform = 2131296301;
+			// aapt resource value: 0x7F0800CF
+			public const int snap = 2131230927;
 			
-			// aapt resource value: 0x7f090009
-			public const int up = 2131296265;
+			// aapt resource value: 0x7F0800D0
+			public const int snapMargins = 2131230928;
 			
-			// aapt resource value: 0x7f090026
-			public const int useLogo = 2131296294;
+			// aapt resource value: 0x7F0800D1
+			public const int spacer = 2131230929;
 			
-			// aapt resource value: 0x7f090016
-			public const int view_offset_helper = 2131296278;
+			// aapt resource value: 0x7F0800D2
+			public const int split_action_bar = 2131230930;
 			
-			// aapt resource value: 0x7f0900d4
-			public const int visible = 2131296468;
+			// aapt resource value: 0x7F0800D3
+			public const int src_atop = 2131230931;
 			
-			// aapt resource value: 0x7f0900af
-			public const int volume_item_container = 2131296431;
+			// aapt resource value: 0x7F0800D4
+			public const int src_in = 2131230932;
 			
-			// aapt resource value: 0x7f09003c
-			public const int withText = 2131296316;
+			// aapt resource value: 0x7F0800D5
+			public const int src_over = 2131230933;
 			
-			// aapt resource value: 0x7f09002e
-			public const int wrap_content = 2131296302;
+			// aapt resource value: 0x7F0800D6
+			public const int start = 2131230934;
+			
+			// aapt resource value: 0x7F0800D7
+			public const int status_bar_latest_event_content = 2131230935;
+			
+			// aapt resource value: 0x7F0800D8
+			public const int stretch = 2131230936;
+			
+			// aapt resource value: 0x7F0800D9
+			public const int submenuarrow = 2131230937;
+			
+			// aapt resource value: 0x7F0800DA
+			public const int submit_area = 2131230938;
+			
+			// aapt resource value: 0x7F080005
+			public const int SYM = 2131230725;
+			
+			// aapt resource value: 0x7F0800DB
+			public const int tabMode = 2131230939;
+			
+			// aapt resource value: 0x7F0800DC
+			public const int tag_transition_group = 2131230940;
+			
+			// aapt resource value: 0x7F0800DD
+			public const int tag_unhandled_key_event_manager = 2131230941;
+			
+			// aapt resource value: 0x7F0800DE
+			public const int tag_unhandled_key_listeners = 2131230942;
+			
+			// aapt resource value: 0x7F0800DF
+			public const int text = 2131230943;
+			
+			// aapt resource value: 0x7F0800E0
+			public const int text2 = 2131230944;
+			
+			// aapt resource value: 0x7F0800E5
+			public const int textinput_counter = 2131230949;
+			
+			// aapt resource value: 0x7F0800E6
+			public const int textinput_error = 2131230950;
+			
+			// aapt resource value: 0x7F0800E7
+			public const int textinput_helper_text = 2131230951;
+			
+			// aapt resource value: 0x7F0800E1
+			public const int textSpacerNoButtons = 2131230945;
+			
+			// aapt resource value: 0x7F0800E2
+			public const int textSpacerNoTitle = 2131230946;
+			
+			// aapt resource value: 0x7F0800E3
+			public const int textStart = 2131230947;
+			
+			// aapt resource value: 0x7F0800E4
+			public const int text_input_password_toggle = 2131230948;
+			
+			// aapt resource value: 0x7F0800E8
+			public const int time = 2131230952;
+			
+			// aapt resource value: 0x7F0800E9
+			public const int title = 2131230953;
+			
+			// aapt resource value: 0x7F0800EA
+			public const int titleDividerNoCustom = 2131230954;
+			
+			// aapt resource value: 0x7F0800EB
+			public const int title_template = 2131230955;
+			
+			// aapt resource value: 0x7F0800EC
+			public const int toolbar = 2131230956;
+			
+			// aapt resource value: 0x7F0800ED
+			public const int top = 2131230957;
+			
+			// aapt resource value: 0x7F0800EE
+			public const int topPanel = 2131230958;
+			
+			// aapt resource value: 0x7F0800EF
+			public const int touch_outside = 2131230959;
+			
+			// aapt resource value: 0x7F0800F0
+			public const int transition_current_scene = 2131230960;
+			
+			// aapt resource value: 0x7F0800F1
+			public const int transition_layout_save = 2131230961;
+			
+			// aapt resource value: 0x7F0800F2
+			public const int transition_position = 2131230962;
+			
+			// aapt resource value: 0x7F0800F3
+			public const int transition_scene_layoutid_cache = 2131230963;
+			
+			// aapt resource value: 0x7F0800F4
+			public const int transition_transform = 2131230964;
+			
+			// aapt resource value: 0x7F0800F5
+			public const int uniform = 2131230965;
+			
+			// aapt resource value: 0x7F0800F6
+			public const int unlabeled = 2131230966;
+			
+			// aapt resource value: 0x7F0800F7
+			public const int up = 2131230967;
+			
+			// aapt resource value: 0x7F0800F8
+			public const int useLogo = 2131230968;
+			
+			// aapt resource value: 0x7F0800F9
+			public const int view_offset_helper = 2131230969;
+			
+			// aapt resource value: 0x7F0800FA
+			public const int visible = 2131230970;
+			
+			// aapt resource value: 0x7F0800FB
+			public const int volume_item_container = 2131230971;
+			
+			// aapt resource value: 0x7F0800FC
+			public const int withText = 2131230972;
+			
+			// aapt resource value: 0x7F0800FD
+			public const int wrap_content = 2131230973;
 			
 			static Id()
 			{
@@ -5688,44 +7050,62 @@ namespace SextantSample.Droid
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f0b0003
-			public const int abc_config_activityDefaultDur = 2131427331;
+			// aapt resource value: 0x7F090000
+			public const int abc_config_activityDefaultDur = 2131296256;
 			
-			// aapt resource value: 0x7f0b0004
-			public const int abc_config_activityShortDur = 2131427332;
+			// aapt resource value: 0x7F090001
+			public const int abc_config_activityShortDur = 2131296257;
 			
-			// aapt resource value: 0x7f0b0008
-			public const int app_bar_elevation_anim_duration = 2131427336;
+			// aapt resource value: 0x7F090002
+			public const int app_bar_elevation_anim_duration = 2131296258;
 			
-			// aapt resource value: 0x7f0b0009
-			public const int bottom_sheet_slide_duration = 2131427337;
+			// aapt resource value: 0x7F090003
+			public const int bottom_sheet_slide_duration = 2131296259;
 			
-			// aapt resource value: 0x7f0b0005
-			public const int cancel_button_image_alpha = 2131427333;
+			// aapt resource value: 0x7F090004
+			public const int cancel_button_image_alpha = 2131296260;
 			
-			// aapt resource value: 0x7f0b0006
-			public const int config_tooltipAnimTime = 2131427334;
+			// aapt resource value: 0x7F090005
+			public const int config_tooltipAnimTime = 2131296261;
 			
-			// aapt resource value: 0x7f0b0007
-			public const int design_snackbar_text_max_lines = 2131427335;
+			// aapt resource value: 0x7F090006
+			public const int design_snackbar_text_max_lines = 2131296262;
 			
-			// aapt resource value: 0x7f0b000a
-			public const int hide_password_duration = 2131427338;
+			// aapt resource value: 0x7F090007
+			public const int design_tab_indicator_anim_duration_ms = 2131296263;
 			
-			// aapt resource value: 0x7f0b0000
-			public const int mr_controller_volume_group_list_animation_duration_ms = 2131427328;
+			// aapt resource value: 0x7F090008
+			public const int hide_password_duration = 2131296264;
 			
-			// aapt resource value: 0x7f0b0001
-			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131427329;
+			// aapt resource value: 0x7F090009
+			public const int mr_controller_volume_group_list_animation_duration_ms = 2131296265;
 			
-			// aapt resource value: 0x7f0b0002
-			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131427330;
+			// aapt resource value: 0x7F09000A
+			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131296266;
 			
-			// aapt resource value: 0x7f0b000b
-			public const int show_password_duration = 2131427339;
+			// aapt resource value: 0x7F09000B
+			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131296267;
 			
-			// aapt resource value: 0x7f0b000c
-			public const int status_bar_notification_info_maxnum = 2131427340;
+			// aapt resource value: 0x7F09000C
+			public const int mr_update_routes_delay_ms = 2131296268;
+			
+			// aapt resource value: 0x7F09000D
+			public const int mtrl_btn_anim_delay_ms = 2131296269;
+			
+			// aapt resource value: 0x7F09000E
+			public const int mtrl_btn_anim_duration_ms = 2131296270;
+			
+			// aapt resource value: 0x7F09000F
+			public const int mtrl_chip_anim_duration = 2131296271;
+			
+			// aapt resource value: 0x7F090010
+			public const int mtrl_tab_indicator_anim_duration_ms = 2131296272;
+			
+			// aapt resource value: 0x7F090011
+			public const int show_password_duration = 2131296273;
+			
+			// aapt resource value: 0x7F090012
+			public const int status_bar_notification_info_maxnum = 2131296274;
 			
 			static Integer()
 			{
@@ -5740,11 +7120,23 @@ namespace SextantSample.Droid
 		public partial class Interpolator
 		{
 			
-			// aapt resource value: 0x7f070000
-			public const int mr_fast_out_slow_in = 2131165184;
+			// aapt resource value: 0x7F0A0000
+			public const int mr_fast_out_slow_in = 2131361792;
 			
-			// aapt resource value: 0x7f070001
-			public const int mr_linear_out_slow_in = 2131165185;
+			// aapt resource value: 0x7F0A0001
+			public const int mr_linear_out_slow_in = 2131361793;
+			
+			// aapt resource value: 0x7F0A0002
+			public const int mtrl_fast_out_linear_in = 2131361794;
+			
+			// aapt resource value: 0x7F0A0003
+			public const int mtrl_fast_out_slow_in = 2131361795;
+			
+			// aapt resource value: 0x7F0A0004
+			public const int mtrl_linear = 2131361796;
+			
+			// aapt resource value: 0x7F0A0005
+			public const int mtrl_linear_out_slow_in = 2131361797;
 			
 			static Interpolator()
 			{
@@ -5759,221 +7151,260 @@ namespace SextantSample.Droid
 		public partial class Layout
 		{
 			
-			// aapt resource value: 0x7f040000
-			public const int abc_action_bar_title_item = 2130968576;
+			// aapt resource value: 0x7F0B0000
+			public const int abc_action_bar_title_item = 2131427328;
 			
-			// aapt resource value: 0x7f040001
-			public const int abc_action_bar_up_container = 2130968577;
+			// aapt resource value: 0x7F0B0001
+			public const int abc_action_bar_up_container = 2131427329;
 			
-			// aapt resource value: 0x7f040002
-			public const int abc_action_menu_item_layout = 2130968578;
+			// aapt resource value: 0x7F0B0002
+			public const int abc_action_menu_item_layout = 2131427330;
 			
-			// aapt resource value: 0x7f040003
-			public const int abc_action_menu_layout = 2130968579;
+			// aapt resource value: 0x7F0B0003
+			public const int abc_action_menu_layout = 2131427331;
 			
-			// aapt resource value: 0x7f040004
-			public const int abc_action_mode_bar = 2130968580;
+			// aapt resource value: 0x7F0B0004
+			public const int abc_action_mode_bar = 2131427332;
 			
-			// aapt resource value: 0x7f040005
-			public const int abc_action_mode_close_item_material = 2130968581;
+			// aapt resource value: 0x7F0B0005
+			public const int abc_action_mode_close_item_material = 2131427333;
 			
-			// aapt resource value: 0x7f040006
-			public const int abc_activity_chooser_view = 2130968582;
+			// aapt resource value: 0x7F0B0006
+			public const int abc_activity_chooser_view = 2131427334;
 			
-			// aapt resource value: 0x7f040007
-			public const int abc_activity_chooser_view_list_item = 2130968583;
+			// aapt resource value: 0x7F0B0007
+			public const int abc_activity_chooser_view_list_item = 2131427335;
 			
-			// aapt resource value: 0x7f040008
-			public const int abc_alert_dialog_button_bar_material = 2130968584;
+			// aapt resource value: 0x7F0B0008
+			public const int abc_alert_dialog_button_bar_material = 2131427336;
 			
-			// aapt resource value: 0x7f040009
-			public const int abc_alert_dialog_material = 2130968585;
+			// aapt resource value: 0x7F0B0009
+			public const int abc_alert_dialog_material = 2131427337;
 			
-			// aapt resource value: 0x7f04000a
-			public const int abc_alert_dialog_title_material = 2130968586;
+			// aapt resource value: 0x7F0B000A
+			public const int abc_alert_dialog_title_material = 2131427338;
 			
-			// aapt resource value: 0x7f04000b
-			public const int abc_dialog_title_material = 2130968587;
+			// aapt resource value: 0x7F0B000B
+			public const int abc_cascading_menu_item_layout = 2131427339;
 			
-			// aapt resource value: 0x7f04000c
-			public const int abc_expanded_menu_layout = 2130968588;
+			// aapt resource value: 0x7F0B000C
+			public const int abc_dialog_title_material = 2131427340;
 			
-			// aapt resource value: 0x7f04000d
-			public const int abc_list_menu_item_checkbox = 2130968589;
+			// aapt resource value: 0x7F0B000D
+			public const int abc_expanded_menu_layout = 2131427341;
 			
-			// aapt resource value: 0x7f04000e
-			public const int abc_list_menu_item_icon = 2130968590;
+			// aapt resource value: 0x7F0B000E
+			public const int abc_list_menu_item_checkbox = 2131427342;
 			
-			// aapt resource value: 0x7f04000f
-			public const int abc_list_menu_item_layout = 2130968591;
+			// aapt resource value: 0x7F0B000F
+			public const int abc_list_menu_item_icon = 2131427343;
 			
-			// aapt resource value: 0x7f040010
-			public const int abc_list_menu_item_radio = 2130968592;
+			// aapt resource value: 0x7F0B0010
+			public const int abc_list_menu_item_layout = 2131427344;
 			
-			// aapt resource value: 0x7f040011
-			public const int abc_popup_menu_header_item_layout = 2130968593;
+			// aapt resource value: 0x7F0B0011
+			public const int abc_list_menu_item_radio = 2131427345;
 			
-			// aapt resource value: 0x7f040012
-			public const int abc_popup_menu_item_layout = 2130968594;
+			// aapt resource value: 0x7F0B0012
+			public const int abc_popup_menu_header_item_layout = 2131427346;
 			
-			// aapt resource value: 0x7f040013
-			public const int abc_screen_content_include = 2130968595;
+			// aapt resource value: 0x7F0B0013
+			public const int abc_popup_menu_item_layout = 2131427347;
 			
-			// aapt resource value: 0x7f040014
-			public const int abc_screen_simple = 2130968596;
+			// aapt resource value: 0x7F0B0014
+			public const int abc_screen_content_include = 2131427348;
 			
-			// aapt resource value: 0x7f040015
-			public const int abc_screen_simple_overlay_action_mode = 2130968597;
+			// aapt resource value: 0x7F0B0015
+			public const int abc_screen_simple = 2131427349;
 			
-			// aapt resource value: 0x7f040016
-			public const int abc_screen_toolbar = 2130968598;
+			// aapt resource value: 0x7F0B0016
+			public const int abc_screen_simple_overlay_action_mode = 2131427350;
 			
-			// aapt resource value: 0x7f040017
-			public const int abc_search_dropdown_item_icons_2line = 2130968599;
+			// aapt resource value: 0x7F0B0017
+			public const int abc_screen_toolbar = 2131427351;
 			
-			// aapt resource value: 0x7f040018
-			public const int abc_search_view = 2130968600;
+			// aapt resource value: 0x7F0B0018
+			public const int abc_search_dropdown_item_icons_2line = 2131427352;
 			
-			// aapt resource value: 0x7f040019
-			public const int abc_select_dialog_material = 2130968601;
+			// aapt resource value: 0x7F0B0019
+			public const int abc_search_view = 2131427353;
 			
-			// aapt resource value: 0x7f04001a
-			public const int BottomTabLayout = 2130968602;
+			// aapt resource value: 0x7F0B001A
+			public const int abc_select_dialog_material = 2131427354;
 			
-			// aapt resource value: 0x7f04001b
-			public const int design_bottom_navigation_item = 2130968603;
+			// aapt resource value: 0x7F0B001B
+			public const int abc_tooltip = 2131427355;
 			
-			// aapt resource value: 0x7f04001c
-			public const int design_bottom_sheet_dialog = 2130968604;
+			// aapt resource value: 0x7F0B001C
+			public const int BottomTabLayout = 2131427356;
 			
-			// aapt resource value: 0x7f04001d
-			public const int design_layout_snackbar = 2130968605;
+			// aapt resource value: 0x7F0B001D
+			public const int browser_actions_context_menu_page = 2131427357;
 			
-			// aapt resource value: 0x7f04001e
-			public const int design_layout_snackbar_include = 2130968606;
+			// aapt resource value: 0x7F0B001E
+			public const int browser_actions_context_menu_row = 2131427358;
 			
-			// aapt resource value: 0x7f04001f
-			public const int design_layout_tab_icon = 2130968607;
+			// aapt resource value: 0x7F0B001F
+			public const int design_bottom_navigation_item = 2131427359;
 			
-			// aapt resource value: 0x7f040020
-			public const int design_layout_tab_text = 2130968608;
+			// aapt resource value: 0x7F0B0020
+			public const int design_bottom_sheet_dialog = 2131427360;
 			
-			// aapt resource value: 0x7f040021
-			public const int design_menu_item_action_area = 2130968609;
+			// aapt resource value: 0x7F0B0021
+			public const int design_layout_snackbar = 2131427361;
 			
-			// aapt resource value: 0x7f040022
-			public const int design_navigation_item = 2130968610;
+			// aapt resource value: 0x7F0B0022
+			public const int design_layout_snackbar_include = 2131427362;
 			
-			// aapt resource value: 0x7f040023
-			public const int design_navigation_item_header = 2130968611;
+			// aapt resource value: 0x7F0B0023
+			public const int design_layout_tab_icon = 2131427363;
 			
-			// aapt resource value: 0x7f040024
-			public const int design_navigation_item_separator = 2130968612;
+			// aapt resource value: 0x7F0B0024
+			public const int design_layout_tab_text = 2131427364;
 			
-			// aapt resource value: 0x7f040025
-			public const int design_navigation_item_subheader = 2130968613;
+			// aapt resource value: 0x7F0B0025
+			public const int design_menu_item_action_area = 2131427365;
 			
-			// aapt resource value: 0x7f040026
-			public const int design_navigation_menu = 2130968614;
+			// aapt resource value: 0x7F0B0026
+			public const int design_navigation_item = 2131427366;
 			
-			// aapt resource value: 0x7f040027
-			public const int design_navigation_menu_item = 2130968615;
+			// aapt resource value: 0x7F0B0027
+			public const int design_navigation_item_header = 2131427367;
 			
-			// aapt resource value: 0x7f040028
-			public const int design_text_input_password_icon = 2130968616;
+			// aapt resource value: 0x7F0B0028
+			public const int design_navigation_item_separator = 2131427368;
 			
-			// aapt resource value: 0x7f040029
-			public const int FlyoutContent = 2130968617;
+			// aapt resource value: 0x7F0B0029
+			public const int design_navigation_item_subheader = 2131427369;
 			
-			// aapt resource value: 0x7f04002a
-			public const int mr_chooser_dialog = 2130968618;
+			// aapt resource value: 0x7F0B002A
+			public const int design_navigation_menu = 2131427370;
 			
-			// aapt resource value: 0x7f04002b
-			public const int mr_chooser_list_item = 2130968619;
+			// aapt resource value: 0x7F0B002B
+			public const int design_navigation_menu_item = 2131427371;
 			
-			// aapt resource value: 0x7f04002c
-			public const int mr_controller_material_dialog_b = 2130968620;
+			// aapt resource value: 0x7F0B002C
+			public const int design_text_input_password_icon = 2131427372;
 			
-			// aapt resource value: 0x7f04002d
-			public const int mr_controller_volume_item = 2130968621;
+			// aapt resource value: 0x7F0B002D
+			public const int FlyoutContent = 2131427373;
 			
-			// aapt resource value: 0x7f04002e
-			public const int mr_playback_control = 2130968622;
+			// aapt resource value: 0x7F0B002E
+			public const int mr_cast_dialog = 2131427374;
 			
-			// aapt resource value: 0x7f04002f
-			public const int mr_volume_control = 2130968623;
+			// aapt resource value: 0x7F0B002F
+			public const int mr_cast_group_item = 2131427375;
 			
-			// aapt resource value: 0x7f040030
-			public const int notification_action = 2130968624;
+			// aapt resource value: 0x7F0B0030
+			public const int mr_cast_group_volume_item = 2131427376;
 			
-			// aapt resource value: 0x7f040031
-			public const int notification_action_tombstone = 2130968625;
+			// aapt resource value: 0x7F0B0031
+			public const int mr_cast_media_metadata = 2131427377;
 			
-			// aapt resource value: 0x7f040032
-			public const int notification_media_action = 2130968626;
+			// aapt resource value: 0x7F0B0032
+			public const int mr_cast_route_item = 2131427378;
 			
-			// aapt resource value: 0x7f040033
-			public const int notification_media_cancel_action = 2130968627;
+			// aapt resource value: 0x7F0B0033
+			public const int mr_chooser_dialog = 2131427379;
 			
-			// aapt resource value: 0x7f040034
-			public const int notification_template_big_media = 2130968628;
+			// aapt resource value: 0x7F0B0034
+			public const int mr_chooser_list_item = 2131427380;
 			
-			// aapt resource value: 0x7f040035
-			public const int notification_template_big_media_custom = 2130968629;
+			// aapt resource value: 0x7F0B0035
+			public const int mr_controller_material_dialog_b = 2131427381;
 			
-			// aapt resource value: 0x7f040036
-			public const int notification_template_big_media_narrow = 2130968630;
+			// aapt resource value: 0x7F0B0036
+			public const int mr_controller_volume_item = 2131427382;
 			
-			// aapt resource value: 0x7f040037
-			public const int notification_template_big_media_narrow_custom = 2130968631;
+			// aapt resource value: 0x7F0B0037
+			public const int mr_dialog_header_item = 2131427383;
 			
-			// aapt resource value: 0x7f040038
-			public const int notification_template_custom_big = 2130968632;
+			// aapt resource value: 0x7F0B0038
+			public const int mr_picker_dialog = 2131427384;
 			
-			// aapt resource value: 0x7f040039
-			public const int notification_template_icon_group = 2130968633;
+			// aapt resource value: 0x7F0B0039
+			public const int mr_picker_route_item = 2131427385;
 			
-			// aapt resource value: 0x7f04003a
-			public const int notification_template_lines_media = 2130968634;
+			// aapt resource value: 0x7F0B003A
+			public const int mr_playback_control = 2131427386;
 			
-			// aapt resource value: 0x7f04003b
-			public const int notification_template_media = 2130968635;
+			// aapt resource value: 0x7F0B003B
+			public const int mr_volume_control = 2131427387;
 			
-			// aapt resource value: 0x7f04003c
-			public const int notification_template_media_custom = 2130968636;
+			// aapt resource value: 0x7F0B003C
+			public const int mtrl_layout_snackbar = 2131427388;
 			
-			// aapt resource value: 0x7f04003d
-			public const int notification_template_part_chronometer = 2130968637;
+			// aapt resource value: 0x7F0B003D
+			public const int mtrl_layout_snackbar_include = 2131427389;
 			
-			// aapt resource value: 0x7f04003e
-			public const int notification_template_part_time = 2130968638;
+			// aapt resource value: 0x7F0B003E
+			public const int notification_action = 2131427390;
 			
-			// aapt resource value: 0x7f04003f
-			public const int RootLayout = 2130968639;
+			// aapt resource value: 0x7F0B003F
+			public const int notification_action_tombstone = 2131427391;
 			
-			// aapt resource value: 0x7f040040
-			public const int select_dialog_item_material = 2130968640;
+			// aapt resource value: 0x7F0B0040
+			public const int notification_media_action = 2131427392;
 			
-			// aapt resource value: 0x7f040041
-			public const int select_dialog_multichoice_material = 2130968641;
+			// aapt resource value: 0x7F0B0041
+			public const int notification_media_cancel_action = 2131427393;
 			
-			// aapt resource value: 0x7f040042
-			public const int select_dialog_singlechoice_material = 2130968642;
+			// aapt resource value: 0x7F0B0042
+			public const int notification_template_big_media = 2131427394;
 			
-			// aapt resource value: 0x7f040043
-			public const int ShellContent = 2130968643;
+			// aapt resource value: 0x7F0B0043
+			public const int notification_template_big_media_custom = 2131427395;
 			
-			// aapt resource value: 0x7f040044
-			public const int support_simple_spinner_dropdown_item = 2130968644;
+			// aapt resource value: 0x7F0B0044
+			public const int notification_template_big_media_narrow = 2131427396;
 			
-			// aapt resource value: 0x7f040045
-			public const int Tabbar = 2130968645;
+			// aapt resource value: 0x7F0B0045
+			public const int notification_template_big_media_narrow_custom = 2131427397;
 			
-			// aapt resource value: 0x7f040046
-			public const int Toolbar = 2130968646;
+			// aapt resource value: 0x7F0B0046
+			public const int notification_template_custom_big = 2131427398;
 			
-			// aapt resource value: 0x7f040047
-			public const int tooltip = 2130968647;
+			// aapt resource value: 0x7F0B0047
+			public const int notification_template_icon_group = 2131427399;
+			
+			// aapt resource value: 0x7F0B0048
+			public const int notification_template_lines_media = 2131427400;
+			
+			// aapt resource value: 0x7F0B0049
+			public const int notification_template_media = 2131427401;
+			
+			// aapt resource value: 0x7F0B004A
+			public const int notification_template_media_custom = 2131427402;
+			
+			// aapt resource value: 0x7F0B004B
+			public const int notification_template_part_chronometer = 2131427403;
+			
+			// aapt resource value: 0x7F0B004C
+			public const int notification_template_part_time = 2131427404;
+			
+			// aapt resource value: 0x7F0B004D
+			public const int RootLayout = 2131427405;
+			
+			// aapt resource value: 0x7F0B004E
+			public const int select_dialog_item_material = 2131427406;
+			
+			// aapt resource value: 0x7F0B004F
+			public const int select_dialog_multichoice_material = 2131427407;
+			
+			// aapt resource value: 0x7F0B0050
+			public const int select_dialog_singlechoice_material = 2131427408;
+			
+			// aapt resource value: 0x7F0B0051
+			public const int ShellContent = 2131427409;
+			
+			// aapt resource value: 0x7F0B0052
+			public const int support_simple_spinner_dropdown_item = 2131427410;
+			
+			// aapt resource value: 0x7F0B0053
+			public const int Tabbar = 2131427411;
+			
+			// aapt resource value: 0x7F0B0054
+			public const int Toolbar = 2131427412;
 			
 			static Layout()
 			{
@@ -5988,14 +7419,14 @@ namespace SextantSample.Droid
 		public partial class Mipmap
 		{
 			
-			// aapt resource value: 0x7f030000
-			public const int icon = 2130903040;
+			// aapt resource value: 0x7F0C0000
+			public const int icon = 2131492864;
 			
-			// aapt resource value: 0x7f030001
-			public const int icon_round = 2130903041;
+			// aapt resource value: 0x7F0C0001
+			public const int icon_round = 2131492865;
 			
-			// aapt resource value: 0x7f030002
-			public const int launcher_foreground = 2130903042;
+			// aapt resource value: 0x7F0C0002
+			public const int launcher_foreground = 2131492866;
 			
 			static Mipmap()
 			{
@@ -6010,185 +7441,239 @@ namespace SextantSample.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f0a0015
-			public const int abc_action_bar_home_description = 2131361813;
+			// aapt resource value: 0x7F0D0000
+			public const int abc_action_bar_home_description = 2131558400;
 			
-			// aapt resource value: 0x7f0a0016
-			public const int abc_action_bar_up_description = 2131361814;
+			// aapt resource value: 0x7F0D0001
+			public const int abc_action_bar_up_description = 2131558401;
 			
-			// aapt resource value: 0x7f0a0017
-			public const int abc_action_menu_overflow_description = 2131361815;
+			// aapt resource value: 0x7F0D0002
+			public const int abc_action_menu_overflow_description = 2131558402;
 			
-			// aapt resource value: 0x7f0a0018
-			public const int abc_action_mode_done = 2131361816;
+			// aapt resource value: 0x7F0D0003
+			public const int abc_action_mode_done = 2131558403;
 			
-			// aapt resource value: 0x7f0a0019
-			public const int abc_activity_chooser_view_see_all = 2131361817;
+			// aapt resource value: 0x7F0D0005
+			public const int abc_activitychooserview_choose_application = 2131558405;
 			
-			// aapt resource value: 0x7f0a001a
-			public const int abc_activitychooserview_choose_application = 2131361818;
+			// aapt resource value: 0x7F0D0004
+			public const int abc_activity_chooser_view_see_all = 2131558404;
 			
-			// aapt resource value: 0x7f0a001b
-			public const int abc_capital_off = 2131361819;
+			// aapt resource value: 0x7F0D0006
+			public const int abc_capital_off = 2131558406;
 			
-			// aapt resource value: 0x7f0a001c
-			public const int abc_capital_on = 2131361820;
+			// aapt resource value: 0x7F0D0007
+			public const int abc_capital_on = 2131558407;
 			
-			// aapt resource value: 0x7f0a0027
-			public const int abc_font_family_body_1_material = 2131361831;
+			// aapt resource value: 0x7F0D0008
+			public const int abc_font_family_body_1_material = 2131558408;
 			
-			// aapt resource value: 0x7f0a0028
-			public const int abc_font_family_body_2_material = 2131361832;
+			// aapt resource value: 0x7F0D0009
+			public const int abc_font_family_body_2_material = 2131558409;
 			
-			// aapt resource value: 0x7f0a0029
-			public const int abc_font_family_button_material = 2131361833;
+			// aapt resource value: 0x7F0D000A
+			public const int abc_font_family_button_material = 2131558410;
 			
-			// aapt resource value: 0x7f0a002a
-			public const int abc_font_family_caption_material = 2131361834;
+			// aapt resource value: 0x7F0D000B
+			public const int abc_font_family_caption_material = 2131558411;
 			
-			// aapt resource value: 0x7f0a002b
-			public const int abc_font_family_display_1_material = 2131361835;
+			// aapt resource value: 0x7F0D000C
+			public const int abc_font_family_display_1_material = 2131558412;
 			
-			// aapt resource value: 0x7f0a002c
-			public const int abc_font_family_display_2_material = 2131361836;
+			// aapt resource value: 0x7F0D000D
+			public const int abc_font_family_display_2_material = 2131558413;
 			
-			// aapt resource value: 0x7f0a002d
-			public const int abc_font_family_display_3_material = 2131361837;
+			// aapt resource value: 0x7F0D000E
+			public const int abc_font_family_display_3_material = 2131558414;
 			
-			// aapt resource value: 0x7f0a002e
-			public const int abc_font_family_display_4_material = 2131361838;
+			// aapt resource value: 0x7F0D000F
+			public const int abc_font_family_display_4_material = 2131558415;
 			
-			// aapt resource value: 0x7f0a002f
-			public const int abc_font_family_headline_material = 2131361839;
+			// aapt resource value: 0x7F0D0010
+			public const int abc_font_family_headline_material = 2131558416;
 			
-			// aapt resource value: 0x7f0a0030
-			public const int abc_font_family_menu_material = 2131361840;
+			// aapt resource value: 0x7F0D0011
+			public const int abc_font_family_menu_material = 2131558417;
 			
-			// aapt resource value: 0x7f0a0031
-			public const int abc_font_family_subhead_material = 2131361841;
+			// aapt resource value: 0x7F0D0012
+			public const int abc_font_family_subhead_material = 2131558418;
 			
-			// aapt resource value: 0x7f0a0032
-			public const int abc_font_family_title_material = 2131361842;
+			// aapt resource value: 0x7F0D0013
+			public const int abc_font_family_title_material = 2131558419;
 			
-			// aapt resource value: 0x7f0a001d
-			public const int abc_search_hint = 2131361821;
+			// aapt resource value: 0x7F0D0014
+			public const int abc_menu_alt_shortcut_label = 2131558420;
 			
-			// aapt resource value: 0x7f0a001e
-			public const int abc_searchview_description_clear = 2131361822;
+			// aapt resource value: 0x7F0D0015
+			public const int abc_menu_ctrl_shortcut_label = 2131558421;
 			
-			// aapt resource value: 0x7f0a001f
-			public const int abc_searchview_description_query = 2131361823;
+			// aapt resource value: 0x7F0D0016
+			public const int abc_menu_delete_shortcut_label = 2131558422;
 			
-			// aapt resource value: 0x7f0a0020
-			public const int abc_searchview_description_search = 2131361824;
+			// aapt resource value: 0x7F0D0017
+			public const int abc_menu_enter_shortcut_label = 2131558423;
 			
-			// aapt resource value: 0x7f0a0021
-			public const int abc_searchview_description_submit = 2131361825;
+			// aapt resource value: 0x7F0D0018
+			public const int abc_menu_function_shortcut_label = 2131558424;
 			
-			// aapt resource value: 0x7f0a0022
-			public const int abc_searchview_description_voice = 2131361826;
+			// aapt resource value: 0x7F0D0019
+			public const int abc_menu_meta_shortcut_label = 2131558425;
 			
-			// aapt resource value: 0x7f0a0023
-			public const int abc_shareactionprovider_share_with = 2131361827;
+			// aapt resource value: 0x7F0D001A
+			public const int abc_menu_shift_shortcut_label = 2131558426;
 			
-			// aapt resource value: 0x7f0a0024
-			public const int abc_shareactionprovider_share_with_application = 2131361828;
+			// aapt resource value: 0x7F0D001B
+			public const int abc_menu_space_shortcut_label = 2131558427;
 			
-			// aapt resource value: 0x7f0a0025
-			public const int abc_toolbar_collapse_description = 2131361829;
+			// aapt resource value: 0x7F0D001C
+			public const int abc_menu_sym_shortcut_label = 2131558428;
 			
-			// aapt resource value: 0x7f0a0033
-			public const int appbar_scrolling_view_behavior = 2131361843;
+			// aapt resource value: 0x7F0D001D
+			public const int abc_prepend_shortcut_label = 2131558429;
 			
-			// aapt resource value: 0x7f0a0034
-			public const int bottom_sheet_behavior = 2131361844;
+			// aapt resource value: 0x7F0D001F
+			public const int abc_searchview_description_clear = 2131558431;
 			
-			// aapt resource value: 0x7f0a0035
-			public const int character_counter_pattern = 2131361845;
+			// aapt resource value: 0x7F0D0020
+			public const int abc_searchview_description_query = 2131558432;
 			
-			// aapt resource value: 0x7f0a0000
-			public const int mr_button_content_description = 2131361792;
+			// aapt resource value: 0x7F0D0021
+			public const int abc_searchview_description_search = 2131558433;
 			
-			// aapt resource value: 0x7f0a0001
-			public const int mr_cast_button_connected = 2131361793;
+			// aapt resource value: 0x7F0D0022
+			public const int abc_searchview_description_submit = 2131558434;
 			
-			// aapt resource value: 0x7f0a0002
-			public const int mr_cast_button_connecting = 2131361794;
+			// aapt resource value: 0x7F0D0023
+			public const int abc_searchview_description_voice = 2131558435;
 			
-			// aapt resource value: 0x7f0a0003
-			public const int mr_cast_button_disconnected = 2131361795;
+			// aapt resource value: 0x7F0D001E
+			public const int abc_search_hint = 2131558430;
 			
-			// aapt resource value: 0x7f0a0004
-			public const int mr_chooser_searching = 2131361796;
+			// aapt resource value: 0x7F0D0024
+			public const int abc_shareactionprovider_share_with = 2131558436;
 			
-			// aapt resource value: 0x7f0a0005
-			public const int mr_chooser_title = 2131361797;
+			// aapt resource value: 0x7F0D0025
+			public const int abc_shareactionprovider_share_with_application = 2131558437;
 			
-			// aapt resource value: 0x7f0a0006
-			public const int mr_controller_album_art = 2131361798;
+			// aapt resource value: 0x7F0D0026
+			public const int abc_toolbar_collapse_description = 2131558438;
 			
-			// aapt resource value: 0x7f0a0007
-			public const int mr_controller_casting_screen = 2131361799;
+			// aapt resource value: 0x7F0D0027
+			public const int appbar_scrolling_view_behavior = 2131558439;
 			
-			// aapt resource value: 0x7f0a0008
-			public const int mr_controller_close_description = 2131361800;
+			// aapt resource value: 0x7F0D0028
+			public const int bottom_sheet_behavior = 2131558440;
 			
-			// aapt resource value: 0x7f0a0009
-			public const int mr_controller_collapse_group = 2131361801;
+			// aapt resource value: 0x7F0D0029
+			public const int character_counter_content_description = 2131558441;
 			
-			// aapt resource value: 0x7f0a000a
-			public const int mr_controller_disconnect = 2131361802;
+			// aapt resource value: 0x7F0D002A
+			public const int character_counter_pattern = 2131558442;
 			
-			// aapt resource value: 0x7f0a000b
-			public const int mr_controller_expand_group = 2131361803;
+			// aapt resource value: 0x7F0D002B
+			public const int fab_transformation_scrim_behavior = 2131558443;
 			
-			// aapt resource value: 0x7f0a000c
-			public const int mr_controller_no_info_available = 2131361804;
+			// aapt resource value: 0x7F0D002C
+			public const int fab_transformation_sheet_behavior = 2131558444;
 			
-			// aapt resource value: 0x7f0a000d
-			public const int mr_controller_no_media_selected = 2131361805;
+			// aapt resource value: 0x7F0D002D
+			public const int hide_bottom_view_on_scroll_behavior = 2131558445;
 			
-			// aapt resource value: 0x7f0a000e
-			public const int mr_controller_pause = 2131361806;
+			// aapt resource value: 0x7F0D002E
+			public const int mr_button_content_description = 2131558446;
 			
-			// aapt resource value: 0x7f0a000f
-			public const int mr_controller_play = 2131361807;
+			// aapt resource value: 0x7F0D002F
+			public const int mr_cast_button_connected = 2131558447;
 			
-			// aapt resource value: 0x7f0a0010
-			public const int mr_controller_stop = 2131361808;
+			// aapt resource value: 0x7F0D0030
+			public const int mr_cast_button_connecting = 2131558448;
 			
-			// aapt resource value: 0x7f0a0011
-			public const int mr_controller_stop_casting = 2131361809;
+			// aapt resource value: 0x7F0D0031
+			public const int mr_cast_button_disconnected = 2131558449;
 			
-			// aapt resource value: 0x7f0a0012
-			public const int mr_controller_volume_slider = 2131361810;
+			// aapt resource value: 0x7F0D0032
+			public const int mr_cast_dialog_title_view_placeholder = 2131558450;
 			
-			// aapt resource value: 0x7f0a0013
-			public const int mr_system_route_name = 2131361811;
+			// aapt resource value: 0x7F0D0033
+			public const int mr_chooser_searching = 2131558451;
 			
-			// aapt resource value: 0x7f0a0014
-			public const int mr_user_route_category_name = 2131361812;
+			// aapt resource value: 0x7F0D0034
+			public const int mr_chooser_title = 2131558452;
 			
-			// aapt resource value: 0x7f0a0036
-			public const int password_toggle_content_description = 2131361846;
+			// aapt resource value: 0x7F0D0035
+			public const int mr_controller_album_art = 2131558453;
 			
-			// aapt resource value: 0x7f0a0037
-			public const int path_password_eye = 2131361847;
+			// aapt resource value: 0x7F0D0036
+			public const int mr_controller_casting_screen = 2131558454;
 			
-			// aapt resource value: 0x7f0a0038
-			public const int path_password_eye_mask_strike_through = 2131361848;
+			// aapt resource value: 0x7F0D0037
+			public const int mr_controller_close_description = 2131558455;
 			
-			// aapt resource value: 0x7f0a0039
-			public const int path_password_eye_mask_visible = 2131361849;
+			// aapt resource value: 0x7F0D0038
+			public const int mr_controller_collapse_group = 2131558456;
 			
-			// aapt resource value: 0x7f0a003a
-			public const int path_password_strike_through = 2131361850;
+			// aapt resource value: 0x7F0D0039
+			public const int mr_controller_disconnect = 2131558457;
 			
-			// aapt resource value: 0x7f0a0026
-			public const int search_menu_title = 2131361830;
+			// aapt resource value: 0x7F0D003A
+			public const int mr_controller_expand_group = 2131558458;
 			
-			// aapt resource value: 0x7f0a003b
-			public const int status_bar_notification_info_overflow = 2131361851;
+			// aapt resource value: 0x7F0D003B
+			public const int mr_controller_no_info_available = 2131558459;
+			
+			// aapt resource value: 0x7F0D003C
+			public const int mr_controller_no_media_selected = 2131558460;
+			
+			// aapt resource value: 0x7F0D003D
+			public const int mr_controller_pause = 2131558461;
+			
+			// aapt resource value: 0x7F0D003E
+			public const int mr_controller_play = 2131558462;
+			
+			// aapt resource value: 0x7F0D003F
+			public const int mr_controller_stop = 2131558463;
+			
+			// aapt resource value: 0x7F0D0040
+			public const int mr_controller_stop_casting = 2131558464;
+			
+			// aapt resource value: 0x7F0D0041
+			public const int mr_controller_volume_slider = 2131558465;
+			
+			// aapt resource value: 0x7F0D0042
+			public const int mr_dialog_device_header = 2131558466;
+			
+			// aapt resource value: 0x7F0D0043
+			public const int mr_dialog_route_header = 2131558467;
+			
+			// aapt resource value: 0x7F0D0044
+			public const int mr_system_route_name = 2131558468;
+			
+			// aapt resource value: 0x7F0D0045
+			public const int mr_user_route_category_name = 2131558469;
+			
+			// aapt resource value: 0x7F0D0046
+			public const int mtrl_chip_close_icon_content_description = 2131558470;
+			
+			// aapt resource value: 0x7F0D0047
+			public const int password_toggle_content_description = 2131558471;
+			
+			// aapt resource value: 0x7F0D0048
+			public const int path_password_eye = 2131558472;
+			
+			// aapt resource value: 0x7F0D0049
+			public const int path_password_eye_mask_strike_through = 2131558473;
+			
+			// aapt resource value: 0x7F0D004A
+			public const int path_password_eye_mask_visible = 2131558474;
+			
+			// aapt resource value: 0x7F0D004B
+			public const int path_password_strike_through = 2131558475;
+			
+			// aapt resource value: 0x7F0D004C
+			public const int search_menu_title = 2131558476;
+			
+			// aapt resource value: 0x7F0D004D
+			public const int status_bar_notification_info_overflow = 2131558477;
 			
 			static String()
 			{
@@ -6203,1211 +7688,1550 @@ namespace SextantSample.Droid
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f0c00a4
-			public const int AlertDialog_AppCompat = 2131493028;
+			// aapt resource value: 0x7F0E0000
+			public const int AlertDialog_AppCompat = 2131623936;
 			
-			// aapt resource value: 0x7f0c00a5
-			public const int AlertDialog_AppCompat_Light = 2131493029;
+			// aapt resource value: 0x7F0E0001
+			public const int AlertDialog_AppCompat_Light = 2131623937;
 			
-			// aapt resource value: 0x7f0c00a6
-			public const int Animation_AppCompat_Dialog = 2131493030;
+			// aapt resource value: 0x7F0E0002
+			public const int Animation_AppCompat_Dialog = 2131623938;
 			
-			// aapt resource value: 0x7f0c00a7
-			public const int Animation_AppCompat_DropDownUp = 2131493031;
+			// aapt resource value: 0x7F0E0003
+			public const int Animation_AppCompat_DropDownUp = 2131623939;
 			
-			// aapt resource value: 0x7f0c00a8
-			public const int Animation_AppCompat_Tooltip = 2131493032;
+			// aapt resource value: 0x7F0E0004
+			public const int Animation_AppCompat_Tooltip = 2131623940;
 			
-			// aapt resource value: 0x7f0c016e
-			public const int Animation_Design_BottomSheetDialog = 2131493230;
+			// aapt resource value: 0x7F0E0005
+			public const int Animation_Design_BottomSheetDialog = 2131623941;
 			
-			// aapt resource value: 0x7f0c0191
-			public const int AppCompatDialogStyle = 2131493265;
+			// aapt resource value: 0x7F0E0006
+			public const int AppCompatDialogStyle = 2131623942;
 			
-			// aapt resource value: 0x7f0c00a9
-			public const int Base_AlertDialog_AppCompat = 2131493033;
+			// aapt resource value: 0x7F0E0007
+			public const int Base_AlertDialog_AppCompat = 2131623943;
 			
-			// aapt resource value: 0x7f0c00aa
-			public const int Base_AlertDialog_AppCompat_Light = 2131493034;
+			// aapt resource value: 0x7F0E0008
+			public const int Base_AlertDialog_AppCompat_Light = 2131623944;
 			
-			// aapt resource value: 0x7f0c00ab
-			public const int Base_Animation_AppCompat_Dialog = 2131493035;
+			// aapt resource value: 0x7F0E0009
+			public const int Base_Animation_AppCompat_Dialog = 2131623945;
 			
-			// aapt resource value: 0x7f0c00ac
-			public const int Base_Animation_AppCompat_DropDownUp = 2131493036;
+			// aapt resource value: 0x7F0E000A
+			public const int Base_Animation_AppCompat_DropDownUp = 2131623946;
 			
-			// aapt resource value: 0x7f0c00ad
-			public const int Base_Animation_AppCompat_Tooltip = 2131493037;
+			// aapt resource value: 0x7F0E000B
+			public const int Base_Animation_AppCompat_Tooltip = 2131623947;
 			
-			// aapt resource value: 0x7f0c000c
-			public const int Base_CardView = 2131492876;
+			// aapt resource value: 0x7F0E000C
+			public const int Base_CardView = 2131623948;
 			
-			// aapt resource value: 0x7f0c00ae
-			public const int Base_DialogWindowTitle_AppCompat = 2131493038;
+			// aapt resource value: 0x7F0E000E
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131623950;
 			
-			// aapt resource value: 0x7f0c00af
-			public const int Base_DialogWindowTitleBackground_AppCompat = 2131493039;
+			// aapt resource value: 0x7F0E000D
+			public const int Base_DialogWindowTitle_AppCompat = 2131623949;
 			
-			// aapt resource value: 0x7f0c0048
-			public const int Base_TextAppearance_AppCompat = 2131492936;
+			// aapt resource value: 0x7F0E000F
+			public const int Base_TextAppearance_AppCompat = 2131623951;
 			
-			// aapt resource value: 0x7f0c0049
-			public const int Base_TextAppearance_AppCompat_Body1 = 2131492937;
+			// aapt resource value: 0x7F0E0010
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131623952;
 			
-			// aapt resource value: 0x7f0c004a
-			public const int Base_TextAppearance_AppCompat_Body2 = 2131492938;
+			// aapt resource value: 0x7F0E0011
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131623953;
 			
-			// aapt resource value: 0x7f0c0036
-			public const int Base_TextAppearance_AppCompat_Button = 2131492918;
+			// aapt resource value: 0x7F0E0012
+			public const int Base_TextAppearance_AppCompat_Button = 2131623954;
 			
-			// aapt resource value: 0x7f0c004b
-			public const int Base_TextAppearance_AppCompat_Caption = 2131492939;
+			// aapt resource value: 0x7F0E0013
+			public const int Base_TextAppearance_AppCompat_Caption = 2131623955;
 			
-			// aapt resource value: 0x7f0c004c
-			public const int Base_TextAppearance_AppCompat_Display1 = 2131492940;
+			// aapt resource value: 0x7F0E0014
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131623956;
 			
-			// aapt resource value: 0x7f0c004d
-			public const int Base_TextAppearance_AppCompat_Display2 = 2131492941;
+			// aapt resource value: 0x7F0E0015
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131623957;
 			
-			// aapt resource value: 0x7f0c004e
-			public const int Base_TextAppearance_AppCompat_Display3 = 2131492942;
+			// aapt resource value: 0x7F0E0016
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131623958;
 			
-			// aapt resource value: 0x7f0c004f
-			public const int Base_TextAppearance_AppCompat_Display4 = 2131492943;
+			// aapt resource value: 0x7F0E0017
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131623959;
 			
-			// aapt resource value: 0x7f0c0050
-			public const int Base_TextAppearance_AppCompat_Headline = 2131492944;
+			// aapt resource value: 0x7F0E0018
+			public const int Base_TextAppearance_AppCompat_Headline = 2131623960;
 			
-			// aapt resource value: 0x7f0c001a
-			public const int Base_TextAppearance_AppCompat_Inverse = 2131492890;
+			// aapt resource value: 0x7F0E0019
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131623961;
 			
-			// aapt resource value: 0x7f0c0051
-			public const int Base_TextAppearance_AppCompat_Large = 2131492945;
+			// aapt resource value: 0x7F0E001A
+			public const int Base_TextAppearance_AppCompat_Large = 2131623962;
 			
-			// aapt resource value: 0x7f0c001b
-			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131492891;
+			// aapt resource value: 0x7F0E001B
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131623963;
 			
-			// aapt resource value: 0x7f0c0052
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131492946;
+			// aapt resource value: 0x7F0E001C
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131623964;
 			
-			// aapt resource value: 0x7f0c0053
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131492947;
+			// aapt resource value: 0x7F0E001D
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131623965;
 			
-			// aapt resource value: 0x7f0c0054
-			public const int Base_TextAppearance_AppCompat_Medium = 2131492948;
+			// aapt resource value: 0x7F0E001E
+			public const int Base_TextAppearance_AppCompat_Medium = 2131623966;
 			
-			// aapt resource value: 0x7f0c001c
-			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131492892;
+			// aapt resource value: 0x7F0E001F
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131623967;
 			
-			// aapt resource value: 0x7f0c0055
-			public const int Base_TextAppearance_AppCompat_Menu = 2131492949;
+			// aapt resource value: 0x7F0E0020
+			public const int Base_TextAppearance_AppCompat_Menu = 2131623968;
 			
-			// aapt resource value: 0x7f0c00b0
-			public const int Base_TextAppearance_AppCompat_SearchResult = 2131493040;
+			// aapt resource value: 0x7F0E0021
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131623969;
 			
-			// aapt resource value: 0x7f0c0056
-			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131492950;
+			// aapt resource value: 0x7F0E0022
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131623970;
 			
-			// aapt resource value: 0x7f0c0057
-			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131492951;
+			// aapt resource value: 0x7F0E0023
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131623971;
 			
-			// aapt resource value: 0x7f0c0058
-			public const int Base_TextAppearance_AppCompat_Small = 2131492952;
+			// aapt resource value: 0x7F0E0024
+			public const int Base_TextAppearance_AppCompat_Small = 2131623972;
 			
-			// aapt resource value: 0x7f0c001d
-			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131492893;
+			// aapt resource value: 0x7F0E0025
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131623973;
 			
-			// aapt resource value: 0x7f0c0059
-			public const int Base_TextAppearance_AppCompat_Subhead = 2131492953;
+			// aapt resource value: 0x7F0E0026
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131623974;
 			
-			// aapt resource value: 0x7f0c001e
-			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131492894;
+			// aapt resource value: 0x7F0E0027
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131623975;
 			
-			// aapt resource value: 0x7f0c005a
-			public const int Base_TextAppearance_AppCompat_Title = 2131492954;
+			// aapt resource value: 0x7F0E0028
+			public const int Base_TextAppearance_AppCompat_Title = 2131623976;
 			
-			// aapt resource value: 0x7f0c001f
-			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131492895;
+			// aapt resource value: 0x7F0E0029
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131623977;
 			
-			// aapt resource value: 0x7f0c00b1
-			public const int Base_TextAppearance_AppCompat_Tooltip = 2131493041;
+			// aapt resource value: 0x7F0E002A
+			public const int Base_TextAppearance_AppCompat_Tooltip = 2131623978;
 			
-			// aapt resource value: 0x7f0c0095
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131493013;
+			// aapt resource value: 0x7F0E002B
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131623979;
 			
-			// aapt resource value: 0x7f0c005b
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131492955;
+			// aapt resource value: 0x7F0E002C
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131623980;
 			
-			// aapt resource value: 0x7f0c005c
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131492956;
+			// aapt resource value: 0x7F0E002D
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131623981;
 			
-			// aapt resource value: 0x7f0c005d
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131492957;
+			// aapt resource value: 0x7F0E002E
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131623982;
 			
-			// aapt resource value: 0x7f0c005e
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131492958;
+			// aapt resource value: 0x7F0E002F
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131623983;
 			
-			// aapt resource value: 0x7f0c005f
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131492959;
+			// aapt resource value: 0x7F0E0030
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131623984;
 			
-			// aapt resource value: 0x7f0c0060
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131492960;
+			// aapt resource value: 0x7F0E0031
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131623985;
 			
-			// aapt resource value: 0x7f0c0061
-			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131492961;
+			// aapt resource value: 0x7F0E0032
+			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131623986;
 			
-			// aapt resource value: 0x7f0c009c
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131493020;
+			// aapt resource value: 0x7F0E0033
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131623987;
 			
-			// aapt resource value: 0x7f0c009d
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131493021;
+			// aapt resource value: 0x7F0E0034
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131623988;
 			
-			// aapt resource value: 0x7f0c0096
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131493014;
+			// aapt resource value: 0x7F0E0035
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131623989;
 			
-			// aapt resource value: 0x7f0c00b2
-			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131493042;
+			// aapt resource value: 0x7F0E0036
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131623990;
 			
-			// aapt resource value: 0x7f0c0062
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131492962;
+			// aapt resource value: 0x7F0E0037
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131623991;
 			
-			// aapt resource value: 0x7f0c0063
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131492963;
+			// aapt resource value: 0x7F0E0038
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131623992;
 			
-			// aapt resource value: 0x7f0c0064
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131492964;
+			// aapt resource value: 0x7F0E0039
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131623993;
 			
-			// aapt resource value: 0x7f0c0065
-			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131492965;
+			// aapt resource value: 0x7F0E003A
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131623994;
 			
-			// aapt resource value: 0x7f0c0066
-			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131492966;
+			// aapt resource value: 0x7F0E003B
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131623995;
 			
-			// aapt resource value: 0x7f0c00b3
-			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131493043;
+			// aapt resource value: 0x7F0E003C
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131623996;
 			
-			// aapt resource value: 0x7f0c0067
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131492967;
+			// aapt resource value: 0x7F0E003D
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131623997;
 			
-			// aapt resource value: 0x7f0c0068
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131492968;
+			// aapt resource value: 0x7F0E003E
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131623998;
 			
-			// aapt resource value: 0x7f0c0069
-			public const int Base_Theme_AppCompat = 2131492969;
+			// aapt resource value: 0x7F0E005E
+			public const int Base_ThemeOverlay_AppCompat = 2131624030;
 			
-			// aapt resource value: 0x7f0c00b4
-			public const int Base_Theme_AppCompat_CompactMenu = 2131493044;
+			// aapt resource value: 0x7F0E005F
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131624031;
 			
-			// aapt resource value: 0x7f0c0020
-			public const int Base_Theme_AppCompat_Dialog = 2131492896;
+			// aapt resource value: 0x7F0E0060
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131624032;
 			
-			// aapt resource value: 0x7f0c0021
-			public const int Base_Theme_AppCompat_Dialog_Alert = 2131492897;
+			// aapt resource value: 0x7F0E0061
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131624033;
 			
-			// aapt resource value: 0x7f0c00b5
-			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131493045;
+			// aapt resource value: 0x7F0E0062
+			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131624034;
 			
-			// aapt resource value: 0x7f0c0022
-			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131492898;
+			// aapt resource value: 0x7F0E0063
+			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131624035;
 			
-			// aapt resource value: 0x7f0c0010
-			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131492880;
+			// aapt resource value: 0x7F0E0064
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131624036;
 			
-			// aapt resource value: 0x7f0c006a
-			public const int Base_Theme_AppCompat_Light = 2131492970;
+			// aapt resource value: 0x7F0E0065
+			public const int Base_ThemeOverlay_MaterialComponents_Dialog = 2131624037;
 			
-			// aapt resource value: 0x7f0c00b6
-			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131493046;
+			// aapt resource value: 0x7F0E0066
+			public const int Base_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131624038;
 			
-			// aapt resource value: 0x7f0c0023
-			public const int Base_Theme_AppCompat_Light_Dialog = 2131492899;
+			// aapt resource value: 0x7F0E003F
+			public const int Base_Theme_AppCompat = 2131623999;
 			
-			// aapt resource value: 0x7f0c0024
-			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131492900;
+			// aapt resource value: 0x7F0E0040
+			public const int Base_Theme_AppCompat_CompactMenu = 2131624000;
 			
-			// aapt resource value: 0x7f0c00b7
-			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131493047;
+			// aapt resource value: 0x7F0E0041
+			public const int Base_Theme_AppCompat_Dialog = 2131624001;
 			
-			// aapt resource value: 0x7f0c0025
-			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131492901;
+			// aapt resource value: 0x7F0E0045
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131624005;
 			
-			// aapt resource value: 0x7f0c0011
-			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131492881;
+			// aapt resource value: 0x7F0E0042
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131624002;
 			
-			// aapt resource value: 0x7f0c00b8
-			public const int Base_ThemeOverlay_AppCompat = 2131493048;
+			// aapt resource value: 0x7F0E0043
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131624003;
 			
-			// aapt resource value: 0x7f0c00b9
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131493049;
+			// aapt resource value: 0x7F0E0044
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131624004;
 			
-			// aapt resource value: 0x7f0c00ba
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131493050;
+			// aapt resource value: 0x7F0E0046
+			public const int Base_Theme_AppCompat_Light = 2131624006;
 			
-			// aapt resource value: 0x7f0c00bb
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131493051;
+			// aapt resource value: 0x7F0E0047
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131624007;
 			
-			// aapt resource value: 0x7f0c0026
-			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131492902;
+			// aapt resource value: 0x7F0E0048
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131624008;
 			
-			// aapt resource value: 0x7f0c0027
-			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131492903;
+			// aapt resource value: 0x7F0E004C
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131624012;
 			
-			// aapt resource value: 0x7f0c00bc
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131493052;
+			// aapt resource value: 0x7F0E0049
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131624009;
 			
-			// aapt resource value: 0x7f0c0028
-			public const int Base_V11_Theme_AppCompat_Dialog = 2131492904;
+			// aapt resource value: 0x7F0E004A
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131624010;
 			
-			// aapt resource value: 0x7f0c0029
-			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131492905;
+			// aapt resource value: 0x7F0E004B
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131624011;
 			
-			// aapt resource value: 0x7f0c002a
-			public const int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131492906;
+			// aapt resource value: 0x7F0E004D
+			public const int Base_Theme_MaterialComponents = 2131624013;
 			
-			// aapt resource value: 0x7f0c0032
-			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131492914;
+			// aapt resource value: 0x7F0E004E
+			public const int Base_Theme_MaterialComponents_Bridge = 2131624014;
 			
-			// aapt resource value: 0x7f0c0033
-			public const int Base_V12_Widget_AppCompat_EditText = 2131492915;
+			// aapt resource value: 0x7F0E004F
+			public const int Base_Theme_MaterialComponents_CompactMenu = 2131624015;
 			
-			// aapt resource value: 0x7f0c016f
-			public const int Base_V14_Widget_Design_AppBarLayout = 2131493231;
+			// aapt resource value: 0x7F0E0050
+			public const int Base_Theme_MaterialComponents_Dialog = 2131624016;
 			
-			// aapt resource value: 0x7f0c006b
-			public const int Base_V21_Theme_AppCompat = 2131492971;
+			// aapt resource value: 0x7F0E0054
+			public const int Base_Theme_MaterialComponents_DialogWhenLarge = 2131624020;
 			
-			// aapt resource value: 0x7f0c006c
-			public const int Base_V21_Theme_AppCompat_Dialog = 2131492972;
+			// aapt resource value: 0x7F0E0051
+			public const int Base_Theme_MaterialComponents_Dialog_Alert = 2131624017;
 			
-			// aapt resource value: 0x7f0c006d
-			public const int Base_V21_Theme_AppCompat_Light = 2131492973;
+			// aapt resource value: 0x7F0E0052
+			public const int Base_Theme_MaterialComponents_Dialog_FixedSize = 2131624018;
 			
-			// aapt resource value: 0x7f0c006e
-			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131492974;
+			// aapt resource value: 0x7F0E0053
+			public const int Base_Theme_MaterialComponents_Dialog_MinWidth = 2131624019;
 			
-			// aapt resource value: 0x7f0c006f
-			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131492975;
+			// aapt resource value: 0x7F0E0055
+			public const int Base_Theme_MaterialComponents_Light = 2131624021;
 			
-			// aapt resource value: 0x7f0c016b
-			public const int Base_V21_Widget_Design_AppBarLayout = 2131493227;
+			// aapt resource value: 0x7F0E0056
+			public const int Base_Theme_MaterialComponents_Light_Bridge = 2131624022;
 			
-			// aapt resource value: 0x7f0c0093
-			public const int Base_V22_Theme_AppCompat = 2131493011;
+			// aapt resource value: 0x7F0E0057
+			public const int Base_Theme_MaterialComponents_Light_DarkActionBar = 2131624023;
 			
-			// aapt resource value: 0x7f0c0094
-			public const int Base_V22_Theme_AppCompat_Light = 2131493012;
+			// aapt resource value: 0x7F0E0058
+			public const int Base_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131624024;
 			
-			// aapt resource value: 0x7f0c0097
-			public const int Base_V23_Theme_AppCompat = 2131493015;
+			// aapt resource value: 0x7F0E0059
+			public const int Base_Theme_MaterialComponents_Light_Dialog = 2131624025;
 			
-			// aapt resource value: 0x7f0c0098
-			public const int Base_V23_Theme_AppCompat_Light = 2131493016;
+			// aapt resource value: 0x7F0E005D
+			public const int Base_Theme_MaterialComponents_Light_DialogWhenLarge = 2131624029;
 			
-			// aapt resource value: 0x7f0c00a0
-			public const int Base_V26_Theme_AppCompat = 2131493024;
+			// aapt resource value: 0x7F0E005A
+			public const int Base_Theme_MaterialComponents_Light_Dialog_Alert = 2131624026;
 			
-			// aapt resource value: 0x7f0c00a1
-			public const int Base_V26_Theme_AppCompat_Light = 2131493025;
+			// aapt resource value: 0x7F0E005B
+			public const int Base_Theme_MaterialComponents_Light_Dialog_FixedSize = 2131624027;
 			
-			// aapt resource value: 0x7f0c00a2
-			public const int Base_V26_Widget_AppCompat_Toolbar = 2131493026;
+			// aapt resource value: 0x7F0E005C
+			public const int Base_Theme_MaterialComponents_Light_Dialog_MinWidth = 2131624028;
 			
-			// aapt resource value: 0x7f0c016d
-			public const int Base_V26_Widget_Design_AppBarLayout = 2131493229;
+			// aapt resource value: 0x7F0E006E
+			public const int Base_V14_ThemeOverlay_MaterialComponents_Dialog = 2131624046;
 			
-			// aapt resource value: 0x7f0c00bd
-			public const int Base_V7_Theme_AppCompat = 2131493053;
+			// aapt resource value: 0x7F0E006F
+			public const int Base_V14_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131624047;
 			
-			// aapt resource value: 0x7f0c00be
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131493054;
+			// aapt resource value: 0x7F0E0067
+			public const int Base_V14_Theme_MaterialComponents = 2131624039;
 			
-			// aapt resource value: 0x7f0c00bf
-			public const int Base_V7_Theme_AppCompat_Light = 2131493055;
+			// aapt resource value: 0x7F0E0068
+			public const int Base_V14_Theme_MaterialComponents_Bridge = 2131624040;
 			
-			// aapt resource value: 0x7f0c00c0
-			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131493056;
+			// aapt resource value: 0x7F0E0069
+			public const int Base_V14_Theme_MaterialComponents_Dialog = 2131624041;
 			
-			// aapt resource value: 0x7f0c00c1
-			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131493057;
+			// aapt resource value: 0x7F0E006A
+			public const int Base_V14_Theme_MaterialComponents_Light = 2131624042;
 			
-			// aapt resource value: 0x7f0c00c2
-			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131493058;
+			// aapt resource value: 0x7F0E006B
+			public const int Base_V14_Theme_MaterialComponents_Light_Bridge = 2131624043;
 			
-			// aapt resource value: 0x7f0c00c3
-			public const int Base_V7_Widget_AppCompat_EditText = 2131493059;
+			// aapt resource value: 0x7F0E006C
+			public const int Base_V14_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131624044;
 			
-			// aapt resource value: 0x7f0c00c4
-			public const int Base_V7_Widget_AppCompat_Toolbar = 2131493060;
+			// aapt resource value: 0x7F0E006D
+			public const int Base_V14_Theme_MaterialComponents_Light_Dialog = 2131624045;
 			
-			// aapt resource value: 0x7f0c00c5
-			public const int Base_Widget_AppCompat_ActionBar = 2131493061;
+			// aapt resource value: 0x7F0E0074
+			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131624052;
 			
-			// aapt resource value: 0x7f0c00c6
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131493062;
+			// aapt resource value: 0x7F0E0070
+			public const int Base_V21_Theme_AppCompat = 2131624048;
 			
-			// aapt resource value: 0x7f0c00c7
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131493063;
+			// aapt resource value: 0x7F0E0071
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131624049;
 			
-			// aapt resource value: 0x7f0c0070
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131492976;
+			// aapt resource value: 0x7F0E0072
+			public const int Base_V21_Theme_AppCompat_Light = 2131624050;
 			
-			// aapt resource value: 0x7f0c0071
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131492977;
+			// aapt resource value: 0x7F0E0073
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131624051;
 			
-			// aapt resource value: 0x7f0c0072
-			public const int Base_Widget_AppCompat_ActionButton = 2131492978;
+			// aapt resource value: 0x7F0E0075
+			public const int Base_V22_Theme_AppCompat = 2131624053;
 			
-			// aapt resource value: 0x7f0c0073
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131492979;
+			// aapt resource value: 0x7F0E0076
+			public const int Base_V22_Theme_AppCompat_Light = 2131624054;
 			
-			// aapt resource value: 0x7f0c0074
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131492980;
+			// aapt resource value: 0x7F0E0077
+			public const int Base_V23_Theme_AppCompat = 2131624055;
 			
-			// aapt resource value: 0x7f0c00c8
-			public const int Base_Widget_AppCompat_ActionMode = 2131493064;
+			// aapt resource value: 0x7F0E0078
+			public const int Base_V23_Theme_AppCompat_Light = 2131624056;
 			
-			// aapt resource value: 0x7f0c00c9
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131493065;
+			// aapt resource value: 0x7F0E0079
+			public const int Base_V26_Theme_AppCompat = 2131624057;
 			
-			// aapt resource value: 0x7f0c0034
-			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131492916;
+			// aapt resource value: 0x7F0E007A
+			public const int Base_V26_Theme_AppCompat_Light = 2131624058;
 			
-			// aapt resource value: 0x7f0c0075
-			public const int Base_Widget_AppCompat_Button = 2131492981;
+			// aapt resource value: 0x7F0E007B
+			public const int Base_V26_Widget_AppCompat_Toolbar = 2131624059;
 			
-			// aapt resource value: 0x7f0c0076
-			public const int Base_Widget_AppCompat_Button_Borderless = 2131492982;
+			// aapt resource value: 0x7F0E007C
+			public const int Base_V28_Theme_AppCompat = 2131624060;
 			
-			// aapt resource value: 0x7f0c0077
-			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131492983;
+			// aapt resource value: 0x7F0E007D
+			public const int Base_V28_Theme_AppCompat_Light = 2131624061;
 			
-			// aapt resource value: 0x7f0c00ca
-			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131493066;
+			// aapt resource value: 0x7F0E0082
+			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131624066;
 			
-			// aapt resource value: 0x7f0c0099
-			public const int Base_Widget_AppCompat_Button_Colored = 2131493017;
+			// aapt resource value: 0x7F0E007E
+			public const int Base_V7_Theme_AppCompat = 2131624062;
 			
-			// aapt resource value: 0x7f0c0078
-			public const int Base_Widget_AppCompat_Button_Small = 2131492984;
+			// aapt resource value: 0x7F0E007F
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131624063;
 			
-			// aapt resource value: 0x7f0c0079
-			public const int Base_Widget_AppCompat_ButtonBar = 2131492985;
+			// aapt resource value: 0x7F0E0080
+			public const int Base_V7_Theme_AppCompat_Light = 2131624064;
 			
-			// aapt resource value: 0x7f0c00cb
-			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131493067;
+			// aapt resource value: 0x7F0E0081
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131624065;
 			
-			// aapt resource value: 0x7f0c007a
-			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131492986;
+			// aapt resource value: 0x7F0E0083
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131624067;
 			
-			// aapt resource value: 0x7f0c007b
-			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131492987;
+			// aapt resource value: 0x7F0E0084
+			public const int Base_V7_Widget_AppCompat_EditText = 2131624068;
 			
-			// aapt resource value: 0x7f0c00cc
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131493068;
+			// aapt resource value: 0x7F0E0085
+			public const int Base_V7_Widget_AppCompat_Toolbar = 2131624069;
 			
-			// aapt resource value: 0x7f0c000f
-			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131492879;
+			// aapt resource value: 0x7F0E0086
+			public const int Base_Widget_AppCompat_ActionBar = 2131624070;
 			
-			// aapt resource value: 0x7f0c00cd
-			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131493069;
+			// aapt resource value: 0x7F0E0087
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131624071;
 			
-			// aapt resource value: 0x7f0c007c
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131492988;
+			// aapt resource value: 0x7F0E0088
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131624072;
 			
-			// aapt resource value: 0x7f0c0035
-			public const int Base_Widget_AppCompat_EditText = 2131492917;
+			// aapt resource value: 0x7F0E0089
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131624073;
 			
-			// aapt resource value: 0x7f0c007d
-			public const int Base_Widget_AppCompat_ImageButton = 2131492989;
+			// aapt resource value: 0x7F0E008A
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131624074;
 			
-			// aapt resource value: 0x7f0c00ce
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131493070;
+			// aapt resource value: 0x7F0E008B
+			public const int Base_Widget_AppCompat_ActionButton = 2131624075;
 			
-			// aapt resource value: 0x7f0c00cf
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131493071;
+			// aapt resource value: 0x7F0E008C
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131624076;
 			
-			// aapt resource value: 0x7f0c00d0
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131493072;
+			// aapt resource value: 0x7F0E008D
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131624077;
 			
-			// aapt resource value: 0x7f0c007e
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131492990;
+			// aapt resource value: 0x7F0E008E
+			public const int Base_Widget_AppCompat_ActionMode = 2131624078;
 			
-			// aapt resource value: 0x7f0c007f
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131492991;
+			// aapt resource value: 0x7F0E008F
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131624079;
 			
-			// aapt resource value: 0x7f0c0080
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131492992;
+			// aapt resource value: 0x7F0E0090
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131624080;
 			
-			// aapt resource value: 0x7f0c0081
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131492993;
+			// aapt resource value: 0x7F0E0091
+			public const int Base_Widget_AppCompat_Button = 2131624081;
 			
-			// aapt resource value: 0x7f0c0082
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131492994;
+			// aapt resource value: 0x7F0E0097
+			public const int Base_Widget_AppCompat_ButtonBar = 2131624087;
 			
-			// aapt resource value: 0x7f0c00d1
-			public const int Base_Widget_AppCompat_ListMenuView = 2131493073;
+			// aapt resource value: 0x7F0E0098
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131624088;
 			
-			// aapt resource value: 0x7f0c0083
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131492995;
+			// aapt resource value: 0x7F0E0092
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131624082;
 			
-			// aapt resource value: 0x7f0c0084
-			public const int Base_Widget_AppCompat_ListView = 2131492996;
+			// aapt resource value: 0x7F0E0093
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131624083;
 			
-			// aapt resource value: 0x7f0c0085
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131492997;
+			// aapt resource value: 0x7F0E0094
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131624084;
 			
-			// aapt resource value: 0x7f0c0086
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131492998;
+			// aapt resource value: 0x7F0E0095
+			public const int Base_Widget_AppCompat_Button_Colored = 2131624085;
 			
-			// aapt resource value: 0x7f0c0087
-			public const int Base_Widget_AppCompat_PopupMenu = 2131492999;
+			// aapt resource value: 0x7F0E0096
+			public const int Base_Widget_AppCompat_Button_Small = 2131624086;
 			
-			// aapt resource value: 0x7f0c0088
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131493000;
+			// aapt resource value: 0x7F0E0099
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131624089;
 			
-			// aapt resource value: 0x7f0c00d2
-			public const int Base_Widget_AppCompat_PopupWindow = 2131493074;
+			// aapt resource value: 0x7F0E009A
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131624090;
 			
-			// aapt resource value: 0x7f0c002b
-			public const int Base_Widget_AppCompat_ProgressBar = 2131492907;
+			// aapt resource value: 0x7F0E009B
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131624091;
 			
-			// aapt resource value: 0x7f0c002c
-			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131492908;
+			// aapt resource value: 0x7F0E009C
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131624092;
 			
-			// aapt resource value: 0x7f0c0089
-			public const int Base_Widget_AppCompat_RatingBar = 2131493001;
+			// aapt resource value: 0x7F0E009D
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131624093;
 			
-			// aapt resource value: 0x7f0c009a
-			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131493018;
+			// aapt resource value: 0x7F0E009E
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131624094;
 			
-			// aapt resource value: 0x7f0c009b
-			public const int Base_Widget_AppCompat_RatingBar_Small = 2131493019;
+			// aapt resource value: 0x7F0E009F
+			public const int Base_Widget_AppCompat_EditText = 2131624095;
 			
-			// aapt resource value: 0x7f0c00d3
-			public const int Base_Widget_AppCompat_SearchView = 2131493075;
+			// aapt resource value: 0x7F0E00A0
+			public const int Base_Widget_AppCompat_ImageButton = 2131624096;
 			
-			// aapt resource value: 0x7f0c00d4
-			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131493076;
+			// aapt resource value: 0x7F0E00A1
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131624097;
 			
-			// aapt resource value: 0x7f0c008a
-			public const int Base_Widget_AppCompat_SeekBar = 2131493002;
+			// aapt resource value: 0x7F0E00A2
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131624098;
 			
-			// aapt resource value: 0x7f0c00d5
-			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131493077;
+			// aapt resource value: 0x7F0E00A3
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131624099;
 			
-			// aapt resource value: 0x7f0c008b
-			public const int Base_Widget_AppCompat_Spinner = 2131493003;
+			// aapt resource value: 0x7F0E00A4
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131624100;
 			
-			// aapt resource value: 0x7f0c0012
-			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131492882;
+			// aapt resource value: 0x7F0E00A5
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131624101;
 			
-			// aapt resource value: 0x7f0c008c
-			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131493004;
+			// aapt resource value: 0x7F0E00A6
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131624102;
 			
-			// aapt resource value: 0x7f0c00a3
-			public const int Base_Widget_AppCompat_Toolbar = 2131493027;
+			// aapt resource value: 0x7F0E00A7
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131624103;
 			
-			// aapt resource value: 0x7f0c008d
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131493005;
+			// aapt resource value: 0x7F0E00A8
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131624104;
 			
-			// aapt resource value: 0x7f0c016c
-			public const int Base_Widget_Design_AppBarLayout = 2131493228;
+			// aapt resource value: 0x7F0E00A9
+			public const int Base_Widget_AppCompat_ListMenuView = 2131624105;
 			
-			// aapt resource value: 0x7f0c0170
-			public const int Base_Widget_Design_TabLayout = 2131493232;
+			// aapt resource value: 0x7F0E00AA
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131624106;
 			
-			// aapt resource value: 0x7f0c000b
-			public const int CardView = 2131492875;
+			// aapt resource value: 0x7F0E00AB
+			public const int Base_Widget_AppCompat_ListView = 2131624107;
 			
-			// aapt resource value: 0x7f0c000d
-			public const int CardView_Dark = 2131492877;
+			// aapt resource value: 0x7F0E00AC
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131624108;
 			
-			// aapt resource value: 0x7f0c000e
-			public const int CardView_Light = 2131492878;
+			// aapt resource value: 0x7F0E00AD
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131624109;
 			
-			// aapt resource value: 0x7f0c018f
-			public const int MainTheme = 2131493263;
+			// aapt resource value: 0x7F0E00AE
+			public const int Base_Widget_AppCompat_PopupMenu = 2131624110;
 			
-			// aapt resource value: 0x7f0c0190
-			public const int MainTheme_Base = 2131493264;
+			// aapt resource value: 0x7F0E00AF
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131624111;
 			
-			// aapt resource value: 0x7f0c002d
-			public const int Platform_AppCompat = 2131492909;
+			// aapt resource value: 0x7F0E00B0
+			public const int Base_Widget_AppCompat_PopupWindow = 2131624112;
 			
-			// aapt resource value: 0x7f0c002e
-			public const int Platform_AppCompat_Light = 2131492910;
+			// aapt resource value: 0x7F0E00B1
+			public const int Base_Widget_AppCompat_ProgressBar = 2131624113;
 			
-			// aapt resource value: 0x7f0c008e
-			public const int Platform_ThemeOverlay_AppCompat = 2131493006;
+			// aapt resource value: 0x7F0E00B2
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131624114;
 			
-			// aapt resource value: 0x7f0c008f
-			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131493007;
+			// aapt resource value: 0x7F0E00B3
+			public const int Base_Widget_AppCompat_RatingBar = 2131624115;
 			
-			// aapt resource value: 0x7f0c0090
-			public const int Platform_ThemeOverlay_AppCompat_Light = 2131493008;
+			// aapt resource value: 0x7F0E00B4
+			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131624116;
 			
-			// aapt resource value: 0x7f0c002f
-			public const int Platform_V11_AppCompat = 2131492911;
+			// aapt resource value: 0x7F0E00B5
+			public const int Base_Widget_AppCompat_RatingBar_Small = 2131624117;
 			
-			// aapt resource value: 0x7f0c0030
-			public const int Platform_V11_AppCompat_Light = 2131492912;
+			// aapt resource value: 0x7F0E00B6
+			public const int Base_Widget_AppCompat_SearchView = 2131624118;
 			
-			// aapt resource value: 0x7f0c0037
-			public const int Platform_V14_AppCompat = 2131492919;
+			// aapt resource value: 0x7F0E00B7
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131624119;
 			
-			// aapt resource value: 0x7f0c0038
-			public const int Platform_V14_AppCompat_Light = 2131492920;
+			// aapt resource value: 0x7F0E00B8
+			public const int Base_Widget_AppCompat_SeekBar = 2131624120;
 			
-			// aapt resource value: 0x7f0c0091
-			public const int Platform_V21_AppCompat = 2131493009;
+			// aapt resource value: 0x7F0E00B9
+			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131624121;
 			
-			// aapt resource value: 0x7f0c0092
-			public const int Platform_V21_AppCompat_Light = 2131493010;
+			// aapt resource value: 0x7F0E00BA
+			public const int Base_Widget_AppCompat_Spinner = 2131624122;
 			
-			// aapt resource value: 0x7f0c009e
-			public const int Platform_V25_AppCompat = 2131493022;
+			// aapt resource value: 0x7F0E00BB
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131624123;
 			
-			// aapt resource value: 0x7f0c009f
-			public const int Platform_V25_AppCompat_Light = 2131493023;
+			// aapt resource value: 0x7F0E00BC
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131624124;
 			
-			// aapt resource value: 0x7f0c0031
-			public const int Platform_Widget_AppCompat_Spinner = 2131492913;
+			// aapt resource value: 0x7F0E00BD
+			public const int Base_Widget_AppCompat_Toolbar = 2131624125;
 			
-			// aapt resource value: 0x7f0c003a
-			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131492922;
+			// aapt resource value: 0x7F0E00BE
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131624126;
 			
-			// aapt resource value: 0x7f0c003b
-			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131492923;
+			// aapt resource value: 0x7F0E00BF
+			public const int Base_Widget_Design_TabLayout = 2131624127;
 			
-			// aapt resource value: 0x7f0c003c
-			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131492924;
+			// aapt resource value: 0x7F0E00C0
+			public const int Base_Widget_MaterialComponents_Chip = 2131624128;
 			
-			// aapt resource value: 0x7f0c003d
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131492925;
+			// aapt resource value: 0x7F0E00C1
+			public const int Base_Widget_MaterialComponents_TextInputEditText = 2131624129;
 			
-			// aapt resource value: 0x7f0c003e
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131492926;
+			// aapt resource value: 0x7F0E00C2
+			public const int Base_Widget_MaterialComponents_TextInputLayout = 2131624130;
 			
-			// aapt resource value: 0x7f0c003f
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131492927;
+			// aapt resource value: 0x7F0E00C3
+			public const int CardView = 2131624131;
 			
-			// aapt resource value: 0x7f0c0040
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131492928;
+			// aapt resource value: 0x7F0E00C4
+			public const int CardView_Dark = 2131624132;
 			
-			// aapt resource value: 0x7f0c0041
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131492929;
+			// aapt resource value: 0x7F0E00C5
+			public const int CardView_Light = 2131624133;
 			
-			// aapt resource value: 0x7f0c0042
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131492930;
+			// aapt resource value: 0x7F0E0202
+			public const int collectionViewStyle = 2131624450;
 			
-			// aapt resource value: 0x7f0c0043
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131492931;
+			// aapt resource value: 0x7F0E00C6
+			public const int MainTheme = 2131624134;
 			
-			// aapt resource value: 0x7f0c0044
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131492932;
+			// aapt resource value: 0x7F0E00C7
+			public const int MainTheme_Base = 2131624135;
 			
-			// aapt resource value: 0x7f0c0045
-			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131492933;
+			// aapt resource value: 0x7F0E00C8
+			public const int Platform_AppCompat = 2131624136;
 			
-			// aapt resource value: 0x7f0c0046
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131492934;
+			// aapt resource value: 0x7F0E00C9
+			public const int Platform_AppCompat_Light = 2131624137;
 			
-			// aapt resource value: 0x7f0c0047
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131492935;
+			// aapt resource value: 0x7F0E00CA
+			public const int Platform_MaterialComponents = 2131624138;
 			
-			// aapt resource value: 0x7f0c00d6
-			public const int TextAppearance_AppCompat = 2131493078;
+			// aapt resource value: 0x7F0E00CB
+			public const int Platform_MaterialComponents_Dialog = 2131624139;
 			
-			// aapt resource value: 0x7f0c00d7
-			public const int TextAppearance_AppCompat_Body1 = 2131493079;
+			// aapt resource value: 0x7F0E00CC
+			public const int Platform_MaterialComponents_Light = 2131624140;
 			
-			// aapt resource value: 0x7f0c00d8
-			public const int TextAppearance_AppCompat_Body2 = 2131493080;
+			// aapt resource value: 0x7F0E00CD
+			public const int Platform_MaterialComponents_Light_Dialog = 2131624141;
 			
-			// aapt resource value: 0x7f0c00d9
-			public const int TextAppearance_AppCompat_Button = 2131493081;
+			// aapt resource value: 0x7F0E00CE
+			public const int Platform_ThemeOverlay_AppCompat = 2131624142;
 			
-			// aapt resource value: 0x7f0c00da
-			public const int TextAppearance_AppCompat_Caption = 2131493082;
+			// aapt resource value: 0x7F0E00CF
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131624143;
 			
-			// aapt resource value: 0x7f0c00db
-			public const int TextAppearance_AppCompat_Display1 = 2131493083;
+			// aapt resource value: 0x7F0E00D0
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131624144;
 			
-			// aapt resource value: 0x7f0c00dc
-			public const int TextAppearance_AppCompat_Display2 = 2131493084;
+			// aapt resource value: 0x7F0E00D1
+			public const int Platform_V21_AppCompat = 2131624145;
 			
-			// aapt resource value: 0x7f0c00dd
-			public const int TextAppearance_AppCompat_Display3 = 2131493085;
+			// aapt resource value: 0x7F0E00D2
+			public const int Platform_V21_AppCompat_Light = 2131624146;
 			
-			// aapt resource value: 0x7f0c00de
-			public const int TextAppearance_AppCompat_Display4 = 2131493086;
+			// aapt resource value: 0x7F0E00D3
+			public const int Platform_V25_AppCompat = 2131624147;
 			
-			// aapt resource value: 0x7f0c00df
-			public const int TextAppearance_AppCompat_Headline = 2131493087;
+			// aapt resource value: 0x7F0E00D4
+			public const int Platform_V25_AppCompat_Light = 2131624148;
 			
-			// aapt resource value: 0x7f0c00e0
-			public const int TextAppearance_AppCompat_Inverse = 2131493088;
+			// aapt resource value: 0x7F0E00D5
+			public const int Platform_Widget_AppCompat_Spinner = 2131624149;
 			
-			// aapt resource value: 0x7f0c00e1
-			public const int TextAppearance_AppCompat_Large = 2131493089;
+			// aapt resource value: 0x7F0E00D6
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131624150;
 			
-			// aapt resource value: 0x7f0c00e2
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131493090;
+			// aapt resource value: 0x7F0E00D7
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131624151;
 			
-			// aapt resource value: 0x7f0c00e3
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131493091;
+			// aapt resource value: 0x7F0E00D8
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131624152;
 			
-			// aapt resource value: 0x7f0c00e4
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131493092;
+			// aapt resource value: 0x7F0E00D9
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131624153;
 			
-			// aapt resource value: 0x7f0c00e5
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131493093;
+			// aapt resource value: 0x7F0E00DA
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131624154;
 			
-			// aapt resource value: 0x7f0c00e6
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131493094;
+			// aapt resource value: 0x7F0E00DB
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Shortcut = 2131624155;
 			
-			// aapt resource value: 0x7f0c00e7
-			public const int TextAppearance_AppCompat_Medium = 2131493095;
+			// aapt resource value: 0x7F0E00DC
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_SubmenuArrow = 2131624156;
 			
-			// aapt resource value: 0x7f0c00e8
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131493096;
+			// aapt resource value: 0x7F0E00DD
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131624157;
 			
-			// aapt resource value: 0x7f0c00e9
-			public const int TextAppearance_AppCompat_Menu = 2131493097;
+			// aapt resource value: 0x7F0E00DE
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Title = 2131624158;
 			
-			// aapt resource value: 0x7f0c00ea
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131493098;
+			// aapt resource value: 0x7F0E00E4
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131624164;
 			
-			// aapt resource value: 0x7f0c00eb
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131493099;
+			// aapt resource value: 0x7F0E00DF
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131624159;
 			
-			// aapt resource value: 0x7f0c00ec
-			public const int TextAppearance_AppCompat_Small = 2131493100;
+			// aapt resource value: 0x7F0E00E0
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131624160;
 			
-			// aapt resource value: 0x7f0c00ed
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131493101;
+			// aapt resource value: 0x7F0E00E1
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131624161;
 			
-			// aapt resource value: 0x7f0c00ee
-			public const int TextAppearance_AppCompat_Subhead = 2131493102;
+			// aapt resource value: 0x7F0E00E2
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131624162;
 			
-			// aapt resource value: 0x7f0c00ef
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131493103;
+			// aapt resource value: 0x7F0E00E3
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131624163;
 			
-			// aapt resource value: 0x7f0c00f0
-			public const int TextAppearance_AppCompat_Title = 2131493104;
+			// aapt resource value: 0x7F0E00E5
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131624165;
 			
-			// aapt resource value: 0x7f0c00f1
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131493105;
+			// aapt resource value: 0x7F0E00E6
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131624166;
 			
-			// aapt resource value: 0x7f0c0039
-			public const int TextAppearance_AppCompat_Tooltip = 2131492921;
+			// aapt resource value: 0x7F0E00E7
+			public const int TextAppearance_AppCompat = 2131624167;
 			
-			// aapt resource value: 0x7f0c00f2
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131493106;
+			// aapt resource value: 0x7F0E00E8
+			public const int TextAppearance_AppCompat_Body1 = 2131624168;
 			
-			// aapt resource value: 0x7f0c00f3
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131493107;
+			// aapt resource value: 0x7F0E00E9
+			public const int TextAppearance_AppCompat_Body2 = 2131624169;
 			
-			// aapt resource value: 0x7f0c00f4
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131493108;
+			// aapt resource value: 0x7F0E00EA
+			public const int TextAppearance_AppCompat_Button = 2131624170;
 			
-			// aapt resource value: 0x7f0c00f5
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131493109;
+			// aapt resource value: 0x7F0E00EB
+			public const int TextAppearance_AppCompat_Caption = 2131624171;
 			
-			// aapt resource value: 0x7f0c00f6
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131493110;
+			// aapt resource value: 0x7F0E00EC
+			public const int TextAppearance_AppCompat_Display1 = 2131624172;
 			
-			// aapt resource value: 0x7f0c00f7
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131493111;
+			// aapt resource value: 0x7F0E00ED
+			public const int TextAppearance_AppCompat_Display2 = 2131624173;
 			
-			// aapt resource value: 0x7f0c00f8
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131493112;
+			// aapt resource value: 0x7F0E00EE
+			public const int TextAppearance_AppCompat_Display3 = 2131624174;
 			
-			// aapt resource value: 0x7f0c00f9
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131493113;
+			// aapt resource value: 0x7F0E00EF
+			public const int TextAppearance_AppCompat_Display4 = 2131624175;
 			
-			// aapt resource value: 0x7f0c00fa
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131493114;
+			// aapt resource value: 0x7F0E00F0
+			public const int TextAppearance_AppCompat_Headline = 2131624176;
 			
-			// aapt resource value: 0x7f0c00fb
-			public const int TextAppearance_AppCompat_Widget_Button = 2131493115;
+			// aapt resource value: 0x7F0E00F1
+			public const int TextAppearance_AppCompat_Inverse = 2131624177;
 			
-			// aapt resource value: 0x7f0c00fc
-			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131493116;
+			// aapt resource value: 0x7F0E00F2
+			public const int TextAppearance_AppCompat_Large = 2131624178;
 			
-			// aapt resource value: 0x7f0c00fd
-			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131493117;
+			// aapt resource value: 0x7F0E00F3
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131624179;
 			
-			// aapt resource value: 0x7f0c00fe
-			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131493118;
+			// aapt resource value: 0x7F0E00F4
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131624180;
 			
-			// aapt resource value: 0x7f0c00ff
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131493119;
+			// aapt resource value: 0x7F0E00F5
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131624181;
 			
-			// aapt resource value: 0x7f0c0100
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131493120;
+			// aapt resource value: 0x7F0E00F6
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131624182;
 			
-			// aapt resource value: 0x7f0c0101
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131493121;
+			// aapt resource value: 0x7F0E00F7
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131624183;
 			
-			// aapt resource value: 0x7f0c0102
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131493122;
+			// aapt resource value: 0x7F0E00F8
+			public const int TextAppearance_AppCompat_Medium = 2131624184;
 			
-			// aapt resource value: 0x7f0c0103
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131493123;
+			// aapt resource value: 0x7F0E00F9
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131624185;
 			
-			// aapt resource value: 0x7f0c0104
-			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131493124;
+			// aapt resource value: 0x7F0E00FA
+			public const int TextAppearance_AppCompat_Menu = 2131624186;
 			
-			// aapt resource value: 0x7f0c0188
-			public const int TextAppearance_Compat_Notification = 2131493256;
+			// aapt resource value: 0x7F0E00FB
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131624187;
 			
-			// aapt resource value: 0x7f0c0189
-			public const int TextAppearance_Compat_Notification_Info = 2131493257;
+			// aapt resource value: 0x7F0E00FC
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131624188;
 			
-			// aapt resource value: 0x7f0c0165
-			public const int TextAppearance_Compat_Notification_Info_Media = 2131493221;
+			// aapt resource value: 0x7F0E00FD
+			public const int TextAppearance_AppCompat_Small = 2131624189;
 			
-			// aapt resource value: 0x7f0c018e
-			public const int TextAppearance_Compat_Notification_Line2 = 2131493262;
+			// aapt resource value: 0x7F0E00FE
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131624190;
 			
-			// aapt resource value: 0x7f0c0169
-			public const int TextAppearance_Compat_Notification_Line2_Media = 2131493225;
+			// aapt resource value: 0x7F0E00FF
+			public const int TextAppearance_AppCompat_Subhead = 2131624191;
 			
-			// aapt resource value: 0x7f0c0166
-			public const int TextAppearance_Compat_Notification_Media = 2131493222;
+			// aapt resource value: 0x7F0E0100
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131624192;
 			
-			// aapt resource value: 0x7f0c018a
-			public const int TextAppearance_Compat_Notification_Time = 2131493258;
+			// aapt resource value: 0x7F0E0101
+			public const int TextAppearance_AppCompat_Title = 2131624193;
 			
-			// aapt resource value: 0x7f0c0167
-			public const int TextAppearance_Compat_Notification_Time_Media = 2131493223;
+			// aapt resource value: 0x7F0E0102
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131624194;
 			
-			// aapt resource value: 0x7f0c018b
-			public const int TextAppearance_Compat_Notification_Title = 2131493259;
+			// aapt resource value: 0x7F0E0103
+			public const int TextAppearance_AppCompat_Tooltip = 2131624195;
 			
-			// aapt resource value: 0x7f0c0168
-			public const int TextAppearance_Compat_Notification_Title_Media = 2131493224;
+			// aapt resource value: 0x7F0E0104
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131624196;
 			
-			// aapt resource value: 0x7f0c0171
-			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131493233;
+			// aapt resource value: 0x7F0E0105
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131624197;
 			
-			// aapt resource value: 0x7f0c0172
-			public const int TextAppearance_Design_Counter = 2131493234;
+			// aapt resource value: 0x7F0E0106
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131624198;
 			
-			// aapt resource value: 0x7f0c0173
-			public const int TextAppearance_Design_Counter_Overflow = 2131493235;
+			// aapt resource value: 0x7F0E0107
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131624199;
 			
-			// aapt resource value: 0x7f0c0174
-			public const int TextAppearance_Design_Error = 2131493236;
+			// aapt resource value: 0x7F0E0108
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131624200;
 			
-			// aapt resource value: 0x7f0c0175
-			public const int TextAppearance_Design_Hint = 2131493237;
+			// aapt resource value: 0x7F0E0109
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131624201;
 			
-			// aapt resource value: 0x7f0c0176
-			public const int TextAppearance_Design_Snackbar_Message = 2131493238;
+			// aapt resource value: 0x7F0E010A
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131624202;
 			
-			// aapt resource value: 0x7f0c0177
-			public const int TextAppearance_Design_Tab = 2131493239;
+			// aapt resource value: 0x7F0E010B
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131624203;
 			
-			// aapt resource value: 0x7f0c0000
-			public const int TextAppearance_MediaRouter_PrimaryText = 2131492864;
+			// aapt resource value: 0x7F0E010C
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131624204;
 			
-			// aapt resource value: 0x7f0c0001
-			public const int TextAppearance_MediaRouter_SecondaryText = 2131492865;
+			// aapt resource value: 0x7F0E010D
+			public const int TextAppearance_AppCompat_Widget_Button = 2131624205;
 			
-			// aapt resource value: 0x7f0c0002
-			public const int TextAppearance_MediaRouter_Title = 2131492866;
+			// aapt resource value: 0x7F0E010E
+			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131624206;
 			
-			// aapt resource value: 0x7f0c0105
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131493125;
+			// aapt resource value: 0x7F0E010F
+			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131624207;
 			
-			// aapt resource value: 0x7f0c0106
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131493126;
+			// aapt resource value: 0x7F0E0110
+			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131624208;
 			
-			// aapt resource value: 0x7f0c0107
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131493127;
+			// aapt resource value: 0x7F0E0111
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131624209;
 			
-			// aapt resource value: 0x7f0c0108
-			public const int Theme_AppCompat = 2131493128;
+			// aapt resource value: 0x7F0E0112
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131624210;
 			
-			// aapt resource value: 0x7f0c0109
-			public const int Theme_AppCompat_CompactMenu = 2131493129;
+			// aapt resource value: 0x7F0E0113
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131624211;
 			
-			// aapt resource value: 0x7f0c0013
-			public const int Theme_AppCompat_DayNight = 2131492883;
+			// aapt resource value: 0x7F0E0114
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131624212;
 			
-			// aapt resource value: 0x7f0c0014
-			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131492884;
+			// aapt resource value: 0x7F0E0115
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131624213;
 			
-			// aapt resource value: 0x7f0c0015
-			public const int Theme_AppCompat_DayNight_Dialog = 2131492885;
+			// aapt resource value: 0x7F0E0116
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131624214;
 			
-			// aapt resource value: 0x7f0c0016
-			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131492886;
+			// aapt resource value: 0x7F0E0117
+			public const int TextAppearance_Compat_Notification = 2131624215;
 			
-			// aapt resource value: 0x7f0c0017
-			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131492887;
+			// aapt resource value: 0x7F0E0118
+			public const int TextAppearance_Compat_Notification_Info = 2131624216;
 			
-			// aapt resource value: 0x7f0c0018
-			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131492888;
+			// aapt resource value: 0x7F0E0119
+			public const int TextAppearance_Compat_Notification_Info_Media = 2131624217;
 			
-			// aapt resource value: 0x7f0c0019
-			public const int Theme_AppCompat_DayNight_NoActionBar = 2131492889;
+			// aapt resource value: 0x7F0E011A
+			public const int TextAppearance_Compat_Notification_Line2 = 2131624218;
 			
-			// aapt resource value: 0x7f0c010a
-			public const int Theme_AppCompat_Dialog = 2131493130;
+			// aapt resource value: 0x7F0E011B
+			public const int TextAppearance_Compat_Notification_Line2_Media = 2131624219;
 			
-			// aapt resource value: 0x7f0c010b
-			public const int Theme_AppCompat_Dialog_Alert = 2131493131;
+			// aapt resource value: 0x7F0E011C
+			public const int TextAppearance_Compat_Notification_Media = 2131624220;
 			
-			// aapt resource value: 0x7f0c010c
-			public const int Theme_AppCompat_Dialog_MinWidth = 2131493132;
+			// aapt resource value: 0x7F0E011D
+			public const int TextAppearance_Compat_Notification_Time = 2131624221;
 			
-			// aapt resource value: 0x7f0c010d
-			public const int Theme_AppCompat_DialogWhenLarge = 2131493133;
+			// aapt resource value: 0x7F0E011E
+			public const int TextAppearance_Compat_Notification_Time_Media = 2131624222;
 			
-			// aapt resource value: 0x7f0c010e
-			public const int Theme_AppCompat_Light = 2131493134;
+			// aapt resource value: 0x7F0E011F
+			public const int TextAppearance_Compat_Notification_Title = 2131624223;
 			
-			// aapt resource value: 0x7f0c010f
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131493135;
+			// aapt resource value: 0x7F0E0120
+			public const int TextAppearance_Compat_Notification_Title_Media = 2131624224;
 			
-			// aapt resource value: 0x7f0c0110
-			public const int Theme_AppCompat_Light_Dialog = 2131493136;
+			// aapt resource value: 0x7F0E0121
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131624225;
 			
-			// aapt resource value: 0x7f0c0111
-			public const int Theme_AppCompat_Light_Dialog_Alert = 2131493137;
+			// aapt resource value: 0x7F0E0122
+			public const int TextAppearance_Design_Counter = 2131624226;
 			
-			// aapt resource value: 0x7f0c0112
-			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131493138;
+			// aapt resource value: 0x7F0E0123
+			public const int TextAppearance_Design_Counter_Overflow = 2131624227;
 			
-			// aapt resource value: 0x7f0c0113
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131493139;
+			// aapt resource value: 0x7F0E0124
+			public const int TextAppearance_Design_Error = 2131624228;
 			
-			// aapt resource value: 0x7f0c0114
-			public const int Theme_AppCompat_Light_NoActionBar = 2131493140;
+			// aapt resource value: 0x7F0E0125
+			public const int TextAppearance_Design_HelperText = 2131624229;
 			
-			// aapt resource value: 0x7f0c0115
-			public const int Theme_AppCompat_NoActionBar = 2131493141;
+			// aapt resource value: 0x7F0E0126
+			public const int TextAppearance_Design_Hint = 2131624230;
 			
-			// aapt resource value: 0x7f0c0178
-			public const int Theme_Design = 2131493240;
+			// aapt resource value: 0x7F0E0127
+			public const int TextAppearance_Design_Snackbar_Message = 2131624231;
 			
-			// aapt resource value: 0x7f0c0179
-			public const int Theme_Design_BottomSheetDialog = 2131493241;
+			// aapt resource value: 0x7F0E0128
+			public const int TextAppearance_Design_Tab = 2131624232;
 			
-			// aapt resource value: 0x7f0c017a
-			public const int Theme_Design_Light = 2131493242;
+			// aapt resource value: 0x7F0E0129
+			public const int TextAppearance_MaterialComponents_Body1 = 2131624233;
 			
-			// aapt resource value: 0x7f0c017b
-			public const int Theme_Design_Light_BottomSheetDialog = 2131493243;
+			// aapt resource value: 0x7F0E012A
+			public const int TextAppearance_MaterialComponents_Body2 = 2131624234;
 			
-			// aapt resource value: 0x7f0c017c
-			public const int Theme_Design_Light_NoActionBar = 2131493244;
+			// aapt resource value: 0x7F0E012B
+			public const int TextAppearance_MaterialComponents_Button = 2131624235;
 			
-			// aapt resource value: 0x7f0c017d
-			public const int Theme_Design_NoActionBar = 2131493245;
+			// aapt resource value: 0x7F0E012C
+			public const int TextAppearance_MaterialComponents_Caption = 2131624236;
 			
-			// aapt resource value: 0x7f0c0003
-			public const int Theme_MediaRouter = 2131492867;
+			// aapt resource value: 0x7F0E012D
+			public const int TextAppearance_MaterialComponents_Chip = 2131624237;
 			
-			// aapt resource value: 0x7f0c0004
-			public const int Theme_MediaRouter_Light = 2131492868;
+			// aapt resource value: 0x7F0E012E
+			public const int TextAppearance_MaterialComponents_Headline1 = 2131624238;
 			
-			// aapt resource value: 0x7f0c0005
-			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131492869;
+			// aapt resource value: 0x7F0E012F
+			public const int TextAppearance_MaterialComponents_Headline2 = 2131624239;
 			
-			// aapt resource value: 0x7f0c0006
-			public const int Theme_MediaRouter_LightControlPanel = 2131492870;
+			// aapt resource value: 0x7F0E0130
+			public const int TextAppearance_MaterialComponents_Headline3 = 2131624240;
 			
-			// aapt resource value: 0x7f0c0116
-			public const int ThemeOverlay_AppCompat = 2131493142;
+			// aapt resource value: 0x7F0E0131
+			public const int TextAppearance_MaterialComponents_Headline4 = 2131624241;
 			
-			// aapt resource value: 0x7f0c0117
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131493143;
+			// aapt resource value: 0x7F0E0132
+			public const int TextAppearance_MaterialComponents_Headline5 = 2131624242;
 			
-			// aapt resource value: 0x7f0c0118
-			public const int ThemeOverlay_AppCompat_Dark = 2131493144;
+			// aapt resource value: 0x7F0E0133
+			public const int TextAppearance_MaterialComponents_Headline6 = 2131624243;
 			
-			// aapt resource value: 0x7f0c0119
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131493145;
+			// aapt resource value: 0x7F0E0134
+			public const int TextAppearance_MaterialComponents_Overline = 2131624244;
 			
-			// aapt resource value: 0x7f0c011a
-			public const int ThemeOverlay_AppCompat_Dialog = 2131493146;
+			// aapt resource value: 0x7F0E0135
+			public const int TextAppearance_MaterialComponents_Subtitle1 = 2131624245;
 			
-			// aapt resource value: 0x7f0c011b
-			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131493147;
+			// aapt resource value: 0x7F0E0136
+			public const int TextAppearance_MaterialComponents_Subtitle2 = 2131624246;
 			
-			// aapt resource value: 0x7f0c011c
-			public const int ThemeOverlay_AppCompat_Light = 2131493148;
+			// aapt resource value: 0x7F0E0137
+			public const int TextAppearance_MaterialComponents_Tab = 2131624247;
 			
-			// aapt resource value: 0x7f0c0007
-			public const int ThemeOverlay_MediaRouter_Dark = 2131492871;
+			// aapt resource value: 0x7F0E0138
+			public const int TextAppearance_MediaRouter_PrimaryText = 2131624248;
 			
-			// aapt resource value: 0x7f0c0008
-			public const int ThemeOverlay_MediaRouter_Light = 2131492872;
+			// aapt resource value: 0x7F0E0139
+			public const int TextAppearance_MediaRouter_SecondaryText = 2131624249;
 			
-			// aapt resource value: 0x7f0c011d
-			public const int Widget_AppCompat_ActionBar = 2131493149;
+			// aapt resource value: 0x7F0E013A
+			public const int TextAppearance_MediaRouter_Title = 2131624250;
 			
-			// aapt resource value: 0x7f0c011e
-			public const int Widget_AppCompat_ActionBar_Solid = 2131493150;
+			// aapt resource value: 0x7F0E013B
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131624251;
 			
-			// aapt resource value: 0x7f0c011f
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131493151;
+			// aapt resource value: 0x7F0E013C
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131624252;
 			
-			// aapt resource value: 0x7f0c0120
-			public const int Widget_AppCompat_ActionBar_TabText = 2131493152;
+			// aapt resource value: 0x7F0E013D
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131624253;
 			
-			// aapt resource value: 0x7f0c0121
-			public const int Widget_AppCompat_ActionBar_TabView = 2131493153;
+			// aapt resource value: 0x7F0E0172
+			public const int ThemeOverlay_AppCompat = 2131624306;
 			
-			// aapt resource value: 0x7f0c0122
-			public const int Widget_AppCompat_ActionButton = 2131493154;
+			// aapt resource value: 0x7F0E0173
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131624307;
 			
-			// aapt resource value: 0x7f0c0123
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131493155;
+			// aapt resource value: 0x7F0E0174
+			public const int ThemeOverlay_AppCompat_Dark = 2131624308;
 			
-			// aapt resource value: 0x7f0c0124
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131493156;
+			// aapt resource value: 0x7F0E0175
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131624309;
 			
-			// aapt resource value: 0x7f0c0125
-			public const int Widget_AppCompat_ActionMode = 2131493157;
+			// aapt resource value: 0x7F0E0176
+			public const int ThemeOverlay_AppCompat_Dialog = 2131624310;
 			
-			// aapt resource value: 0x7f0c0126
-			public const int Widget_AppCompat_ActivityChooserView = 2131493158;
+			// aapt resource value: 0x7F0E0177
+			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131624311;
 			
-			// aapt resource value: 0x7f0c0127
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131493159;
+			// aapt resource value: 0x7F0E0178
+			public const int ThemeOverlay_AppCompat_Light = 2131624312;
 			
-			// aapt resource value: 0x7f0c0128
-			public const int Widget_AppCompat_Button = 2131493160;
+			// aapt resource value: 0x7F0E0179
+			public const int ThemeOverlay_MaterialComponents = 2131624313;
 			
-			// aapt resource value: 0x7f0c0129
-			public const int Widget_AppCompat_Button_Borderless = 2131493161;
+			// aapt resource value: 0x7F0E017A
+			public const int ThemeOverlay_MaterialComponents_ActionBar = 2131624314;
 			
-			// aapt resource value: 0x7f0c012a
-			public const int Widget_AppCompat_Button_Borderless_Colored = 2131493162;
+			// aapt resource value: 0x7F0E017B
+			public const int ThemeOverlay_MaterialComponents_Dark = 2131624315;
 			
-			// aapt resource value: 0x7f0c012b
-			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131493163;
+			// aapt resource value: 0x7F0E017C
+			public const int ThemeOverlay_MaterialComponents_Dark_ActionBar = 2131624316;
 			
-			// aapt resource value: 0x7f0c012c
-			public const int Widget_AppCompat_Button_Colored = 2131493164;
+			// aapt resource value: 0x7F0E017D
+			public const int ThemeOverlay_MaterialComponents_Dialog = 2131624317;
 			
-			// aapt resource value: 0x7f0c012d
-			public const int Widget_AppCompat_Button_Small = 2131493165;
+			// aapt resource value: 0x7F0E017E
+			public const int ThemeOverlay_MaterialComponents_Dialog_Alert = 2131624318;
 			
-			// aapt resource value: 0x7f0c012e
-			public const int Widget_AppCompat_ButtonBar = 2131493166;
+			// aapt resource value: 0x7F0E017F
+			public const int ThemeOverlay_MaterialComponents_Light = 2131624319;
 			
-			// aapt resource value: 0x7f0c012f
-			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131493167;
+			// aapt resource value: 0x7F0E0180
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText = 2131624320;
 			
-			// aapt resource value: 0x7f0c0130
-			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131493168;
+			// aapt resource value: 0x7F0E0181
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox = 2131624321;
 			
-			// aapt resource value: 0x7f0c0131
-			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131493169;
+			// aapt resource value: 0x7F0E0182
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131624322;
 			
-			// aapt resource value: 0x7f0c0132
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131493170;
+			// aapt resource value: 0x7F0E0183
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox = 2131624323;
 			
-			// aapt resource value: 0x7f0c0133
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131493171;
+			// aapt resource value: 0x7F0E0184
+			public const int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131624324;
 			
-			// aapt resource value: 0x7f0c0134
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131493172;
+			// aapt resource value: 0x7F0E0185
+			public const int ThemeOverlay_MediaRouter_Dark = 2131624325;
 			
-			// aapt resource value: 0x7f0c0135
-			public const int Widget_AppCompat_EditText = 2131493173;
+			// aapt resource value: 0x7F0E0186
+			public const int ThemeOverlay_MediaRouter_Light = 2131624326;
 			
-			// aapt resource value: 0x7f0c0136
-			public const int Widget_AppCompat_ImageButton = 2131493174;
+			// aapt resource value: 0x7F0E013E
+			public const int Theme_AppCompat = 2131624254;
 			
-			// aapt resource value: 0x7f0c0137
-			public const int Widget_AppCompat_Light_ActionBar = 2131493175;
+			// aapt resource value: 0x7F0E013F
+			public const int Theme_AppCompat_CompactMenu = 2131624255;
 			
-			// aapt resource value: 0x7f0c0138
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131493176;
+			// aapt resource value: 0x7F0E0140
+			public const int Theme_AppCompat_DayNight = 2131624256;
 			
-			// aapt resource value: 0x7f0c0139
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131493177;
+			// aapt resource value: 0x7F0E0141
+			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131624257;
 			
-			// aapt resource value: 0x7f0c013a
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131493178;
+			// aapt resource value: 0x7F0E0142
+			public const int Theme_AppCompat_DayNight_Dialog = 2131624258;
 			
-			// aapt resource value: 0x7f0c013b
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131493179;
+			// aapt resource value: 0x7F0E0145
+			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131624261;
 			
-			// aapt resource value: 0x7f0c013c
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131493180;
+			// aapt resource value: 0x7F0E0143
+			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131624259;
 			
-			// aapt resource value: 0x7f0c013d
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131493181;
+			// aapt resource value: 0x7F0E0144
+			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131624260;
 			
-			// aapt resource value: 0x7f0c013e
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131493182;
+			// aapt resource value: 0x7F0E0146
+			public const int Theme_AppCompat_DayNight_NoActionBar = 2131624262;
 			
-			// aapt resource value: 0x7f0c013f
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131493183;
+			// aapt resource value: 0x7F0E0147
+			public const int Theme_AppCompat_Dialog = 2131624263;
 			
-			// aapt resource value: 0x7f0c0140
-			public const int Widget_AppCompat_Light_ActionButton = 2131493184;
+			// aapt resource value: 0x7F0E014A
+			public const int Theme_AppCompat_DialogWhenLarge = 2131624266;
 			
-			// aapt resource value: 0x7f0c0141
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131493185;
+			// aapt resource value: 0x7F0E0148
+			public const int Theme_AppCompat_Dialog_Alert = 2131624264;
 			
-			// aapt resource value: 0x7f0c0142
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131493186;
+			// aapt resource value: 0x7F0E0149
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131624265;
 			
-			// aapt resource value: 0x7f0c0143
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131493187;
+			// aapt resource value: 0x7F0E014B
+			public const int Theme_AppCompat_Light = 2131624267;
 			
-			// aapt resource value: 0x7f0c0144
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131493188;
+			// aapt resource value: 0x7F0E014C
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131624268;
 			
-			// aapt resource value: 0x7f0c0145
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131493189;
+			// aapt resource value: 0x7F0E014D
+			public const int Theme_AppCompat_Light_Dialog = 2131624269;
 			
-			// aapt resource value: 0x7f0c0146
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131493190;
+			// aapt resource value: 0x7F0E0150
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131624272;
 			
-			// aapt resource value: 0x7f0c0147
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131493191;
+			// aapt resource value: 0x7F0E014E
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131624270;
 			
-			// aapt resource value: 0x7f0c0148
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131493192;
+			// aapt resource value: 0x7F0E014F
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131624271;
 			
-			// aapt resource value: 0x7f0c0149
-			public const int Widget_AppCompat_Light_PopupMenu = 2131493193;
+			// aapt resource value: 0x7F0E0151
+			public const int Theme_AppCompat_Light_NoActionBar = 2131624273;
 			
-			// aapt resource value: 0x7f0c014a
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131493194;
+			// aapt resource value: 0x7F0E0152
+			public const int Theme_AppCompat_NoActionBar = 2131624274;
 			
-			// aapt resource value: 0x7f0c014b
-			public const int Widget_AppCompat_Light_SearchView = 2131493195;
+			// aapt resource value: 0x7F0E0153
+			public const int Theme_Design = 2131624275;
 			
-			// aapt resource value: 0x7f0c014c
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131493196;
+			// aapt resource value: 0x7F0E0154
+			public const int Theme_Design_BottomSheetDialog = 2131624276;
 			
-			// aapt resource value: 0x7f0c014d
-			public const int Widget_AppCompat_ListMenuView = 2131493197;
+			// aapt resource value: 0x7F0E0155
+			public const int Theme_Design_Light = 2131624277;
 			
-			// aapt resource value: 0x7f0c014e
-			public const int Widget_AppCompat_ListPopupWindow = 2131493198;
+			// aapt resource value: 0x7F0E0156
+			public const int Theme_Design_Light_BottomSheetDialog = 2131624278;
 			
-			// aapt resource value: 0x7f0c014f
-			public const int Widget_AppCompat_ListView = 2131493199;
+			// aapt resource value: 0x7F0E0157
+			public const int Theme_Design_Light_NoActionBar = 2131624279;
 			
-			// aapt resource value: 0x7f0c0150
-			public const int Widget_AppCompat_ListView_DropDown = 2131493200;
+			// aapt resource value: 0x7F0E0158
+			public const int Theme_Design_NoActionBar = 2131624280;
 			
-			// aapt resource value: 0x7f0c0151
-			public const int Widget_AppCompat_ListView_Menu = 2131493201;
+			// aapt resource value: 0x7F0E0159
+			public const int Theme_MaterialComponents = 2131624281;
 			
-			// aapt resource value: 0x7f0c0152
-			public const int Widget_AppCompat_PopupMenu = 2131493202;
+			// aapt resource value: 0x7F0E015A
+			public const int Theme_MaterialComponents_BottomSheetDialog = 2131624282;
 			
-			// aapt resource value: 0x7f0c0153
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131493203;
+			// aapt resource value: 0x7F0E015B
+			public const int Theme_MaterialComponents_Bridge = 2131624283;
 			
-			// aapt resource value: 0x7f0c0154
-			public const int Widget_AppCompat_PopupWindow = 2131493204;
+			// aapt resource value: 0x7F0E015C
+			public const int Theme_MaterialComponents_CompactMenu = 2131624284;
 			
-			// aapt resource value: 0x7f0c0155
-			public const int Widget_AppCompat_ProgressBar = 2131493205;
+			// aapt resource value: 0x7F0E015D
+			public const int Theme_MaterialComponents_Dialog = 2131624285;
 			
-			// aapt resource value: 0x7f0c0156
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131493206;
+			// aapt resource value: 0x7F0E0160
+			public const int Theme_MaterialComponents_DialogWhenLarge = 2131624288;
 			
-			// aapt resource value: 0x7f0c0157
-			public const int Widget_AppCompat_RatingBar = 2131493207;
+			// aapt resource value: 0x7F0E015E
+			public const int Theme_MaterialComponents_Dialog_Alert = 2131624286;
 			
-			// aapt resource value: 0x7f0c0158
-			public const int Widget_AppCompat_RatingBar_Indicator = 2131493208;
+			// aapt resource value: 0x7F0E015F
+			public const int Theme_MaterialComponents_Dialog_MinWidth = 2131624287;
 			
-			// aapt resource value: 0x7f0c0159
-			public const int Widget_AppCompat_RatingBar_Small = 2131493209;
+			// aapt resource value: 0x7F0E0161
+			public const int Theme_MaterialComponents_Light = 2131624289;
 			
-			// aapt resource value: 0x7f0c015a
-			public const int Widget_AppCompat_SearchView = 2131493210;
+			// aapt resource value: 0x7F0E0162
+			public const int Theme_MaterialComponents_Light_BottomSheetDialog = 2131624290;
 			
-			// aapt resource value: 0x7f0c015b
-			public const int Widget_AppCompat_SearchView_ActionBar = 2131493211;
+			// aapt resource value: 0x7F0E0163
+			public const int Theme_MaterialComponents_Light_Bridge = 2131624291;
 			
-			// aapt resource value: 0x7f0c015c
-			public const int Widget_AppCompat_SeekBar = 2131493212;
+			// aapt resource value: 0x7F0E0164
+			public const int Theme_MaterialComponents_Light_DarkActionBar = 2131624292;
 			
-			// aapt resource value: 0x7f0c015d
-			public const int Widget_AppCompat_SeekBar_Discrete = 2131493213;
+			// aapt resource value: 0x7F0E0165
+			public const int Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131624293;
 			
-			// aapt resource value: 0x7f0c015e
-			public const int Widget_AppCompat_Spinner = 2131493214;
+			// aapt resource value: 0x7F0E0166
+			public const int Theme_MaterialComponents_Light_Dialog = 2131624294;
 			
-			// aapt resource value: 0x7f0c015f
-			public const int Widget_AppCompat_Spinner_DropDown = 2131493215;
+			// aapt resource value: 0x7F0E0169
+			public const int Theme_MaterialComponents_Light_DialogWhenLarge = 2131624297;
 			
-			// aapt resource value: 0x7f0c0160
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131493216;
+			// aapt resource value: 0x7F0E0167
+			public const int Theme_MaterialComponents_Light_Dialog_Alert = 2131624295;
 			
-			// aapt resource value: 0x7f0c0161
-			public const int Widget_AppCompat_Spinner_Underlined = 2131493217;
+			// aapt resource value: 0x7F0E0168
+			public const int Theme_MaterialComponents_Light_Dialog_MinWidth = 2131624296;
 			
-			// aapt resource value: 0x7f0c0162
-			public const int Widget_AppCompat_TextView_SpinnerItem = 2131493218;
+			// aapt resource value: 0x7F0E016A
+			public const int Theme_MaterialComponents_Light_NoActionBar = 2131624298;
 			
-			// aapt resource value: 0x7f0c0163
-			public const int Widget_AppCompat_Toolbar = 2131493219;
+			// aapt resource value: 0x7F0E016B
+			public const int Theme_MaterialComponents_Light_NoActionBar_Bridge = 2131624299;
 			
-			// aapt resource value: 0x7f0c0164
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131493220;
+			// aapt resource value: 0x7F0E016C
+			public const int Theme_MaterialComponents_NoActionBar = 2131624300;
 			
-			// aapt resource value: 0x7f0c018c
-			public const int Widget_Compat_NotificationActionContainer = 2131493260;
+			// aapt resource value: 0x7F0E016D
+			public const int Theme_MaterialComponents_NoActionBar_Bridge = 2131624301;
 			
-			// aapt resource value: 0x7f0c018d
-			public const int Widget_Compat_NotificationActionText = 2131493261;
+			// aapt resource value: 0x7F0E016E
+			public const int Theme_MediaRouter = 2131624302;
 			
-			// aapt resource value: 0x7f0c017e
-			public const int Widget_Design_AppBarLayout = 2131493246;
+			// aapt resource value: 0x7F0E016F
+			public const int Theme_MediaRouter_Light = 2131624303;
 			
-			// aapt resource value: 0x7f0c017f
-			public const int Widget_Design_BottomNavigationView = 2131493247;
+			// aapt resource value: 0x7F0E0171
+			public const int Theme_MediaRouter_LightControlPanel = 2131624305;
 			
-			// aapt resource value: 0x7f0c0180
-			public const int Widget_Design_BottomSheet_Modal = 2131493248;
+			// aapt resource value: 0x7F0E0170
+			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131624304;
 			
-			// aapt resource value: 0x7f0c0181
-			public const int Widget_Design_CollapsingToolbar = 2131493249;
+			// aapt resource value: 0x7F0E0187
+			public const int Widget_AppCompat_ActionBar = 2131624327;
 			
-			// aapt resource value: 0x7f0c0182
-			public const int Widget_Design_CoordinatorLayout = 2131493250;
+			// aapt resource value: 0x7F0E0188
+			public const int Widget_AppCompat_ActionBar_Solid = 2131624328;
 			
-			// aapt resource value: 0x7f0c0183
-			public const int Widget_Design_FloatingActionButton = 2131493251;
+			// aapt resource value: 0x7F0E0189
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131624329;
 			
-			// aapt resource value: 0x7f0c0184
-			public const int Widget_Design_NavigationView = 2131493252;
+			// aapt resource value: 0x7F0E018A
+			public const int Widget_AppCompat_ActionBar_TabText = 2131624330;
 			
-			// aapt resource value: 0x7f0c0185
-			public const int Widget_Design_ScrimInsetsFrameLayout = 2131493253;
+			// aapt resource value: 0x7F0E018B
+			public const int Widget_AppCompat_ActionBar_TabView = 2131624331;
 			
-			// aapt resource value: 0x7f0c0186
-			public const int Widget_Design_Snackbar = 2131493254;
+			// aapt resource value: 0x7F0E018C
+			public const int Widget_AppCompat_ActionButton = 2131624332;
 			
-			// aapt resource value: 0x7f0c016a
-			public const int Widget_Design_TabLayout = 2131493226;
+			// aapt resource value: 0x7F0E018D
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131624333;
 			
-			// aapt resource value: 0x7f0c0187
-			public const int Widget_Design_TextInputLayout = 2131493255;
+			// aapt resource value: 0x7F0E018E
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131624334;
 			
-			// aapt resource value: 0x7f0c0009
-			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131492873;
+			// aapt resource value: 0x7F0E018F
+			public const int Widget_AppCompat_ActionMode = 2131624335;
 			
-			// aapt resource value: 0x7f0c000a
-			public const int Widget_MediaRouter_MediaRouteButton = 2131492874;
+			// aapt resource value: 0x7F0E0190
+			public const int Widget_AppCompat_ActivityChooserView = 2131624336;
+			
+			// aapt resource value: 0x7F0E0191
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131624337;
+			
+			// aapt resource value: 0x7F0E0192
+			public const int Widget_AppCompat_Button = 2131624338;
+			
+			// aapt resource value: 0x7F0E0198
+			public const int Widget_AppCompat_ButtonBar = 2131624344;
+			
+			// aapt resource value: 0x7F0E0199
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131624345;
+			
+			// aapt resource value: 0x7F0E0193
+			public const int Widget_AppCompat_Button_Borderless = 2131624339;
+			
+			// aapt resource value: 0x7F0E0194
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131624340;
+			
+			// aapt resource value: 0x7F0E0195
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131624341;
+			
+			// aapt resource value: 0x7F0E0196
+			public const int Widget_AppCompat_Button_Colored = 2131624342;
+			
+			// aapt resource value: 0x7F0E0197
+			public const int Widget_AppCompat_Button_Small = 2131624343;
+			
+			// aapt resource value: 0x7F0E019A
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131624346;
+			
+			// aapt resource value: 0x7F0E019B
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131624347;
+			
+			// aapt resource value: 0x7F0E019C
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131624348;
+			
+			// aapt resource value: 0x7F0E019D
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131624349;
+			
+			// aapt resource value: 0x7F0E019E
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131624350;
+			
+			// aapt resource value: 0x7F0E019F
+			public const int Widget_AppCompat_EditText = 2131624351;
+			
+			// aapt resource value: 0x7F0E01A0
+			public const int Widget_AppCompat_ImageButton = 2131624352;
+			
+			// aapt resource value: 0x7F0E01A1
+			public const int Widget_AppCompat_Light_ActionBar = 2131624353;
+			
+			// aapt resource value: 0x7F0E01A2
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131624354;
+			
+			// aapt resource value: 0x7F0E01A3
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131624355;
+			
+			// aapt resource value: 0x7F0E01A4
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131624356;
+			
+			// aapt resource value: 0x7F0E01A5
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131624357;
+			
+			// aapt resource value: 0x7F0E01A6
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131624358;
+			
+			// aapt resource value: 0x7F0E01A7
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131624359;
+			
+			// aapt resource value: 0x7F0E01A8
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131624360;
+			
+			// aapt resource value: 0x7F0E01A9
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131624361;
+			
+			// aapt resource value: 0x7F0E01AA
+			public const int Widget_AppCompat_Light_ActionButton = 2131624362;
+			
+			// aapt resource value: 0x7F0E01AB
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131624363;
+			
+			// aapt resource value: 0x7F0E01AC
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131624364;
+			
+			// aapt resource value: 0x7F0E01AD
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131624365;
+			
+			// aapt resource value: 0x7F0E01AE
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131624366;
+			
+			// aapt resource value: 0x7F0E01AF
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131624367;
+			
+			// aapt resource value: 0x7F0E01B0
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131624368;
+			
+			// aapt resource value: 0x7F0E01B1
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131624369;
+			
+			// aapt resource value: 0x7F0E01B2
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131624370;
+			
+			// aapt resource value: 0x7F0E01B3
+			public const int Widget_AppCompat_Light_PopupMenu = 2131624371;
+			
+			// aapt resource value: 0x7F0E01B4
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131624372;
+			
+			// aapt resource value: 0x7F0E01B5
+			public const int Widget_AppCompat_Light_SearchView = 2131624373;
+			
+			// aapt resource value: 0x7F0E01B6
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131624374;
+			
+			// aapt resource value: 0x7F0E01B7
+			public const int Widget_AppCompat_ListMenuView = 2131624375;
+			
+			// aapt resource value: 0x7F0E01B8
+			public const int Widget_AppCompat_ListPopupWindow = 2131624376;
+			
+			// aapt resource value: 0x7F0E01B9
+			public const int Widget_AppCompat_ListView = 2131624377;
+			
+			// aapt resource value: 0x7F0E01BA
+			public const int Widget_AppCompat_ListView_DropDown = 2131624378;
+			
+			// aapt resource value: 0x7F0E01BB
+			public const int Widget_AppCompat_ListView_Menu = 2131624379;
+			
+			// aapt resource value: 0x7F0E01BC
+			public const int Widget_AppCompat_PopupMenu = 2131624380;
+			
+			// aapt resource value: 0x7F0E01BD
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131624381;
+			
+			// aapt resource value: 0x7F0E01BE
+			public const int Widget_AppCompat_PopupWindow = 2131624382;
+			
+			// aapt resource value: 0x7F0E01BF
+			public const int Widget_AppCompat_ProgressBar = 2131624383;
+			
+			// aapt resource value: 0x7F0E01C0
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131624384;
+			
+			// aapt resource value: 0x7F0E01C1
+			public const int Widget_AppCompat_RatingBar = 2131624385;
+			
+			// aapt resource value: 0x7F0E01C2
+			public const int Widget_AppCompat_RatingBar_Indicator = 2131624386;
+			
+			// aapt resource value: 0x7F0E01C3
+			public const int Widget_AppCompat_RatingBar_Small = 2131624387;
+			
+			// aapt resource value: 0x7F0E01C4
+			public const int Widget_AppCompat_SearchView = 2131624388;
+			
+			// aapt resource value: 0x7F0E01C5
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131624389;
+			
+			// aapt resource value: 0x7F0E01C6
+			public const int Widget_AppCompat_SeekBar = 2131624390;
+			
+			// aapt resource value: 0x7F0E01C7
+			public const int Widget_AppCompat_SeekBar_Discrete = 2131624391;
+			
+			// aapt resource value: 0x7F0E01C8
+			public const int Widget_AppCompat_Spinner = 2131624392;
+			
+			// aapt resource value: 0x7F0E01C9
+			public const int Widget_AppCompat_Spinner_DropDown = 2131624393;
+			
+			// aapt resource value: 0x7F0E01CA
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131624394;
+			
+			// aapt resource value: 0x7F0E01CB
+			public const int Widget_AppCompat_Spinner_Underlined = 2131624395;
+			
+			// aapt resource value: 0x7F0E01CC
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131624396;
+			
+			// aapt resource value: 0x7F0E01CD
+			public const int Widget_AppCompat_Toolbar = 2131624397;
+			
+			// aapt resource value: 0x7F0E01CE
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131624398;
+			
+			// aapt resource value: 0x7F0E01CF
+			public const int Widget_Compat_NotificationActionContainer = 2131624399;
+			
+			// aapt resource value: 0x7F0E01D0
+			public const int Widget_Compat_NotificationActionText = 2131624400;
+			
+			// aapt resource value: 0x7F0E01D1
+			public const int Widget_Design_AppBarLayout = 2131624401;
+			
+			// aapt resource value: 0x7F0E01D2
+			public const int Widget_Design_BottomNavigationView = 2131624402;
+			
+			// aapt resource value: 0x7F0E01D3
+			public const int Widget_Design_BottomSheet_Modal = 2131624403;
+			
+			// aapt resource value: 0x7F0E01D4
+			public const int Widget_Design_CollapsingToolbar = 2131624404;
+			
+			// aapt resource value: 0x7F0E01D5
+			public const int Widget_Design_FloatingActionButton = 2131624405;
+			
+			// aapt resource value: 0x7F0E01D6
+			public const int Widget_Design_NavigationView = 2131624406;
+			
+			// aapt resource value: 0x7F0E01D7
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131624407;
+			
+			// aapt resource value: 0x7F0E01D8
+			public const int Widget_Design_Snackbar = 2131624408;
+			
+			// aapt resource value: 0x7F0E01D9
+			public const int Widget_Design_TabLayout = 2131624409;
+			
+			// aapt resource value: 0x7F0E01DA
+			public const int Widget_Design_TextInputLayout = 2131624410;
+			
+			// aapt resource value: 0x7F0E01DB
+			public const int Widget_MaterialComponents_BottomAppBar = 2131624411;
+			
+			// aapt resource value: 0x7F0E01DC
+			public const int Widget_MaterialComponents_BottomAppBar_Colored = 2131624412;
+			
+			// aapt resource value: 0x7F0E01DD
+			public const int Widget_MaterialComponents_BottomNavigationView = 2131624413;
+			
+			// aapt resource value: 0x7F0E01DE
+			public const int Widget_MaterialComponents_BottomNavigationView_Colored = 2131624414;
+			
+			// aapt resource value: 0x7F0E01DF
+			public const int Widget_MaterialComponents_BottomSheet_Modal = 2131624415;
+			
+			// aapt resource value: 0x7F0E01E0
+			public const int Widget_MaterialComponents_Button = 2131624416;
+			
+			// aapt resource value: 0x7F0E01E1
+			public const int Widget_MaterialComponents_Button_Icon = 2131624417;
+			
+			// aapt resource value: 0x7F0E01E2
+			public const int Widget_MaterialComponents_Button_OutlinedButton = 2131624418;
+			
+			// aapt resource value: 0x7F0E01E3
+			public const int Widget_MaterialComponents_Button_OutlinedButton_Icon = 2131624419;
+			
+			// aapt resource value: 0x7F0E01E4
+			public const int Widget_MaterialComponents_Button_TextButton = 2131624420;
+			
+			// aapt resource value: 0x7F0E01E5
+			public const int Widget_MaterialComponents_Button_TextButton_Dialog = 2131624421;
+			
+			// aapt resource value: 0x7F0E01E6
+			public const int Widget_MaterialComponents_Button_TextButton_Dialog_Icon = 2131624422;
+			
+			// aapt resource value: 0x7F0E01E7
+			public const int Widget_MaterialComponents_Button_TextButton_Icon = 2131624423;
+			
+			// aapt resource value: 0x7F0E01E8
+			public const int Widget_MaterialComponents_Button_UnelevatedButton = 2131624424;
+			
+			// aapt resource value: 0x7F0E01E9
+			public const int Widget_MaterialComponents_Button_UnelevatedButton_Icon = 2131624425;
+			
+			// aapt resource value: 0x7F0E01EA
+			public const int Widget_MaterialComponents_CardView = 2131624426;
+			
+			// aapt resource value: 0x7F0E01EF
+			public const int Widget_MaterialComponents_ChipGroup = 2131624431;
+			
+			// aapt resource value: 0x7F0E01EB
+			public const int Widget_MaterialComponents_Chip_Action = 2131624427;
+			
+			// aapt resource value: 0x7F0E01EC
+			public const int Widget_MaterialComponents_Chip_Choice = 2131624428;
+			
+			// aapt resource value: 0x7F0E01ED
+			public const int Widget_MaterialComponents_Chip_Entry = 2131624429;
+			
+			// aapt resource value: 0x7F0E01EE
+			public const int Widget_MaterialComponents_Chip_Filter = 2131624430;
+			
+			// aapt resource value: 0x7F0E01F0
+			public const int Widget_MaterialComponents_FloatingActionButton = 2131624432;
+			
+			// aapt resource value: 0x7F0E01F1
+			public const int Widget_MaterialComponents_NavigationView = 2131624433;
+			
+			// aapt resource value: 0x7F0E01F2
+			public const int Widget_MaterialComponents_Snackbar = 2131624434;
+			
+			// aapt resource value: 0x7F0E01F3
+			public const int Widget_MaterialComponents_Snackbar_FullWidth = 2131624435;
+			
+			// aapt resource value: 0x7F0E01F4
+			public const int Widget_MaterialComponents_TabLayout = 2131624436;
+			
+			// aapt resource value: 0x7F0E01F5
+			public const int Widget_MaterialComponents_TabLayout_Colored = 2131624437;
+			
+			// aapt resource value: 0x7F0E01F6
+			public const int Widget_MaterialComponents_TextInputEditText_FilledBox = 2131624438;
+			
+			// aapt resource value: 0x7F0E01F7
+			public const int Widget_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131624439;
+			
+			// aapt resource value: 0x7F0E01F8
+			public const int Widget_MaterialComponents_TextInputEditText_OutlinedBox = 2131624440;
+			
+			// aapt resource value: 0x7F0E01F9
+			public const int Widget_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131624441;
+			
+			// aapt resource value: 0x7F0E01FA
+			public const int Widget_MaterialComponents_TextInputLayout_FilledBox = 2131624442;
+			
+			// aapt resource value: 0x7F0E01FB
+			public const int Widget_MaterialComponents_TextInputLayout_FilledBox_Dense = 2131624443;
+			
+			// aapt resource value: 0x7F0E01FC
+			public const int Widget_MaterialComponents_TextInputLayout_OutlinedBox = 2131624444;
+			
+			// aapt resource value: 0x7F0E01FD
+			public const int Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense = 2131624445;
+			
+			// aapt resource value: 0x7F0E01FE
+			public const int Widget_MaterialComponents_Toolbar = 2131624446;
+			
+			// aapt resource value: 0x7F0E01FF
+			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131624447;
+			
+			// aapt resource value: 0x7F0E0200
+			public const int Widget_MediaRouter_MediaRouteButton = 2131624448;
+			
+			// aapt resource value: 0x7F0E0201
+			public const int Widget_Support_CoordinatorLayout = 2131624449;
 			
 			static Style()
 			{
@@ -7422,210 +9246,300 @@ namespace SextantSample.Droid
 		public partial class Styleable
 		{
 			
+			// aapt resource value: { 0x7F030031,0x7F030032,0x7F030033,0x7F030091,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F0300A4,0x7F0300A9,0x7F0300AA,0x7F0300B5,0x7F0300E0,0x7F0300E5,0x7F0300EA,0x7F0300EB,0x7F0300ED,0x7F0300F7,0x7F030101,0x7F030124,0x7F03013D,0x7F03014E,0x7F030152,0x7F030153,0x7F030181,0x7F030184,0x7F0301C9,0x7F0301D3 }
 			public static int[] ActionBar = new int[] {
-					2130772003,
-					2130772005,
-					2130772006,
-					2130772007,
-					2130772008,
-					2130772009,
-					2130772010,
-					2130772011,
-					2130772012,
-					2130772013,
-					2130772014,
-					2130772015,
-					2130772016,
-					2130772017,
-					2130772018,
-					2130772019,
-					2130772020,
-					2130772021,
-					2130772022,
-					2130772023,
-					2130772024,
-					2130772025,
-					2130772026,
-					2130772027,
-					2130772028,
-					2130772029,
-					2130772030,
-					2130772031,
-					2130772101};
+					2130903089,
+					2130903090,
+					2130903091,
+					2130903185,
+					2130903186,
+					2130903187,
+					2130903188,
+					2130903189,
+					2130903190,
+					2130903204,
+					2130903209,
+					2130903210,
+					2130903221,
+					2130903264,
+					2130903269,
+					2130903274,
+					2130903275,
+					2130903277,
+					2130903287,
+					2130903297,
+					2130903332,
+					2130903357,
+					2130903374,
+					2130903378,
+					2130903379,
+					2130903425,
+					2130903428,
+					2130903497,
+					2130903507};
 			
-			// aapt resource value: 10
-			public const int ActionBar_background = 10;
-			
-			// aapt resource value: 12
-			public const int ActionBar_backgroundSplit = 12;
-			
-			// aapt resource value: 11
-			public const int ActionBar_backgroundStacked = 11;
-			
-			// aapt resource value: 21
-			public const int ActionBar_contentInsetEnd = 21;
-			
-			// aapt resource value: 25
-			public const int ActionBar_contentInsetEndWithActions = 25;
-			
-			// aapt resource value: 22
-			public const int ActionBar_contentInsetLeft = 22;
-			
-			// aapt resource value: 23
-			public const int ActionBar_contentInsetRight = 23;
-			
-			// aapt resource value: 20
-			public const int ActionBar_contentInsetStart = 20;
-			
-			// aapt resource value: 24
-			public const int ActionBar_contentInsetStartWithNavigation = 24;
-			
-			// aapt resource value: 13
-			public const int ActionBar_customNavigationLayout = 13;
-			
-			// aapt resource value: 3
-			public const int ActionBar_displayOptions = 3;
-			
-			// aapt resource value: 9
-			public const int ActionBar_divider = 9;
-			
-			// aapt resource value: 26
-			public const int ActionBar_elevation = 26;
-			
-			// aapt resource value: 0
-			public const int ActionBar_height = 0;
-			
-			// aapt resource value: 19
-			public const int ActionBar_hideOnContentScroll = 19;
-			
-			// aapt resource value: 28
-			public const int ActionBar_homeAsUpIndicator = 28;
-			
-			// aapt resource value: 14
-			public const int ActionBar_homeLayout = 14;
-			
-			// aapt resource value: 7
-			public const int ActionBar_icon = 7;
-			
-			// aapt resource value: 16
-			public const int ActionBar_indeterminateProgressStyle = 16;
-			
-			// aapt resource value: 18
-			public const int ActionBar_itemPadding = 18;
-			
-			// aapt resource value: 8
-			public const int ActionBar_logo = 8;
-			
-			// aapt resource value: 2
-			public const int ActionBar_navigationMode = 2;
-			
-			// aapt resource value: 27
-			public const int ActionBar_popupTheme = 27;
-			
-			// aapt resource value: 17
-			public const int ActionBar_progressBarPadding = 17;
-			
-			// aapt resource value: 15
-			public const int ActionBar_progressBarStyle = 15;
-			
-			// aapt resource value: 4
-			public const int ActionBar_subtitle = 4;
-			
-			// aapt resource value: 6
-			public const int ActionBar_subtitleTextStyle = 6;
-			
-			// aapt resource value: 1
-			public const int ActionBar_title = 1;
-			
-			// aapt resource value: 5
-			public const int ActionBar_titleTextStyle = 5;
-			
+			// aapt resource value: { 0x10100B3 }
 			public static int[] ActionBarLayout = new int[] {
 					16842931};
 			
 			// aapt resource value: 0
 			public const int ActionBarLayout_android_layout_gravity = 0;
 			
+			// aapt resource value: 0
+			public const int ActionBar_background = 0;
+			
+			// aapt resource value: 1
+			public const int ActionBar_backgroundSplit = 1;
+			
+			// aapt resource value: 2
+			public const int ActionBar_backgroundStacked = 2;
+			
+			// aapt resource value: 3
+			public const int ActionBar_contentInsetEnd = 3;
+			
+			// aapt resource value: 4
+			public const int ActionBar_contentInsetEndWithActions = 4;
+			
+			// aapt resource value: 5
+			public const int ActionBar_contentInsetLeft = 5;
+			
+			// aapt resource value: 6
+			public const int ActionBar_contentInsetRight = 6;
+			
+			// aapt resource value: 7
+			public const int ActionBar_contentInsetStart = 7;
+			
+			// aapt resource value: 8
+			public const int ActionBar_contentInsetStartWithNavigation = 8;
+			
+			// aapt resource value: 9
+			public const int ActionBar_customNavigationLayout = 9;
+			
+			// aapt resource value: 10
+			public const int ActionBar_displayOptions = 10;
+			
+			// aapt resource value: 11
+			public const int ActionBar_divider = 11;
+			
+			// aapt resource value: 12
+			public const int ActionBar_elevation = 12;
+			
+			// aapt resource value: 13
+			public const int ActionBar_height = 13;
+			
+			// aapt resource value: 14
+			public const int ActionBar_hideOnContentScroll = 14;
+			
+			// aapt resource value: 15
+			public const int ActionBar_homeAsUpIndicator = 15;
+			
+			// aapt resource value: 16
+			public const int ActionBar_homeLayout = 16;
+			
+			// aapt resource value: 17
+			public const int ActionBar_icon = 17;
+			
+			// aapt resource value: 18
+			public const int ActionBar_indeterminateProgressStyle = 18;
+			
+			// aapt resource value: 19
+			public const int ActionBar_itemPadding = 19;
+			
+			// aapt resource value: 20
+			public const int ActionBar_logo = 20;
+			
+			// aapt resource value: 21
+			public const int ActionBar_navigationMode = 21;
+			
+			// aapt resource value: 22
+			public const int ActionBar_popupTheme = 22;
+			
+			// aapt resource value: 23
+			public const int ActionBar_progressBarPadding = 23;
+			
+			// aapt resource value: 24
+			public const int ActionBar_progressBarStyle = 24;
+			
+			// aapt resource value: 25
+			public const int ActionBar_subtitle = 25;
+			
+			// aapt resource value: 26
+			public const int ActionBar_subtitleTextStyle = 26;
+			
+			// aapt resource value: 27
+			public const int ActionBar_title = 27;
+			
+			// aapt resource value: 28
+			public const int ActionBar_titleTextStyle = 28;
+			
+			// aapt resource value: { 0x101013F }
 			public static int[] ActionMenuItemView = new int[] {
 					16843071};
 			
 			// aapt resource value: 0
 			public const int ActionMenuItemView_android_minWidth = 0;
 			
-			public static int[] ActionMenuView;
+			// aapt resource value: { 0xFFFFFFFF }
+			public static int[] ActionMenuView = new int[] {
+					-1};
 			
+			// aapt resource value: { 0x7F030031,0x7F030032,0x7F03007E,0x7F0300E0,0x7F030184,0x7F0301D3 }
 			public static int[] ActionMode = new int[] {
-					2130772003,
-					2130772009,
-					2130772010,
-					2130772014,
-					2130772016,
-					2130772032};
-			
-			// aapt resource value: 3
-			public const int ActionMode_background = 3;
-			
-			// aapt resource value: 4
-			public const int ActionMode_backgroundSplit = 4;
-			
-			// aapt resource value: 5
-			public const int ActionMode_closeItemLayout = 5;
+					2130903089,
+					2130903090,
+					2130903166,
+					2130903264,
+					2130903428,
+					2130903507};
 			
 			// aapt resource value: 0
-			public const int ActionMode_height = 0;
+			public const int ActionMode_background = 0;
+			
+			// aapt resource value: 1
+			public const int ActionMode_backgroundSplit = 1;
 			
 			// aapt resource value: 2
-			public const int ActionMode_subtitleTextStyle = 2;
+			public const int ActionMode_closeItemLayout = 2;
 			
-			// aapt resource value: 1
-			public const int ActionMode_titleTextStyle = 1;
+			// aapt resource value: 3
+			public const int ActionMode_height = 3;
 			
+			// aapt resource value: 4
+			public const int ActionMode_subtitleTextStyle = 4;
+			
+			// aapt resource value: 5
+			public const int ActionMode_titleTextStyle = 5;
+			
+			// aapt resource value: { 0x7F0300BA,0x7F0300F8 }
 			public static int[] ActivityChooserView = new int[] {
-					2130772033,
-					2130772034};
-			
-			// aapt resource value: 1
-			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 1;
+					2130903226,
+					2130903288};
 			
 			// aapt resource value: 0
-			public const int ActivityChooserView_initialActivityCount = 0;
+			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 0;
 			
+			// aapt resource value: 1
+			public const int ActivityChooserView_initialActivityCount = 1;
+			
+			// aapt resource value: { 0x10100F2,0x7F030052,0x7F030053,0x7F03011B,0x7F03011C,0x7F03013A,0x7F030169,0x7F03016A }
 			public static int[] AlertDialog = new int[] {
 					16842994,
-					2130772035,
-					2130772036,
-					2130772037,
-					2130772038,
-					2130772039,
-					2130772040};
+					2130903122,
+					2130903123,
+					2130903323,
+					2130903324,
+					2130903354,
+					2130903401,
+					2130903402};
 			
 			// aapt resource value: 0
 			public const int AlertDialog_android_layout = 0;
 			
 			// aapt resource value: 1
-			public const int AlertDialog_buttonPanelSideLayout = 1;
-			
-			// aapt resource value: 5
-			public const int AlertDialog_listItemLayout = 5;
+			public const int AlertDialog_buttonIconDimen = 1;
 			
 			// aapt resource value: 2
-			public const int AlertDialog_listLayout = 2;
+			public const int AlertDialog_buttonPanelSideLayout = 2;
 			
 			// aapt resource value: 3
-			public const int AlertDialog_multiChoiceItemLayout = 3;
+			public const int AlertDialog_listItemLayout = 3;
+			
+			// aapt resource value: 4
+			public const int AlertDialog_listLayout = 4;
+			
+			// aapt resource value: 5
+			public const int AlertDialog_multiChoiceItemLayout = 5;
 			
 			// aapt resource value: 6
 			public const int AlertDialog_showTitle = 6;
 			
-			// aapt resource value: 4
-			public const int AlertDialog_singleChoiceItemLayout = 4;
+			// aapt resource value: 7
+			public const int AlertDialog_singleChoiceItemLayout = 7;
 			
+			// aapt resource value: { 0x101011C,0x1010194,0x1010195,0x1010196,0x101030C,0x101030D }
+			public static int[] AnimatedStateListDrawableCompat = new int[] {
+					16843036,
+					16843156,
+					16843157,
+					16843158,
+					16843532,
+					16843533};
+			
+			// aapt resource value: 3
+			public const int AnimatedStateListDrawableCompat_android_constantSize = 3;
+			
+			// aapt resource value: 0
+			public const int AnimatedStateListDrawableCompat_android_dither = 0;
+			
+			// aapt resource value: 4
+			public const int AnimatedStateListDrawableCompat_android_enterFadeDuration = 4;
+			
+			// aapt resource value: 5
+			public const int AnimatedStateListDrawableCompat_android_exitFadeDuration = 5;
+			
+			// aapt resource value: 2
+			public const int AnimatedStateListDrawableCompat_android_variablePadding = 2;
+			
+			// aapt resource value: 1
+			public const int AnimatedStateListDrawableCompat_android_visible = 1;
+			
+			// aapt resource value: { 0x10100D0,0x1010199 }
+			public static int[] AnimatedStateListDrawableItem = new int[] {
+					16842960,
+					16843161};
+			
+			// aapt resource value: 1
+			public const int AnimatedStateListDrawableItem_android_drawable = 1;
+			
+			// aapt resource value: 0
+			public const int AnimatedStateListDrawableItem_android_id = 0;
+			
+			// aapt resource value: { 0x1010199,0x1010449,0x101044A,0x101044B }
+			public static int[] AnimatedStateListDrawableTransition = new int[] {
+					16843161,
+					16843849,
+					16843850,
+					16843851};
+			
+			// aapt resource value: 0
+			public const int AnimatedStateListDrawableTransition_android_drawable = 0;
+			
+			// aapt resource value: 2
+			public const int AnimatedStateListDrawableTransition_android_fromId = 2;
+			
+			// aapt resource value: 3
+			public const int AnimatedStateListDrawableTransition_android_reversible = 3;
+			
+			// aapt resource value: 1
+			public const int AnimatedStateListDrawableTransition_android_toId = 1;
+			
+			// aapt resource value: { 0x10100D4,0x101048F,0x1010540,0x7F0300B5,0x7F0300BB,0x7F030116 }
 			public static int[] AppBarLayout = new int[] {
 					16842964,
 					16843919,
 					16844096,
-					2130772030,
-					2130772248};
+					2130903221,
+					2130903227,
+					2130903318};
+			
+			// aapt resource value: { 0x7F030177,0x7F030178,0x7F030179,0x7F03017A }
+			public static int[] AppBarLayoutStates = new int[] {
+					2130903415,
+					2130903416,
+					2130903417,
+					2130903418};
+			
+			// aapt resource value: 0
+			public const int AppBarLayoutStates_state_collapsed = 0;
+			
+			// aapt resource value: 1
+			public const int AppBarLayoutStates_state_collapsible = 1;
+			
+			// aapt resource value: 2
+			public const int AppBarLayoutStates_state_liftable = 2;
+			
+			// aapt resource value: 3
+			public const int AppBarLayoutStates_state_lifted = 3;
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_android_background = 0;
@@ -7642,19 +9556,10 @@ namespace SextantSample.Droid
 			// aapt resource value: 4
 			public const int AppBarLayout_expanded = 4;
 			
-			public static int[] AppBarLayoutStates = new int[] {
-					2130772249,
-					2130772250};
-			
-			// aapt resource value: 0
-			public const int AppBarLayoutStates_state_collapsed = 0;
-			
-			// aapt resource value: 1
-			public const int AppBarLayoutStates_state_collapsible = 1;
-			
+			// aapt resource value: { 0x7F030114,0x7F030115 }
 			public static int[] AppBarLayout_Layout = new int[] {
-					2130772251,
-					2130772252};
+					2130903316,
+					2130903317};
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_Layout_layout_scrollFlags = 0;
@@ -7662,11 +9567,15 @@ namespace SextantSample.Droid
 			// aapt resource value: 1
 			public const int AppBarLayout_Layout_layout_scrollInterpolator = 1;
 			
+			// aapt resource value: 5
+			public const int AppBarLayout_liftOnScroll = 5;
+			
+			// aapt resource value: { 0x1010119,0x7F030174,0x7F0301C7,0x7F0301C8 }
 			public static int[] AppCompatImageView = new int[] {
 					16843033,
-					2130772041,
-					2130772042,
-					2130772043};
+					2130903412,
+					2130903495,
+					2130903496};
 			
 			// aapt resource value: 0
 			public const int AppCompatImageView_android_src = 0;
@@ -7680,11 +9589,12 @@ namespace SextantSample.Droid
 			// aapt resource value: 3
 			public const int AppCompatImageView_tintMode = 3;
 			
+			// aapt resource value: { 0x1010142,0x7F0301C4,0x7F0301C5,0x7F0301C6 }
 			public static int[] AppCompatSeekBar = new int[] {
 					16843074,
-					2130772044,
-					2130772045,
-					2130772046};
+					2130903492,
+					2130903493,
+					2130903494};
 			
 			// aapt resource value: 0
 			public const int AppCompatSeekBar_android_thumb = 0;
@@ -7698,6 +9608,7 @@ namespace SextantSample.Droid
 			// aapt resource value: 3
 			public const int AppCompatSeekBar_tickMarkTintMode = 3;
 			
+			// aapt resource value: { 0x1010034,0x101016D,0x101016E,0x101016F,0x1010170,0x1010392,0x1010393 }
 			public static int[] AppCompatTextHelper = new int[] {
 					16842804,
 					16843117,
@@ -7728,265 +9639,281 @@ namespace SextantSample.Droid
 			// aapt resource value: 0
 			public const int AppCompatTextHelper_android_textAppearance = 0;
 			
+			// aapt resource value: { 0x1010034,0x7F03002C,0x7F03002D,0x7F03002E,0x7F03002F,0x7F030030,0x7F0300CF,0x7F0300D2,0x7F030109,0x7F030117,0x7F0301A4 }
 			public static int[] AppCompatTextView = new int[] {
 					16842804,
-					2130772047,
-					2130772048,
-					2130772049,
-					2130772050,
-					2130772051,
-					2130772052,
-					2130772053};
+					2130903084,
+					2130903085,
+					2130903086,
+					2130903087,
+					2130903088,
+					2130903247,
+					2130903250,
+					2130903305,
+					2130903319,
+					2130903460};
 			
 			// aapt resource value: 0
 			public const int AppCompatTextView_android_textAppearance = 0;
 			
-			// aapt resource value: 6
-			public const int AppCompatTextView_autoSizeMaxTextSize = 6;
-			
-			// aapt resource value: 5
-			public const int AppCompatTextView_autoSizeMinTextSize = 5;
-			
-			// aapt resource value: 4
-			public const int AppCompatTextView_autoSizePresetSizes = 4;
-			
-			// aapt resource value: 3
-			public const int AppCompatTextView_autoSizeStepGranularity = 3;
+			// aapt resource value: 1
+			public const int AppCompatTextView_autoSizeMaxTextSize = 1;
 			
 			// aapt resource value: 2
-			public const int AppCompatTextView_autoSizeTextType = 2;
+			public const int AppCompatTextView_autoSizeMinTextSize = 2;
+			
+			// aapt resource value: 3
+			public const int AppCompatTextView_autoSizePresetSizes = 3;
+			
+			// aapt resource value: 4
+			public const int AppCompatTextView_autoSizeStepGranularity = 4;
+			
+			// aapt resource value: 5
+			public const int AppCompatTextView_autoSizeTextType = 5;
+			
+			// aapt resource value: 6
+			public const int AppCompatTextView_firstBaselineToTopHeight = 6;
 			
 			// aapt resource value: 7
 			public const int AppCompatTextView_fontFamily = 7;
 			
-			// aapt resource value: 1
-			public const int AppCompatTextView_textAllCaps = 1;
+			// aapt resource value: 8
+			public const int AppCompatTextView_lastBaselineToBottomHeight = 8;
 			
+			// aapt resource value: 9
+			public const int AppCompatTextView_lineHeight = 9;
+			
+			// aapt resource value: 10
+			public const int AppCompatTextView_textAllCaps = 10;
+			
+			// aapt resource value: { 0x1010057,0x10100AE,0x7F030000,0x7F030001,0x7F030002,0x7F030003,0x7F030004,0x7F030005,0x7F030006,0x7F030007,0x7F030008,0x7F030009,0x7F03000A,0x7F03000B,0x7F03000C,0x7F03000E,0x7F03000F,0x7F030010,0x7F030011,0x7F030012,0x7F030013,0x7F030014,0x7F030015,0x7F030016,0x7F030017,0x7F030018,0x7F030019,0x7F03001A,0x7F03001B,0x7F03001C,0x7F03001D,0x7F03001E,0x7F030021,0x7F030022,0x7F030023,0x7F030024,0x7F030025,0x7F03002B,0x7F03003E,0x7F03004C,0x7F03004D,0x7F03004E,0x7F03004F,0x7F030050,0x7F030054,0x7F030055,0x7F03005F,0x7F030064,0x7F030084,0x7F030085,0x7F030086,0x7F030087,0x7F030088,0x7F030089,0x7F03008A,0x7F03008B,0x7F03008C,0x7F03008E,0x7F03009D,0x7F0300A6,0x7F0300A7,0x7F0300A8,0x7F0300AB,0x7F0300AD,0x7F0300B0,0x7F0300B1,0x7F0300B2,0x7F0300B3,0x7F0300B4,0x7F0300EA,0x7F0300F6,0x7F030119,0x7F03011A,0x7F03011D,0x7F03011E,0x7F03011F,0x7F030120,0x7F030121,0x7F030122,0x7F030123,0x7F030145,0x7F030146,0x7F030147,0x7F03014D,0x7F03014F,0x7F030156,0x7F030157,0x7F030158,0x7F030159,0x7F030161,0x7F030162,0x7F030163,0x7F030164,0x7F030171,0x7F030172,0x7F030188,0x7F0301AF,0x7F0301B0,0x7F0301B1,0x7F0301B2,0x7F0301B4,0x7F0301B5,0x7F0301B6,0x7F0301B7,0x7F0301BA,0x7F0301BB,0x7F0301D5,0x7F0301D6,0x7F0301D7,0x7F0301D8,0x7F0301DF,0x7F0301E1,0x7F0301E2,0x7F0301E3,0x7F0301E4,0x7F0301E5,0x7F0301E6,0x7F0301E7,0x7F0301E8,0x7F0301E9,0x7F0301EA }
 			public static int[] AppCompatTheme = new int[] {
 					16842839,
 					16842926,
-					2130772054,
-					2130772055,
-					2130772056,
-					2130772057,
-					2130772058,
-					2130772059,
-					2130772060,
-					2130772061,
-					2130772062,
-					2130772063,
-					2130772064,
-					2130772065,
-					2130772066,
-					2130772067,
-					2130772068,
-					2130772069,
-					2130772070,
-					2130772071,
-					2130772072,
-					2130772073,
-					2130772074,
-					2130772075,
-					2130772076,
-					2130772077,
-					2130772078,
-					2130772079,
-					2130772080,
-					2130772081,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772086,
-					2130772087,
-					2130772088,
-					2130772089,
-					2130772090,
-					2130772091,
-					2130772092,
-					2130772093,
-					2130772094,
-					2130772095,
-					2130772096,
-					2130772097,
-					2130772098,
-					2130772099,
-					2130772100,
-					2130772101,
-					2130772102,
-					2130772103,
-					2130772104,
-					2130772105,
-					2130772106,
-					2130772107,
-					2130772108,
-					2130772109,
-					2130772110,
-					2130772111,
-					2130772112,
-					2130772113,
-					2130772114,
-					2130772115,
-					2130772116,
-					2130772117,
-					2130772118,
-					2130772119,
-					2130772120,
-					2130772121,
-					2130772122,
-					2130772123,
-					2130772124,
-					2130772125,
-					2130772126,
-					2130772127,
-					2130772128,
-					2130772129,
-					2130772130,
-					2130772131,
-					2130772132,
-					2130772133,
-					2130772134,
-					2130772135,
-					2130772136,
-					2130772137,
-					2130772138,
-					2130772139,
-					2130772140,
-					2130772141,
-					2130772142,
-					2130772143,
-					2130772144,
-					2130772145,
-					2130772146,
-					2130772147,
-					2130772148,
-					2130772149,
-					2130772150,
-					2130772151,
-					2130772152,
-					2130772153,
-					2130772154,
-					2130772155,
-					2130772156,
-					2130772157,
-					2130772158,
-					2130772159,
-					2130772160,
-					2130772161,
-					2130772162,
-					2130772163,
-					2130772164,
-					2130772165,
-					2130772166,
-					2130772167,
-					2130772168,
-					2130772169,
-					2130772170};
+					2130903040,
+					2130903041,
+					2130903042,
+					2130903043,
+					2130903044,
+					2130903045,
+					2130903046,
+					2130903047,
+					2130903048,
+					2130903049,
+					2130903050,
+					2130903051,
+					2130903052,
+					2130903054,
+					2130903055,
+					2130903056,
+					2130903057,
+					2130903058,
+					2130903059,
+					2130903060,
+					2130903061,
+					2130903062,
+					2130903063,
+					2130903064,
+					2130903065,
+					2130903066,
+					2130903067,
+					2130903068,
+					2130903069,
+					2130903070,
+					2130903073,
+					2130903074,
+					2130903075,
+					2130903076,
+					2130903077,
+					2130903083,
+					2130903102,
+					2130903116,
+					2130903117,
+					2130903118,
+					2130903119,
+					2130903120,
+					2130903124,
+					2130903125,
+					2130903135,
+					2130903140,
+					2130903172,
+					2130903173,
+					2130903174,
+					2130903175,
+					2130903176,
+					2130903177,
+					2130903178,
+					2130903179,
+					2130903180,
+					2130903182,
+					2130903197,
+					2130903206,
+					2130903207,
+					2130903208,
+					2130903211,
+					2130903213,
+					2130903216,
+					2130903217,
+					2130903218,
+					2130903219,
+					2130903220,
+					2130903274,
+					2130903286,
+					2130903321,
+					2130903322,
+					2130903325,
+					2130903326,
+					2130903327,
+					2130903328,
+					2130903329,
+					2130903330,
+					2130903331,
+					2130903365,
+					2130903366,
+					2130903367,
+					2130903373,
+					2130903375,
+					2130903382,
+					2130903383,
+					2130903384,
+					2130903385,
+					2130903393,
+					2130903394,
+					2130903395,
+					2130903396,
+					2130903409,
+					2130903410,
+					2130903432,
+					2130903471,
+					2130903472,
+					2130903473,
+					2130903474,
+					2130903476,
+					2130903477,
+					2130903478,
+					2130903479,
+					2130903482,
+					2130903483,
+					2130903509,
+					2130903510,
+					2130903511,
+					2130903512,
+					2130903519,
+					2130903521,
+					2130903522,
+					2130903523,
+					2130903524,
+					2130903525,
+					2130903526,
+					2130903527,
+					2130903528,
+					2130903529,
+					2130903530};
 			
-			// aapt resource value: 23
-			public const int AppCompatTheme_actionBarDivider = 23;
+			// aapt resource value: 2
+			public const int AppCompatTheme_actionBarDivider = 2;
 			
-			// aapt resource value: 24
-			public const int AppCompatTheme_actionBarItemBackground = 24;
+			// aapt resource value: 3
+			public const int AppCompatTheme_actionBarItemBackground = 3;
 			
-			// aapt resource value: 17
-			public const int AppCompatTheme_actionBarPopupTheme = 17;
+			// aapt resource value: 4
+			public const int AppCompatTheme_actionBarPopupTheme = 4;
 			
-			// aapt resource value: 22
-			public const int AppCompatTheme_actionBarSize = 22;
+			// aapt resource value: 5
+			public const int AppCompatTheme_actionBarSize = 5;
 			
-			// aapt resource value: 19
-			public const int AppCompatTheme_actionBarSplitStyle = 19;
+			// aapt resource value: 6
+			public const int AppCompatTheme_actionBarSplitStyle = 6;
 			
-			// aapt resource value: 18
-			public const int AppCompatTheme_actionBarStyle = 18;
+			// aapt resource value: 7
+			public const int AppCompatTheme_actionBarStyle = 7;
 			
-			// aapt resource value: 13
-			public const int AppCompatTheme_actionBarTabBarStyle = 13;
+			// aapt resource value: 8
+			public const int AppCompatTheme_actionBarTabBarStyle = 8;
+			
+			// aapt resource value: 9
+			public const int AppCompatTheme_actionBarTabStyle = 9;
+			
+			// aapt resource value: 10
+			public const int AppCompatTheme_actionBarTabTextStyle = 10;
+			
+			// aapt resource value: 11
+			public const int AppCompatTheme_actionBarTheme = 11;
 			
 			// aapt resource value: 12
-			public const int AppCompatTheme_actionBarTabStyle = 12;
+			public const int AppCompatTheme_actionBarWidgetTheme = 12;
+			
+			// aapt resource value: 13
+			public const int AppCompatTheme_actionButtonStyle = 13;
 			
 			// aapt resource value: 14
-			public const int AppCompatTheme_actionBarTabTextStyle = 14;
-			
-			// aapt resource value: 20
-			public const int AppCompatTheme_actionBarTheme = 20;
-			
-			// aapt resource value: 21
-			public const int AppCompatTheme_actionBarWidgetTheme = 21;
-			
-			// aapt resource value: 50
-			public const int AppCompatTheme_actionButtonStyle = 50;
-			
-			// aapt resource value: 46
-			public const int AppCompatTheme_actionDropDownStyle = 46;
-			
-			// aapt resource value: 25
-			public const int AppCompatTheme_actionMenuTextAppearance = 25;
-			
-			// aapt resource value: 26
-			public const int AppCompatTheme_actionMenuTextColor = 26;
-			
-			// aapt resource value: 29
-			public const int AppCompatTheme_actionModeBackground = 29;
-			
-			// aapt resource value: 28
-			public const int AppCompatTheme_actionModeCloseButtonStyle = 28;
-			
-			// aapt resource value: 31
-			public const int AppCompatTheme_actionModeCloseDrawable = 31;
-			
-			// aapt resource value: 33
-			public const int AppCompatTheme_actionModeCopyDrawable = 33;
-			
-			// aapt resource value: 32
-			public const int AppCompatTheme_actionModeCutDrawable = 32;
-			
-			// aapt resource value: 37
-			public const int AppCompatTheme_actionModeFindDrawable = 37;
-			
-			// aapt resource value: 34
-			public const int AppCompatTheme_actionModePasteDrawable = 34;
-			
-			// aapt resource value: 39
-			public const int AppCompatTheme_actionModePopupWindowStyle = 39;
-			
-			// aapt resource value: 35
-			public const int AppCompatTheme_actionModeSelectAllDrawable = 35;
-			
-			// aapt resource value: 36
-			public const int AppCompatTheme_actionModeShareDrawable = 36;
-			
-			// aapt resource value: 30
-			public const int AppCompatTheme_actionModeSplitBackground = 30;
-			
-			// aapt resource value: 27
-			public const int AppCompatTheme_actionModeStyle = 27;
-			
-			// aapt resource value: 38
-			public const int AppCompatTheme_actionModeWebSearchDrawable = 38;
+			public const int AppCompatTheme_actionDropDownStyle = 14;
 			
 			// aapt resource value: 15
-			public const int AppCompatTheme_actionOverflowButtonStyle = 15;
+			public const int AppCompatTheme_actionMenuTextAppearance = 15;
 			
 			// aapt resource value: 16
-			public const int AppCompatTheme_actionOverflowMenuStyle = 16;
+			public const int AppCompatTheme_actionMenuTextColor = 16;
 			
-			// aapt resource value: 58
-			public const int AppCompatTheme_activityChooserViewStyle = 58;
+			// aapt resource value: 17
+			public const int AppCompatTheme_actionModeBackground = 17;
 			
-			// aapt resource value: 95
-			public const int AppCompatTheme_alertDialogButtonGroupStyle = 95;
+			// aapt resource value: 18
+			public const int AppCompatTheme_actionModeCloseButtonStyle = 18;
 			
-			// aapt resource value: 96
-			public const int AppCompatTheme_alertDialogCenterButtons = 96;
+			// aapt resource value: 19
+			public const int AppCompatTheme_actionModeCloseDrawable = 19;
 			
-			// aapt resource value: 94
-			public const int AppCompatTheme_alertDialogStyle = 94;
+			// aapt resource value: 20
+			public const int AppCompatTheme_actionModeCopyDrawable = 20;
 			
-			// aapt resource value: 97
-			public const int AppCompatTheme_alertDialogTheme = 97;
+			// aapt resource value: 21
+			public const int AppCompatTheme_actionModeCutDrawable = 21;
+			
+			// aapt resource value: 22
+			public const int AppCompatTheme_actionModeFindDrawable = 22;
+			
+			// aapt resource value: 23
+			public const int AppCompatTheme_actionModePasteDrawable = 23;
+			
+			// aapt resource value: 24
+			public const int AppCompatTheme_actionModePopupWindowStyle = 24;
+			
+			// aapt resource value: 25
+			public const int AppCompatTheme_actionModeSelectAllDrawable = 25;
+			
+			// aapt resource value: 26
+			public const int AppCompatTheme_actionModeShareDrawable = 26;
+			
+			// aapt resource value: 27
+			public const int AppCompatTheme_actionModeSplitBackground = 27;
+			
+			// aapt resource value: 28
+			public const int AppCompatTheme_actionModeStyle = 28;
+			
+			// aapt resource value: 29
+			public const int AppCompatTheme_actionModeWebSearchDrawable = 29;
+			
+			// aapt resource value: 30
+			public const int AppCompatTheme_actionOverflowButtonStyle = 30;
+			
+			// aapt resource value: 31
+			public const int AppCompatTheme_actionOverflowMenuStyle = 31;
+			
+			// aapt resource value: 32
+			public const int AppCompatTheme_activityChooserViewStyle = 32;
+			
+			// aapt resource value: 33
+			public const int AppCompatTheme_alertDialogButtonGroupStyle = 33;
+			
+			// aapt resource value: 34
+			public const int AppCompatTheme_alertDialogCenterButtons = 34;
+			
+			// aapt resource value: 35
+			public const int AppCompatTheme_alertDialogStyle = 35;
+			
+			// aapt resource value: 36
+			public const int AppCompatTheme_alertDialogTheme = 36;
 			
 			// aapt resource value: 1
 			public const int AppCompatTheme_android_windowAnimationStyle = 1;
@@ -7994,308 +9921,369 @@ namespace SextantSample.Droid
 			// aapt resource value: 0
 			public const int AppCompatTheme_android_windowIsFloating = 0;
 			
-			// aapt resource value: 102
-			public const int AppCompatTheme_autoCompleteTextViewStyle = 102;
+			// aapt resource value: 37
+			public const int AppCompatTheme_autoCompleteTextViewStyle = 37;
 			
-			// aapt resource value: 55
-			public const int AppCompatTheme_borderlessButtonStyle = 55;
+			// aapt resource value: 38
+			public const int AppCompatTheme_borderlessButtonStyle = 38;
 			
-			// aapt resource value: 52
-			public const int AppCompatTheme_buttonBarButtonStyle = 52;
+			// aapt resource value: 39
+			public const int AppCompatTheme_buttonBarButtonStyle = 39;
 			
-			// aapt resource value: 100
-			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 100;
+			// aapt resource value: 40
+			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 40;
 			
-			// aapt resource value: 101
-			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 101;
+			// aapt resource value: 41
+			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 41;
 			
-			// aapt resource value: 99
-			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 99;
-			
-			// aapt resource value: 51
-			public const int AppCompatTheme_buttonBarStyle = 51;
-			
-			// aapt resource value: 103
-			public const int AppCompatTheme_buttonStyle = 103;
-			
-			// aapt resource value: 104
-			public const int AppCompatTheme_buttonStyleSmall = 104;
-			
-			// aapt resource value: 105
-			public const int AppCompatTheme_checkboxStyle = 105;
-			
-			// aapt resource value: 106
-			public const int AppCompatTheme_checkedTextViewStyle = 106;
-			
-			// aapt resource value: 86
-			public const int AppCompatTheme_colorAccent = 86;
-			
-			// aapt resource value: 93
-			public const int AppCompatTheme_colorBackgroundFloating = 93;
-			
-			// aapt resource value: 90
-			public const int AppCompatTheme_colorButtonNormal = 90;
-			
-			// aapt resource value: 88
-			public const int AppCompatTheme_colorControlActivated = 88;
-			
-			// aapt resource value: 89
-			public const int AppCompatTheme_colorControlHighlight = 89;
-			
-			// aapt resource value: 87
-			public const int AppCompatTheme_colorControlNormal = 87;
-			
-			// aapt resource value: 118
-			public const int AppCompatTheme_colorError = 118;
-			
-			// aapt resource value: 84
-			public const int AppCompatTheme_colorPrimary = 84;
-			
-			// aapt resource value: 85
-			public const int AppCompatTheme_colorPrimaryDark = 85;
-			
-			// aapt resource value: 91
-			public const int AppCompatTheme_colorSwitchThumbNormal = 91;
-			
-			// aapt resource value: 92
-			public const int AppCompatTheme_controlBackground = 92;
-			
-			// aapt resource value: 44
-			public const int AppCompatTheme_dialogPreferredPadding = 44;
+			// aapt resource value: 42
+			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 42;
 			
 			// aapt resource value: 43
-			public const int AppCompatTheme_dialogTheme = 43;
+			public const int AppCompatTheme_buttonBarStyle = 43;
 			
-			// aapt resource value: 57
-			public const int AppCompatTheme_dividerHorizontal = 57;
-			
-			// aapt resource value: 56
-			public const int AppCompatTheme_dividerVertical = 56;
-			
-			// aapt resource value: 75
-			public const int AppCompatTheme_dropDownListViewStyle = 75;
-			
-			// aapt resource value: 47
-			public const int AppCompatTheme_dropdownListPreferredItemHeight = 47;
-			
-			// aapt resource value: 64
-			public const int AppCompatTheme_editTextBackground = 64;
-			
-			// aapt resource value: 63
-			public const int AppCompatTheme_editTextColor = 63;
-			
-			// aapt resource value: 107
-			public const int AppCompatTheme_editTextStyle = 107;
-			
-			// aapt resource value: 49
-			public const int AppCompatTheme_homeAsUpIndicator = 49;
-			
-			// aapt resource value: 65
-			public const int AppCompatTheme_imageButtonStyle = 65;
-			
-			// aapt resource value: 83
-			public const int AppCompatTheme_listChoiceBackgroundIndicator = 83;
+			// aapt resource value: 44
+			public const int AppCompatTheme_buttonStyle = 44;
 			
 			// aapt resource value: 45
-			public const int AppCompatTheme_listDividerAlertDialog = 45;
+			public const int AppCompatTheme_buttonStyleSmall = 45;
 			
-			// aapt resource value: 115
-			public const int AppCompatTheme_listMenuViewStyle = 115;
+			// aapt resource value: 46
+			public const int AppCompatTheme_checkboxStyle = 46;
 			
-			// aapt resource value: 76
-			public const int AppCompatTheme_listPopupWindowStyle = 76;
+			// aapt resource value: 47
+			public const int AppCompatTheme_checkedTextViewStyle = 47;
+			
+			// aapt resource value: 48
+			public const int AppCompatTheme_colorAccent = 48;
+			
+			// aapt resource value: 49
+			public const int AppCompatTheme_colorBackgroundFloating = 49;
+			
+			// aapt resource value: 50
+			public const int AppCompatTheme_colorButtonNormal = 50;
+			
+			// aapt resource value: 51
+			public const int AppCompatTheme_colorControlActivated = 51;
+			
+			// aapt resource value: 52
+			public const int AppCompatTheme_colorControlHighlight = 52;
+			
+			// aapt resource value: 53
+			public const int AppCompatTheme_colorControlNormal = 53;
+			
+			// aapt resource value: 54
+			public const int AppCompatTheme_colorError = 54;
+			
+			// aapt resource value: 55
+			public const int AppCompatTheme_colorPrimary = 55;
+			
+			// aapt resource value: 56
+			public const int AppCompatTheme_colorPrimaryDark = 56;
+			
+			// aapt resource value: 57
+			public const int AppCompatTheme_colorSwitchThumbNormal = 57;
+			
+			// aapt resource value: 58
+			public const int AppCompatTheme_controlBackground = 58;
+			
+			// aapt resource value: 59
+			public const int AppCompatTheme_dialogCornerRadius = 59;
+			
+			// aapt resource value: 60
+			public const int AppCompatTheme_dialogPreferredPadding = 60;
+			
+			// aapt resource value: 61
+			public const int AppCompatTheme_dialogTheme = 61;
+			
+			// aapt resource value: 62
+			public const int AppCompatTheme_dividerHorizontal = 62;
+			
+			// aapt resource value: 63
+			public const int AppCompatTheme_dividerVertical = 63;
+			
+			// aapt resource value: 65
+			public const int AppCompatTheme_dropdownListPreferredItemHeight = 65;
+			
+			// aapt resource value: 64
+			public const int AppCompatTheme_dropDownListViewStyle = 64;
+			
+			// aapt resource value: 66
+			public const int AppCompatTheme_editTextBackground = 66;
+			
+			// aapt resource value: 67
+			public const int AppCompatTheme_editTextColor = 67;
+			
+			// aapt resource value: 68
+			public const int AppCompatTheme_editTextStyle = 68;
+			
+			// aapt resource value: 69
+			public const int AppCompatTheme_homeAsUpIndicator = 69;
 			
 			// aapt resource value: 70
-			public const int AppCompatTheme_listPreferredItemHeight = 70;
-			
-			// aapt resource value: 72
-			public const int AppCompatTheme_listPreferredItemHeightLarge = 72;
+			public const int AppCompatTheme_imageButtonStyle = 70;
 			
 			// aapt resource value: 71
-			public const int AppCompatTheme_listPreferredItemHeightSmall = 71;
+			public const int AppCompatTheme_listChoiceBackgroundIndicator = 71;
+			
+			// aapt resource value: 72
+			public const int AppCompatTheme_listDividerAlertDialog = 72;
 			
 			// aapt resource value: 73
-			public const int AppCompatTheme_listPreferredItemPaddingLeft = 73;
+			public const int AppCompatTheme_listMenuViewStyle = 73;
 			
 			// aapt resource value: 74
-			public const int AppCompatTheme_listPreferredItemPaddingRight = 74;
+			public const int AppCompatTheme_listPopupWindowStyle = 74;
+			
+			// aapt resource value: 75
+			public const int AppCompatTheme_listPreferredItemHeight = 75;
+			
+			// aapt resource value: 76
+			public const int AppCompatTheme_listPreferredItemHeightLarge = 76;
+			
+			// aapt resource value: 77
+			public const int AppCompatTheme_listPreferredItemHeightSmall = 77;
+			
+			// aapt resource value: 78
+			public const int AppCompatTheme_listPreferredItemPaddingLeft = 78;
+			
+			// aapt resource value: 79
+			public const int AppCompatTheme_listPreferredItemPaddingRight = 79;
 			
 			// aapt resource value: 80
 			public const int AppCompatTheme_panelBackground = 80;
 			
-			// aapt resource value: 82
-			public const int AppCompatTheme_panelMenuListTheme = 82;
-			
 			// aapt resource value: 81
-			public const int AppCompatTheme_panelMenuListWidth = 81;
+			public const int AppCompatTheme_panelMenuListTheme = 81;
 			
-			// aapt resource value: 61
-			public const int AppCompatTheme_popupMenuStyle = 61;
+			// aapt resource value: 82
+			public const int AppCompatTheme_panelMenuListWidth = 82;
 			
-			// aapt resource value: 62
-			public const int AppCompatTheme_popupWindowStyle = 62;
+			// aapt resource value: 83
+			public const int AppCompatTheme_popupMenuStyle = 83;
 			
-			// aapt resource value: 108
-			public const int AppCompatTheme_radioButtonStyle = 108;
+			// aapt resource value: 84
+			public const int AppCompatTheme_popupWindowStyle = 84;
 			
-			// aapt resource value: 109
-			public const int AppCompatTheme_ratingBarStyle = 109;
+			// aapt resource value: 85
+			public const int AppCompatTheme_radioButtonStyle = 85;
 			
-			// aapt resource value: 110
-			public const int AppCompatTheme_ratingBarStyleIndicator = 110;
+			// aapt resource value: 86
+			public const int AppCompatTheme_ratingBarStyle = 86;
 			
-			// aapt resource value: 111
-			public const int AppCompatTheme_ratingBarStyleSmall = 111;
+			// aapt resource value: 87
+			public const int AppCompatTheme_ratingBarStyleIndicator = 87;
 			
-			// aapt resource value: 69
-			public const int AppCompatTheme_searchViewStyle = 69;
+			// aapt resource value: 88
+			public const int AppCompatTheme_ratingBarStyleSmall = 88;
 			
-			// aapt resource value: 112
-			public const int AppCompatTheme_seekBarStyle = 112;
+			// aapt resource value: 89
+			public const int AppCompatTheme_searchViewStyle = 89;
 			
-			// aapt resource value: 53
-			public const int AppCompatTheme_selectableItemBackground = 53;
+			// aapt resource value: 90
+			public const int AppCompatTheme_seekBarStyle = 90;
 			
-			// aapt resource value: 54
-			public const int AppCompatTheme_selectableItemBackgroundBorderless = 54;
+			// aapt resource value: 91
+			public const int AppCompatTheme_selectableItemBackground = 91;
 			
-			// aapt resource value: 48
-			public const int AppCompatTheme_spinnerDropDownItemStyle = 48;
+			// aapt resource value: 92
+			public const int AppCompatTheme_selectableItemBackgroundBorderless = 92;
 			
-			// aapt resource value: 113
-			public const int AppCompatTheme_spinnerStyle = 113;
+			// aapt resource value: 93
+			public const int AppCompatTheme_spinnerDropDownItemStyle = 93;
 			
-			// aapt resource value: 114
-			public const int AppCompatTheme_switchStyle = 114;
+			// aapt resource value: 94
+			public const int AppCompatTheme_spinnerStyle = 94;
 			
-			// aapt resource value: 40
-			public const int AppCompatTheme_textAppearanceLargePopupMenu = 40;
+			// aapt resource value: 95
+			public const int AppCompatTheme_switchStyle = 95;
 			
-			// aapt resource value: 77
-			public const int AppCompatTheme_textAppearanceListItem = 77;
+			// aapt resource value: 96
+			public const int AppCompatTheme_textAppearanceLargePopupMenu = 96;
 			
-			// aapt resource value: 78
-			public const int AppCompatTheme_textAppearanceListItemSecondary = 78;
-			
-			// aapt resource value: 79
-			public const int AppCompatTheme_textAppearanceListItemSmall = 79;
-			
-			// aapt resource value: 42
-			public const int AppCompatTheme_textAppearancePopupMenuHeader = 42;
-			
-			// aapt resource value: 67
-			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 67;
-			
-			// aapt resource value: 66
-			public const int AppCompatTheme_textAppearanceSearchResultTitle = 66;
-			
-			// aapt resource value: 41
-			public const int AppCompatTheme_textAppearanceSmallPopupMenu = 41;
+			// aapt resource value: 97
+			public const int AppCompatTheme_textAppearanceListItem = 97;
 			
 			// aapt resource value: 98
-			public const int AppCompatTheme_textColorAlertDialogListItem = 98;
+			public const int AppCompatTheme_textAppearanceListItemSecondary = 98;
 			
-			// aapt resource value: 68
-			public const int AppCompatTheme_textColorSearchUrl = 68;
+			// aapt resource value: 99
+			public const int AppCompatTheme_textAppearanceListItemSmall = 99;
 			
-			// aapt resource value: 60
-			public const int AppCompatTheme_toolbarNavigationButtonStyle = 60;
+			// aapt resource value: 100
+			public const int AppCompatTheme_textAppearancePopupMenuHeader = 100;
 			
-			// aapt resource value: 59
-			public const int AppCompatTheme_toolbarStyle = 59;
+			// aapt resource value: 101
+			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 101;
 			
-			// aapt resource value: 117
-			public const int AppCompatTheme_tooltipForegroundColor = 117;
+			// aapt resource value: 102
+			public const int AppCompatTheme_textAppearanceSearchResultTitle = 102;
+			
+			// aapt resource value: 103
+			public const int AppCompatTheme_textAppearanceSmallPopupMenu = 103;
+			
+			// aapt resource value: 104
+			public const int AppCompatTheme_textColorAlertDialogListItem = 104;
+			
+			// aapt resource value: 105
+			public const int AppCompatTheme_textColorSearchUrl = 105;
+			
+			// aapt resource value: 106
+			public const int AppCompatTheme_toolbarNavigationButtonStyle = 106;
+			
+			// aapt resource value: 107
+			public const int AppCompatTheme_toolbarStyle = 107;
+			
+			// aapt resource value: 108
+			public const int AppCompatTheme_tooltipForegroundColor = 108;
+			
+			// aapt resource value: 109
+			public const int AppCompatTheme_tooltipFrameBackground = 109;
+			
+			// aapt resource value: 110
+			public const int AppCompatTheme_viewInflaterClass = 110;
+			
+			// aapt resource value: 111
+			public const int AppCompatTheme_windowActionBar = 111;
+			
+			// aapt resource value: 112
+			public const int AppCompatTheme_windowActionBarOverlay = 112;
+			
+			// aapt resource value: 113
+			public const int AppCompatTheme_windowActionModeOverlay = 113;
+			
+			// aapt resource value: 114
+			public const int AppCompatTheme_windowFixedHeightMajor = 114;
+			
+			// aapt resource value: 115
+			public const int AppCompatTheme_windowFixedHeightMinor = 115;
 			
 			// aapt resource value: 116
-			public const int AppCompatTheme_tooltipFrameBackground = 116;
+			public const int AppCompatTheme_windowFixedWidthMajor = 116;
+			
+			// aapt resource value: 117
+			public const int AppCompatTheme_windowFixedWidthMinor = 117;
+			
+			// aapt resource value: 118
+			public const int AppCompatTheme_windowMinWidthMajor = 118;
+			
+			// aapt resource value: 119
+			public const int AppCompatTheme_windowMinWidthMinor = 119;
+			
+			// aapt resource value: 120
+			public const int AppCompatTheme_windowNoTitle = 120;
+			
+			// aapt resource value: { 0x7F030034,0x7F0300C4,0x7F0300C5,0x7F0300C6,0x7F0300C7,0x7F0300E6 }
+			public static int[] BottomAppBar = new int[] {
+					2130903092,
+					2130903236,
+					2130903237,
+					2130903238,
+					2130903239,
+					2130903270};
+			
+			// aapt resource value: 0
+			public const int BottomAppBar_backgroundTint = 0;
+			
+			// aapt resource value: 1
+			public const int BottomAppBar_fabAlignmentMode = 1;
 			
 			// aapt resource value: 2
-			public const int AppCompatTheme_windowActionBar = 2;
-			
-			// aapt resource value: 4
-			public const int AppCompatTheme_windowActionBarOverlay = 4;
-			
-			// aapt resource value: 5
-			public const int AppCompatTheme_windowActionModeOverlay = 5;
-			
-			// aapt resource value: 9
-			public const int AppCompatTheme_windowFixedHeightMajor = 9;
-			
-			// aapt resource value: 7
-			public const int AppCompatTheme_windowFixedHeightMinor = 7;
-			
-			// aapt resource value: 6
-			public const int AppCompatTheme_windowFixedWidthMajor = 6;
-			
-			// aapt resource value: 8
-			public const int AppCompatTheme_windowFixedWidthMinor = 8;
-			
-			// aapt resource value: 10
-			public const int AppCompatTheme_windowMinWidthMajor = 10;
-			
-			// aapt resource value: 11
-			public const int AppCompatTheme_windowMinWidthMinor = 11;
+			public const int BottomAppBar_fabCradleMargin = 2;
 			
 			// aapt resource value: 3
-			public const int AppCompatTheme_windowNoTitle = 3;
+			public const int BottomAppBar_fabCradleRoundedCornerRadius = 3;
 			
+			// aapt resource value: 4
+			public const int BottomAppBar_fabCradleVerticalOffset = 4;
+			
+			// aapt resource value: 5
+			public const int BottomAppBar_hideOnScroll = 5;
+			
+			// aapt resource value: { 0x7F0300B5,0x7F0300FB,0x7F0300FD,0x7F0300FF,0x7F030100,0x7F030104,0x7F030105,0x7F030106,0x7F030108,0x7F030139 }
 			public static int[] BottomNavigationView = new int[] {
-					2130772030,
-					2130772291,
-					2130772292,
-					2130772293,
-					2130772294};
+					2130903221,
+					2130903291,
+					2130903293,
+					2130903295,
+					2130903296,
+					2130903300,
+					2130903301,
+					2130903302,
+					2130903304,
+					2130903353};
 			
 			// aapt resource value: 0
 			public const int BottomNavigationView_elevation = 0;
 			
-			// aapt resource value: 4
-			public const int BottomNavigationView_itemBackground = 4;
+			// aapt resource value: 1
+			public const int BottomNavigationView_itemBackground = 1;
 			
 			// aapt resource value: 2
-			public const int BottomNavigationView_itemIconTint = 2;
+			public const int BottomNavigationView_itemHorizontalTranslationEnabled = 2;
 			
 			// aapt resource value: 3
-			public const int BottomNavigationView_itemTextColor = 3;
+			public const int BottomNavigationView_itemIconSize = 3;
 			
-			// aapt resource value: 1
-			public const int BottomNavigationView_menu = 1;
+			// aapt resource value: 4
+			public const int BottomNavigationView_itemIconTint = 4;
 			
+			// aapt resource value: 5
+			public const int BottomNavigationView_itemTextAppearanceActive = 5;
+			
+			// aapt resource value: 6
+			public const int BottomNavigationView_itemTextAppearanceInactive = 6;
+			
+			// aapt resource value: 7
+			public const int BottomNavigationView_itemTextColor = 7;
+			
+			// aapt resource value: 8
+			public const int BottomNavigationView_labelVisibilityMode = 8;
+			
+			// aapt resource value: 9
+			public const int BottomNavigationView_menu = 9;
+			
+			// aapt resource value: { 0x7F030038,0x7F030039,0x7F03003B,0x7F03003C }
 			public static int[] BottomSheetBehavior_Layout = new int[] {
-					2130772253,
-					2130772254,
-					2130772255};
+					2130903096,
+					2130903097,
+					2130903099,
+					2130903100};
+			
+			// aapt resource value: 0
+			public const int BottomSheetBehavior_Layout_behavior_fitToContents = 0;
 			
 			// aapt resource value: 1
 			public const int BottomSheetBehavior_Layout_behavior_hideable = 1;
 			
-			// aapt resource value: 0
-			public const int BottomSheetBehavior_Layout_behavior_peekHeight = 0;
-			
 			// aapt resource value: 2
-			public const int BottomSheetBehavior_Layout_behavior_skipCollapsed = 2;
+			public const int BottomSheetBehavior_Layout_behavior_peekHeight = 2;
 			
+			// aapt resource value: 3
+			public const int BottomSheetBehavior_Layout_behavior_skipCollapsed = 3;
+			
+			// aapt resource value: { 0x7F030026 }
 			public static int[] ButtonBarLayout = new int[] {
-					2130772171};
+					2130903078};
 			
 			// aapt resource value: 0
 			public const int ButtonBarLayout_allowStacking = 0;
 			
+			// aapt resource value: { 0x101013F,0x1010140,0x7F030058,0x7F030059,0x7F03005A,0x7F03005B,0x7F03005C,0x7F03005D,0x7F030097,0x7F030098,0x7F030099,0x7F03009A,0x7F03009B }
 			public static int[] CardView = new int[] {
 					16843071,
 					16843072,
-					2130771991,
-					2130771992,
-					2130771993,
-					2130771994,
-					2130771995,
-					2130771996,
-					2130771997,
-					2130771998,
-					2130771999,
-					2130772000,
-					2130772001};
+					2130903128,
+					2130903129,
+					2130903130,
+					2130903131,
+					2130903132,
+					2130903133,
+					2130903191,
+					2130903192,
+					2130903193,
+					2130903194,
+					2130903195};
 			
 			// aapt resource value: 1
 			public const int CardView_android_minHeight = 1;
@@ -8315,96 +10303,246 @@ namespace SextantSample.Droid
 			// aapt resource value: 5
 			public const int CardView_cardMaxElevation = 5;
 			
-			// aapt resource value: 7
-			public const int CardView_cardPreventCornerOverlap = 7;
-			
 			// aapt resource value: 6
-			public const int CardView_cardUseCompatPadding = 6;
+			public const int CardView_cardPreventCornerOverlap = 6;
+			
+			// aapt resource value: 7
+			public const int CardView_cardUseCompatPadding = 7;
 			
 			// aapt resource value: 8
 			public const int CardView_contentPadding = 8;
 			
-			// aapt resource value: 12
-			public const int CardView_contentPaddingBottom = 12;
-			
 			// aapt resource value: 9
-			public const int CardView_contentPaddingLeft = 9;
+			public const int CardView_contentPaddingBottom = 9;
 			
 			// aapt resource value: 10
-			public const int CardView_contentPaddingRight = 10;
+			public const int CardView_contentPaddingLeft = 10;
 			
 			// aapt resource value: 11
-			public const int CardView_contentPaddingTop = 11;
+			public const int CardView_contentPaddingRight = 11;
 			
-			public static int[] CollapsingToolbarLayout = new int[] {
-					2130772005,
-					2130772256,
-					2130772257,
-					2130772258,
-					2130772259,
-					2130772260,
-					2130772261,
-					2130772262,
-					2130772263,
-					2130772264,
-					2130772265,
-					2130772266,
-					2130772267,
-					2130772268,
-					2130772269,
-					2130772270};
+			// aapt resource value: 12
+			public const int CardView_contentPaddingTop = 12;
 			
-			// aapt resource value: 13
-			public const int CollapsingToolbarLayout_collapsedTitleGravity = 13;
+			// aapt resource value: { 0x1010034,0x10100AB,0x101011F,0x101014F,0x10101E5,0x7F030061,0x7F030062,0x7F030063,0x7F030065,0x7F030066,0x7F030067,0x7F030069,0x7F03006A,0x7F03006B,0x7F03006C,0x7F03006D,0x7F03006E,0x7F030073,0x7F030074,0x7F030075,0x7F030077,0x7F030078,0x7F030079,0x7F03007A,0x7F03007B,0x7F03007C,0x7F03007D,0x7F0300E4,0x7F0300EE,0x7F0300F2,0x7F03015B,0x7F030167,0x7F0301BC,0x7F0301BE }
+			public static int[] Chip = new int[] {
+					16842804,
+					16842923,
+					16843039,
+					16843087,
+					16843237,
+					2130903137,
+					2130903138,
+					2130903139,
+					2130903141,
+					2130903142,
+					2130903143,
+					2130903145,
+					2130903146,
+					2130903147,
+					2130903148,
+					2130903149,
+					2130903150,
+					2130903155,
+					2130903156,
+					2130903157,
+					2130903159,
+					2130903160,
+					2130903161,
+					2130903162,
+					2130903163,
+					2130903164,
+					2130903165,
+					2130903268,
+					2130903278,
+					2130903282,
+					2130903387,
+					2130903399,
+					2130903484,
+					2130903486};
 			
-			// aapt resource value: 7
-			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 7;
+			// aapt resource value: { 0x7F030060,0x7F03006F,0x7F030070,0x7F030071,0x7F03016B,0x7F03016C }
+			public static int[] ChipGroup = new int[] {
+					2130903136,
+					2130903151,
+					2130903152,
+					2130903153,
+					2130903403,
+					2130903404};
 			
-			// aapt resource value: 8
-			public const int CollapsingToolbarLayout_contentScrim = 8;
-			
-			// aapt resource value: 14
-			public const int CollapsingToolbarLayout_expandedTitleGravity = 14;
+			// aapt resource value: 0
+			public const int ChipGroup_checkedChip = 0;
 			
 			// aapt resource value: 1
-			public const int CollapsingToolbarLayout_expandedTitleMargin = 1;
+			public const int ChipGroup_chipSpacing = 1;
+			
+			// aapt resource value: 2
+			public const int ChipGroup_chipSpacingHorizontal = 2;
+			
+			// aapt resource value: 3
+			public const int ChipGroup_chipSpacingVertical = 3;
+			
+			// aapt resource value: 4
+			public const int ChipGroup_singleLine = 4;
+			
+			// aapt resource value: 5
+			public const int ChipGroup_singleSelection = 5;
+			
+			// aapt resource value: 4
+			public const int Chip_android_checkable = 4;
+			
+			// aapt resource value: 1
+			public const int Chip_android_ellipsize = 1;
+			
+			// aapt resource value: 2
+			public const int Chip_android_maxWidth = 2;
+			
+			// aapt resource value: 3
+			public const int Chip_android_text = 3;
+			
+			// aapt resource value: 0
+			public const int Chip_android_textAppearance = 0;
+			
+			// aapt resource value: 5
+			public const int Chip_checkedIcon = 5;
+			
+			// aapt resource value: 6
+			public const int Chip_checkedIconEnabled = 6;
+			
+			// aapt resource value: 7
+			public const int Chip_checkedIconVisible = 7;
+			
+			// aapt resource value: 8
+			public const int Chip_chipBackgroundColor = 8;
+			
+			// aapt resource value: 9
+			public const int Chip_chipCornerRadius = 9;
+			
+			// aapt resource value: 10
+			public const int Chip_chipEndPadding = 10;
+			
+			// aapt resource value: 11
+			public const int Chip_chipIcon = 11;
+			
+			// aapt resource value: 12
+			public const int Chip_chipIconEnabled = 12;
+			
+			// aapt resource value: 13
+			public const int Chip_chipIconSize = 13;
+			
+			// aapt resource value: 14
+			public const int Chip_chipIconTint = 14;
+			
+			// aapt resource value: 15
+			public const int Chip_chipIconVisible = 15;
+			
+			// aapt resource value: 16
+			public const int Chip_chipMinHeight = 16;
+			
+			// aapt resource value: 17
+			public const int Chip_chipStartPadding = 17;
+			
+			// aapt resource value: 18
+			public const int Chip_chipStrokeColor = 18;
+			
+			// aapt resource value: 19
+			public const int Chip_chipStrokeWidth = 19;
+			
+			// aapt resource value: 20
+			public const int Chip_closeIcon = 20;
+			
+			// aapt resource value: 21
+			public const int Chip_closeIconEnabled = 21;
+			
+			// aapt resource value: 22
+			public const int Chip_closeIconEndPadding = 22;
+			
+			// aapt resource value: 23
+			public const int Chip_closeIconSize = 23;
+			
+			// aapt resource value: 24
+			public const int Chip_closeIconStartPadding = 24;
+			
+			// aapt resource value: 25
+			public const int Chip_closeIconTint = 25;
+			
+			// aapt resource value: 26
+			public const int Chip_closeIconVisible = 26;
+			
+			// aapt resource value: 27
+			public const int Chip_hideMotionSpec = 27;
+			
+			// aapt resource value: 28
+			public const int Chip_iconEndPadding = 28;
+			
+			// aapt resource value: 29
+			public const int Chip_iconStartPadding = 29;
+			
+			// aapt resource value: 30
+			public const int Chip_rippleColor = 30;
+			
+			// aapt resource value: 31
+			public const int Chip_showMotionSpec = 31;
+			
+			// aapt resource value: 32
+			public const int Chip_textEndPadding = 32;
+			
+			// aapt resource value: 33
+			public const int Chip_textStartPadding = 33;
+			
+			// aapt resource value: { 0x7F030081,0x7F030082,0x7F03009C,0x7F0300BC,0x7F0300BD,0x7F0300BE,0x7F0300BF,0x7F0300C0,0x7F0300C1,0x7F0300C2,0x7F03015C,0x7F03015E,0x7F03017C,0x7F0301C9,0x7F0301CA,0x7F0301D4 }
+			public static int[] CollapsingToolbarLayout = new int[] {
+					2130903169,
+					2130903170,
+					2130903196,
+					2130903228,
+					2130903229,
+					2130903230,
+					2130903231,
+					2130903232,
+					2130903233,
+					2130903234,
+					2130903388,
+					2130903390,
+					2130903420,
+					2130903497,
+					2130903498,
+					2130903508};
+			
+			// aapt resource value: 0
+			public const int CollapsingToolbarLayout_collapsedTitleGravity = 0;
+			
+			// aapt resource value: 1
+			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 1;
+			
+			// aapt resource value: 2
+			public const int CollapsingToolbarLayout_contentScrim = 2;
+			
+			// aapt resource value: 3
+			public const int CollapsingToolbarLayout_expandedTitleGravity = 3;
+			
+			// aapt resource value: 4
+			public const int CollapsingToolbarLayout_expandedTitleMargin = 4;
 			
 			// aapt resource value: 5
 			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 5;
 			
-			// aapt resource value: 4
-			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 4;
-			
-			// aapt resource value: 2
-			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 2;
-			
-			// aapt resource value: 3
-			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 3;
-			
 			// aapt resource value: 6
-			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 6;
+			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 6;
 			
-			// aapt resource value: 12
-			public const int CollapsingToolbarLayout_scrimAnimationDuration = 12;
+			// aapt resource value: 7
+			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 7;
 			
-			// aapt resource value: 11
-			public const int CollapsingToolbarLayout_scrimVisibleHeightTrigger = 11;
+			// aapt resource value: 8
+			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 8;
 			
 			// aapt resource value: 9
-			public const int CollapsingToolbarLayout_statusBarScrim = 9;
+			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 9;
 			
-			// aapt resource value: 0
-			public const int CollapsingToolbarLayout_title = 0;
-			
-			// aapt resource value: 15
-			public const int CollapsingToolbarLayout_titleEnabled = 15;
-			
-			// aapt resource value: 10
-			public const int CollapsingToolbarLayout_toolbarId = 10;
-			
+			// aapt resource value: { 0x7F03010F,0x7F030110 }
 			public static int[] CollapsingToolbarLayout_Layout = new int[] {
-					2130772271,
-					2130772272};
+					2130903311,
+					2130903312};
 			
 			// aapt resource value: 0
 			public const int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
@@ -8412,10 +10550,29 @@ namespace SextantSample.Droid
 			// aapt resource value: 1
 			public const int CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = 1;
 			
+			// aapt resource value: 10
+			public const int CollapsingToolbarLayout_scrimAnimationDuration = 10;
+			
+			// aapt resource value: 11
+			public const int CollapsingToolbarLayout_scrimVisibleHeightTrigger = 11;
+			
+			// aapt resource value: 12
+			public const int CollapsingToolbarLayout_statusBarScrim = 12;
+			
+			// aapt resource value: 13
+			public const int CollapsingToolbarLayout_title = 13;
+			
+			// aapt resource value: 14
+			public const int CollapsingToolbarLayout_titleEnabled = 14;
+			
+			// aapt resource value: 15
+			public const int CollapsingToolbarLayout_toolbarId = 15;
+			
+			// aapt resource value: { 0x10101A5,0x101031F,0x7F030027 }
 			public static int[] ColorStateListItem = new int[] {
 					16843173,
 					16843551,
-					2130772172};
+					2130903079};
 			
 			// aapt resource value: 2
 			public const int ColorStateListItem_alpha = 2;
@@ -8426,10 +10583,11 @@ namespace SextantSample.Droid
 			// aapt resource value: 0
 			public const int ColorStateListItem_android_color = 0;
 			
+			// aapt resource value: { 0x1010107,0x7F030056,0x7F030057 }
 			public static int[] CompoundButton = new int[] {
 					16843015,
-					2130772173,
-					2130772174};
+					2130903126,
+					2130903127};
 			
 			// aapt resource value: 0
 			public const int CompoundButton_android_button = 0;
@@ -8440,50 +10598,52 @@ namespace SextantSample.Droid
 			// aapt resource value: 2
 			public const int CompoundButton_buttonTintMode = 2;
 			
+			// aapt resource value: { 0x7F030107,0x7F03017B }
 			public static int[] CoordinatorLayout = new int[] {
-					2130772273,
-					2130772274};
+					2130903303,
+					2130903419};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_keylines = 0;
 			
-			// aapt resource value: 1
-			public const int CoordinatorLayout_statusBarBackground = 1;
-			
+			// aapt resource value: { 0x10100B3,0x7F03010C,0x7F03010D,0x7F03010E,0x7F030111,0x7F030112,0x7F030113 }
 			public static int[] CoordinatorLayout_Layout = new int[] {
 					16842931,
-					2130772275,
-					2130772276,
-					2130772277,
-					2130772278,
-					2130772279,
-					2130772280};
+					2130903308,
+					2130903309,
+					2130903310,
+					2130903313,
+					2130903314,
+					2130903315};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_Layout_android_layout_gravity = 0;
 			
+			// aapt resource value: 1
+			public const int CoordinatorLayout_Layout_layout_anchor = 1;
+			
 			// aapt resource value: 2
-			public const int CoordinatorLayout_Layout_layout_anchor = 2;
+			public const int CoordinatorLayout_Layout_layout_anchorGravity = 2;
+			
+			// aapt resource value: 3
+			public const int CoordinatorLayout_Layout_layout_behavior = 3;
 			
 			// aapt resource value: 4
-			public const int CoordinatorLayout_Layout_layout_anchorGravity = 4;
-			
-			// aapt resource value: 1
-			public const int CoordinatorLayout_Layout_layout_behavior = 1;
-			
-			// aapt resource value: 6
-			public const int CoordinatorLayout_Layout_layout_dodgeInsetEdges = 6;
+			public const int CoordinatorLayout_Layout_layout_dodgeInsetEdges = 4;
 			
 			// aapt resource value: 5
 			public const int CoordinatorLayout_Layout_layout_insetEdge = 5;
 			
-			// aapt resource value: 3
-			public const int CoordinatorLayout_Layout_layout_keyline = 3;
+			// aapt resource value: 6
+			public const int CoordinatorLayout_Layout_layout_keyline = 6;
 			
+			// aapt resource value: 1
+			public const int CoordinatorLayout_statusBarBackground = 1;
+			
+			// aapt resource value: { 0x7F030041,0x7F030042 }
 			public static int[] DesignTheme = new int[] {
-					2130772281,
-					2130772282,
-					2130772283};
+					2130903105,
+					2130903106};
 			
 			// aapt resource value: 0
 			public const int DesignTheme_bottomSheetDialogTheme = 0;
@@ -8491,116 +10651,135 @@ namespace SextantSample.Droid
 			// aapt resource value: 1
 			public const int DesignTheme_bottomSheetStyle = 1;
 			
-			// aapt resource value: 2
-			public const int DesignTheme_textColorError = 2;
-			
+			// aapt resource value: { 0x7F030029,0x7F03002A,0x7F030036,0x7F030083,0x7F0300AE,0x7F0300DD,0x7F030170,0x7F0301C0 }
 			public static int[] DrawerArrowToggle = new int[] {
-					2130772175,
-					2130772176,
-					2130772177,
-					2130772178,
-					2130772179,
-					2130772180,
-					2130772181,
-					2130772182};
-			
-			// aapt resource value: 4
-			public const int DrawerArrowToggle_arrowHeadLength = 4;
-			
-			// aapt resource value: 5
-			public const int DrawerArrowToggle_arrowShaftLength = 5;
-			
-			// aapt resource value: 6
-			public const int DrawerArrowToggle_barLength = 6;
+					2130903081,
+					2130903082,
+					2130903094,
+					2130903171,
+					2130903214,
+					2130903261,
+					2130903408,
+					2130903488};
 			
 			// aapt resource value: 0
-			public const int DrawerArrowToggle_color = 0;
-			
-			// aapt resource value: 2
-			public const int DrawerArrowToggle_drawableSize = 2;
-			
-			// aapt resource value: 3
-			public const int DrawerArrowToggle_gapBetweenBars = 3;
+			public const int DrawerArrowToggle_arrowHeadLength = 0;
 			
 			// aapt resource value: 1
-			public const int DrawerArrowToggle_spinBars = 1;
+			public const int DrawerArrowToggle_arrowShaftLength = 1;
+			
+			// aapt resource value: 2
+			public const int DrawerArrowToggle_barLength = 2;
+			
+			// aapt resource value: 3
+			public const int DrawerArrowToggle_color = 3;
+			
+			// aapt resource value: 4
+			public const int DrawerArrowToggle_drawableSize = 4;
+			
+			// aapt resource value: 5
+			public const int DrawerArrowToggle_gapBetweenBars = 5;
+			
+			// aapt resource value: 6
+			public const int DrawerArrowToggle_spinBars = 6;
 			
 			// aapt resource value: 7
 			public const int DrawerArrowToggle_thickness = 7;
 			
+			// aapt resource value: { 0x7F030034,0x7F030035,0x7F03003D,0x7F0300B5,0x7F0300C8,0x7F0300C9,0x7F0300E4,0x7F0300EC,0x7F03012A,0x7F030151,0x7F03015B,0x7F030167,0x7F0301DE }
 			public static int[] FloatingActionButton = new int[] {
-					2130772030,
-					2130772246,
-					2130772247,
-					2130772284,
-					2130772285,
-					2130772286,
-					2130772287,
-					2130772288};
-			
-			// aapt resource value: 1
-			public const int FloatingActionButton_backgroundTint = 1;
-			
-			// aapt resource value: 2
-			public const int FloatingActionButton_backgroundTintMode = 2;
-			
-			// aapt resource value: 6
-			public const int FloatingActionButton_borderWidth = 6;
+					2130903092,
+					2130903093,
+					2130903101,
+					2130903221,
+					2130903240,
+					2130903241,
+					2130903268,
+					2130903276,
+					2130903338,
+					2130903377,
+					2130903387,
+					2130903399,
+					2130903518};
 			
 			// aapt resource value: 0
-			public const int FloatingActionButton_elevation = 0;
+			public const int FloatingActionButton_backgroundTint = 0;
 			
-			// aapt resource value: 4
-			public const int FloatingActionButton_fabSize = 4;
+			// aapt resource value: 1
+			public const int FloatingActionButton_backgroundTintMode = 1;
 			
-			// aapt resource value: 5
-			public const int FloatingActionButton_pressedTranslationZ = 5;
-			
-			// aapt resource value: 3
-			public const int FloatingActionButton_rippleColor = 3;
-			
-			// aapt resource value: 7
-			public const int FloatingActionButton_useCompatPadding = 7;
-			
+			// aapt resource value: { 0x7F030037 }
 			public static int[] FloatingActionButton_Behavior_Layout = new int[] {
-					2130772289};
+					2130903095};
 			
 			// aapt resource value: 0
 			public const int FloatingActionButton_Behavior_Layout_behavior_autoHide = 0;
 			
-			public static int[] FontFamily = new int[] {
-					2130772330,
-					2130772331,
-					2130772332,
-					2130772333,
-					2130772334,
-					2130772335};
-			
-			// aapt resource value: 0
-			public const int FontFamily_fontProviderAuthority = 0;
+			// aapt resource value: 2
+			public const int FloatingActionButton_borderWidth = 2;
 			
 			// aapt resource value: 3
-			public const int FontFamily_fontProviderCerts = 3;
+			public const int FloatingActionButton_elevation = 3;
 			
 			// aapt resource value: 4
-			public const int FontFamily_fontProviderFetchStrategy = 4;
+			public const int FloatingActionButton_fabCustomSize = 4;
 			
 			// aapt resource value: 5
-			public const int FontFamily_fontProviderFetchTimeout = 5;
+			public const int FloatingActionButton_fabSize = 5;
+			
+			// aapt resource value: 6
+			public const int FloatingActionButton_hideMotionSpec = 6;
+			
+			// aapt resource value: 7
+			public const int FloatingActionButton_hoveredFocusedTranslationZ = 7;
+			
+			// aapt resource value: 8
+			public const int FloatingActionButton_maxImageSize = 8;
+			
+			// aapt resource value: 9
+			public const int FloatingActionButton_pressedTranslationZ = 9;
+			
+			// aapt resource value: 10
+			public const int FloatingActionButton_rippleColor = 10;
+			
+			// aapt resource value: 11
+			public const int FloatingActionButton_showMotionSpec = 11;
+			
+			// aapt resource value: 12
+			public const int FloatingActionButton_useCompatPadding = 12;
+			
+			// aapt resource value: { 0x7F030102,0x7F030118 }
+			public static int[] FlowLayout = new int[] {
+					2130903298,
+					2130903320};
+			
+			// aapt resource value: 0
+			public const int FlowLayout_itemSpacing = 0;
 			
 			// aapt resource value: 1
-			public const int FontFamily_fontProviderPackage = 1;
+			public const int FlowLayout_lineSpacing = 1;
 			
-			// aapt resource value: 2
-			public const int FontFamily_fontProviderQuery = 2;
+			// aapt resource value: { 0x7F0300D3,0x7F0300D4,0x7F0300D5,0x7F0300D6,0x7F0300D7,0x7F0300D8 }
+			public static int[] FontFamily = new int[] {
+					2130903251,
+					2130903252,
+					2130903253,
+					2130903254,
+					2130903255,
+					2130903256};
 			
+			// aapt resource value: { 0x1010532,0x1010533,0x101053F,0x101056F,0x1010570,0x7F0300D1,0x7F0300D9,0x7F0300DA,0x7F0300DB,0x7F0301DD }
 			public static int[] FontFamilyFont = new int[] {
 					16844082,
 					16844083,
 					16844095,
-					2130772336,
-					2130772337,
-					2130772338};
+					16844143,
+					16844144,
+					2130903249,
+					2130903257,
+					2130903258,
+					2130903259,
+					2130903517};
 			
 			// aapt resource value: 0
 			public const int FontFamilyFont_android_font = 0;
@@ -8608,22 +10787,53 @@ namespace SextantSample.Droid
 			// aapt resource value: 2
 			public const int FontFamilyFont_android_fontStyle = 2;
 			
+			// aapt resource value: 4
+			public const int FontFamilyFont_android_fontVariationSettings = 4;
+			
 			// aapt resource value: 1
 			public const int FontFamilyFont_android_fontWeight = 1;
 			
-			// aapt resource value: 4
-			public const int FontFamilyFont_font = 4;
-			
 			// aapt resource value: 3
-			public const int FontFamilyFont_fontStyle = 3;
+			public const int FontFamilyFont_android_ttcIndex = 3;
 			
 			// aapt resource value: 5
-			public const int FontFamilyFont_fontWeight = 5;
+			public const int FontFamilyFont_font = 5;
 			
+			// aapt resource value: 6
+			public const int FontFamilyFont_fontStyle = 6;
+			
+			// aapt resource value: 7
+			public const int FontFamilyFont_fontVariationSettings = 7;
+			
+			// aapt resource value: 8
+			public const int FontFamilyFont_fontWeight = 8;
+			
+			// aapt resource value: 9
+			public const int FontFamilyFont_ttcIndex = 9;
+			
+			// aapt resource value: 0
+			public const int FontFamily_fontProviderAuthority = 0;
+			
+			// aapt resource value: 1
+			public const int FontFamily_fontProviderCerts = 1;
+			
+			// aapt resource value: 2
+			public const int FontFamily_fontProviderFetchStrategy = 2;
+			
+			// aapt resource value: 3
+			public const int FontFamily_fontProviderFetchTimeout = 3;
+			
+			// aapt resource value: 4
+			public const int FontFamily_fontProviderPackage = 4;
+			
+			// aapt resource value: 5
+			public const int FontFamily_fontProviderQuery = 5;
+			
+			// aapt resource value: { 0x1010109,0x1010200,0x7F0300DC }
 			public static int[] ForegroundLinearLayout = new int[] {
 					16843017,
 					16843264,
-					2130772290};
+					2130903260};
 			
 			// aapt resource value: 0
 			public const int ForegroundLinearLayout_android_foreground = 0;
@@ -8634,16 +10844,79 @@ namespace SextantSample.Droid
 			// aapt resource value: 2
 			public const int ForegroundLinearLayout_foregroundInsidePadding = 2;
 			
+			// aapt resource value: { 0x101019D,0x101019E,0x10101A1,0x10101A2,0x10101A3,0x10101A4,0x1010201,0x101020B,0x1010510,0x1010511,0x1010512,0x1010513 }
+			public static int[] GradientColor = new int[] {
+					16843165,
+					16843166,
+					16843169,
+					16843170,
+					16843171,
+					16843172,
+					16843265,
+					16843275,
+					16844048,
+					16844049,
+					16844050,
+					16844051};
+			
+			// aapt resource value: { 0x10101A5,0x1010514 }
+			public static int[] GradientColorItem = new int[] {
+					16843173,
+					16844052};
+			
+			// aapt resource value: 0
+			public const int GradientColorItem_android_color = 0;
+			
+			// aapt resource value: 1
+			public const int GradientColorItem_android_offset = 1;
+			
+			// aapt resource value: 7
+			public const int GradientColor_android_centerColor = 7;
+			
+			// aapt resource value: 3
+			public const int GradientColor_android_centerX = 3;
+			
+			// aapt resource value: 4
+			public const int GradientColor_android_centerY = 4;
+			
+			// aapt resource value: 1
+			public const int GradientColor_android_endColor = 1;
+			
+			// aapt resource value: 10
+			public const int GradientColor_android_endX = 10;
+			
+			// aapt resource value: 11
+			public const int GradientColor_android_endY = 11;
+			
+			// aapt resource value: 5
+			public const int GradientColor_android_gradientRadius = 5;
+			
+			// aapt resource value: 0
+			public const int GradientColor_android_startColor = 0;
+			
+			// aapt resource value: 8
+			public const int GradientColor_android_startX = 8;
+			
+			// aapt resource value: 9
+			public const int GradientColor_android_startY = 9;
+			
+			// aapt resource value: 6
+			public const int GradientColor_android_tileMode = 6;
+			
+			// aapt resource value: 2
+			public const int GradientColor_android_type = 2;
+			
+			// aapt resource value: { 0x10100AF,0x10100C4,0x1010126,0x1010127,0x1010128,0x7F0300AA,0x7F0300AC,0x7F03012B,0x7F030166 }
 			public static int[] LinearLayoutCompat = new int[] {
 					16842927,
 					16842948,
 					16843046,
 					16843047,
 					16843048,
-					2130772013,
-					2130772183,
-					2130772184,
-					2130772185};
+					2130903210,
+					2130903212,
+					2130903339,
+					2130903398};
 			
 			// aapt resource value: 2
 			public const int LinearLayoutCompat_android_baselineAligned = 2;
@@ -8663,15 +10936,10 @@ namespace SextantSample.Droid
 			// aapt resource value: 5
 			public const int LinearLayoutCompat_divider = 5;
 			
-			// aapt resource value: 8
-			public const int LinearLayoutCompat_dividerPadding = 8;
-			
 			// aapt resource value: 6
-			public const int LinearLayoutCompat_measureWithLargestChild = 6;
+			public const int LinearLayoutCompat_dividerPadding = 6;
 			
-			// aapt resource value: 7
-			public const int LinearLayoutCompat_showDividers = 7;
-			
+			// aapt resource value: { 0x10100B3,0x10100F4,0x10100F5,0x1010181 }
 			public static int[] LinearLayoutCompat_Layout = new int[] {
 					16842931,
 					16842996,
@@ -8690,6 +10958,13 @@ namespace SextantSample.Droid
 			// aapt resource value: 1
 			public const int LinearLayoutCompat_Layout_android_layout_width = 1;
 			
+			// aapt resource value: 7
+			public const int LinearLayoutCompat_measureWithLargestChild = 7;
+			
+			// aapt resource value: 8
+			public const int LinearLayoutCompat_showDividers = 8;
+			
+			// aapt resource value: { 0x10102AC,0x10102AD }
 			public static int[] ListPopupWindow = new int[] {
 					16843436,
 					16843437};
@@ -8700,11 +10975,221 @@ namespace SextantSample.Droid
 			// aapt resource value: 1
 			public const int ListPopupWindow_android_dropDownVerticalOffset = 1;
 			
+			// aapt resource value: { 0x10101B7,0x10101B8,0x10101B9,0x10101BA,0x7F030034,0x7F030035,0x7F03009F,0x7F0300ED,0x7F0300EF,0x7F0300F0,0x7F0300F1,0x7F0300F3,0x7F0300F4,0x7F03015B,0x7F03017D,0x7F03017E }
+			public static int[] MaterialButton = new int[] {
+					16843191,
+					16843192,
+					16843193,
+					16843194,
+					2130903092,
+					2130903093,
+					2130903199,
+					2130903277,
+					2130903279,
+					2130903280,
+					2130903281,
+					2130903283,
+					2130903284,
+					2130903387,
+					2130903421,
+					2130903422};
+			
+			// aapt resource value: 3
+			public const int MaterialButton_android_insetBottom = 3;
+			
+			// aapt resource value: 0
+			public const int MaterialButton_android_insetLeft = 0;
+			
+			// aapt resource value: 1
+			public const int MaterialButton_android_insetRight = 1;
+			
+			// aapt resource value: 2
+			public const int MaterialButton_android_insetTop = 2;
+			
+			// aapt resource value: 4
+			public const int MaterialButton_backgroundTint = 4;
+			
+			// aapt resource value: 5
+			public const int MaterialButton_backgroundTintMode = 5;
+			
+			// aapt resource value: 6
+			public const int MaterialButton_cornerRadius = 6;
+			
+			// aapt resource value: 7
+			public const int MaterialButton_icon = 7;
+			
+			// aapt resource value: 8
+			public const int MaterialButton_iconGravity = 8;
+			
+			// aapt resource value: 9
+			public const int MaterialButton_iconPadding = 9;
+			
+			// aapt resource value: 10
+			public const int MaterialButton_iconSize = 10;
+			
+			// aapt resource value: 11
+			public const int MaterialButton_iconTint = 11;
+			
+			// aapt resource value: 12
+			public const int MaterialButton_iconTintMode = 12;
+			
+			// aapt resource value: 13
+			public const int MaterialButton_rippleColor = 13;
+			
+			// aapt resource value: 14
+			public const int MaterialButton_strokeColor = 14;
+			
+			// aapt resource value: 15
+			public const int MaterialButton_strokeWidth = 15;
+			
+			// aapt resource value: { 0x7F03017D,0x7F03017E }
+			public static int[] MaterialCardView = new int[] {
+					2130903421,
+					2130903422};
+			
+			// aapt resource value: 0
+			public const int MaterialCardView_strokeColor = 0;
+			
+			// aapt resource value: 1
+			public const int MaterialCardView_strokeWidth = 1;
+			
+			// aapt resource value: { 0x7F030041,0x7F030042,0x7F030068,0x7F030072,0x7F030076,0x7F030084,0x7F030085,0x7F03008B,0x7F03008C,0x7F03008D,0x7F0300B4,0x7F0300D0,0x7F030126,0x7F030127,0x7F03013E,0x7F03015D,0x7F03016D,0x7F0301A0,0x7F0301A5,0x7F0301A6,0x7F0301A7,0x7F0301A8,0x7F0301A9,0x7F0301AA,0x7F0301AB,0x7F0301AC,0x7F0301AD,0x7F0301AE,0x7F0301B3,0x7F0301B8,0x7F0301B9,0x7F0301BD }
+			public static int[] MaterialComponentsTheme = new int[] {
+					2130903105,
+					2130903106,
+					2130903144,
+					2130903154,
+					2130903158,
+					2130903172,
+					2130903173,
+					2130903179,
+					2130903180,
+					2130903181,
+					2130903220,
+					2130903248,
+					2130903334,
+					2130903335,
+					2130903358,
+					2130903389,
+					2130903405,
+					2130903456,
+					2130903461,
+					2130903462,
+					2130903463,
+					2130903464,
+					2130903465,
+					2130903466,
+					2130903467,
+					2130903468,
+					2130903469,
+					2130903470,
+					2130903475,
+					2130903480,
+					2130903481,
+					2130903485};
+			
+			// aapt resource value: 0
+			public const int MaterialComponentsTheme_bottomSheetDialogTheme = 0;
+			
+			// aapt resource value: 1
+			public const int MaterialComponentsTheme_bottomSheetStyle = 1;
+			
+			// aapt resource value: 2
+			public const int MaterialComponentsTheme_chipGroupStyle = 2;
+			
+			// aapt resource value: 3
+			public const int MaterialComponentsTheme_chipStandaloneStyle = 3;
+			
+			// aapt resource value: 4
+			public const int MaterialComponentsTheme_chipStyle = 4;
+			
+			// aapt resource value: 5
+			public const int MaterialComponentsTheme_colorAccent = 5;
+			
+			// aapt resource value: 6
+			public const int MaterialComponentsTheme_colorBackgroundFloating = 6;
+			
+			// aapt resource value: 7
+			public const int MaterialComponentsTheme_colorPrimary = 7;
+			
+			// aapt resource value: 8
+			public const int MaterialComponentsTheme_colorPrimaryDark = 8;
+			
+			// aapt resource value: 9
+			public const int MaterialComponentsTheme_colorSecondary = 9;
+			
+			// aapt resource value: 10
+			public const int MaterialComponentsTheme_editTextStyle = 10;
+			
+			// aapt resource value: 11
+			public const int MaterialComponentsTheme_floatingActionButtonStyle = 11;
+			
+			// aapt resource value: 12
+			public const int MaterialComponentsTheme_materialButtonStyle = 12;
+			
+			// aapt resource value: 13
+			public const int MaterialComponentsTheme_materialCardViewStyle = 13;
+			
+			// aapt resource value: 14
+			public const int MaterialComponentsTheme_navigationViewStyle = 14;
+			
+			// aapt resource value: 15
+			public const int MaterialComponentsTheme_scrimBackground = 15;
+			
+			// aapt resource value: 16
+			public const int MaterialComponentsTheme_snackbarButtonStyle = 16;
+			
+			// aapt resource value: 17
+			public const int MaterialComponentsTheme_tabStyle = 17;
+			
+			// aapt resource value: 18
+			public const int MaterialComponentsTheme_textAppearanceBody1 = 18;
+			
+			// aapt resource value: 19
+			public const int MaterialComponentsTheme_textAppearanceBody2 = 19;
+			
+			// aapt resource value: 20
+			public const int MaterialComponentsTheme_textAppearanceButton = 20;
+			
+			// aapt resource value: 21
+			public const int MaterialComponentsTheme_textAppearanceCaption = 21;
+			
+			// aapt resource value: 22
+			public const int MaterialComponentsTheme_textAppearanceHeadline1 = 22;
+			
+			// aapt resource value: 23
+			public const int MaterialComponentsTheme_textAppearanceHeadline2 = 23;
+			
+			// aapt resource value: 24
+			public const int MaterialComponentsTheme_textAppearanceHeadline3 = 24;
+			
+			// aapt resource value: 25
+			public const int MaterialComponentsTheme_textAppearanceHeadline4 = 25;
+			
+			// aapt resource value: 26
+			public const int MaterialComponentsTheme_textAppearanceHeadline5 = 26;
+			
+			// aapt resource value: 27
+			public const int MaterialComponentsTheme_textAppearanceHeadline6 = 27;
+			
+			// aapt resource value: 28
+			public const int MaterialComponentsTheme_textAppearanceOverline = 28;
+			
+			// aapt resource value: 29
+			public const int MaterialComponentsTheme_textAppearanceSubtitle1 = 29;
+			
+			// aapt resource value: 30
+			public const int MaterialComponentsTheme_textAppearanceSubtitle2 = 30;
+			
+			// aapt resource value: 31
+			public const int MaterialComponentsTheme_textInputStyle = 31;
+			
+			// aapt resource value: { 0x101013F,0x1010140,0x7F0300C3,0x7F03012E }
 			public static int[] MediaRouteButton = new int[] {
 					16843071,
 					16843072,
-					2130771989,
-					2130771990};
+					2130903235,
+					2130903342};
 			
 			// aapt resource value: 1
 			public const int MediaRouteButton_android_minHeight = 1;
@@ -8718,6 +11203,7 @@ namespace SextantSample.Droid
 			// aapt resource value: 3
 			public const int MediaRouteButton_mediaRouteButtonTint = 3;
 			
+			// aapt resource value: { 0x101000E,0x10100D0,0x1010194,0x10101DE,0x10101DF,0x10101E0 }
 			public static int[] MenuGroup = new int[] {
 					16842766,
 					16842960,
@@ -8744,6 +11230,7 @@ namespace SextantSample.Droid
 			// aapt resource value: 2
 			public const int MenuGroup_android_visible = 2;
 			
+			// aapt resource value: { 0x1010002,0x101000E,0x10100D0,0x1010106,0x1010194,0x10101DE,0x10101DF,0x10101E1,0x10101E2,0x10101E3,0x10101E4,0x10101E5,0x101026F,0x7F03000D,0x7F03001F,0x7F030020,0x7F030028,0x7F030090,0x7F0300F3,0x7F0300F4,0x7F03013F,0x7F030165,0x7F0301D9 }
 			public static int[] MenuItem = new int[] {
 					16842754,
 					16842766,
@@ -8758,28 +11245,28 @@ namespace SextantSample.Droid
 					16843236,
 					16843237,
 					16843375,
-					2130772186,
-					2130772187,
-					2130772188,
-					2130772189,
-					2130772190,
-					2130772191,
-					2130772192,
-					2130772193,
-					2130772194,
-					2130772195};
-			
-			// aapt resource value: 16
-			public const int MenuItem_actionLayout = 16;
-			
-			// aapt resource value: 18
-			public const int MenuItem_actionProviderClass = 18;
-			
-			// aapt resource value: 17
-			public const int MenuItem_actionViewClass = 17;
+					2130903053,
+					2130903071,
+					2130903072,
+					2130903080,
+					2130903184,
+					2130903283,
+					2130903284,
+					2130903359,
+					2130903397,
+					2130903513};
 			
 			// aapt resource value: 13
-			public const int MenuItem_alphabeticModifiers = 13;
+			public const int MenuItem_actionLayout = 13;
+			
+			// aapt resource value: 14
+			public const int MenuItem_actionProviderClass = 14;
+			
+			// aapt resource value: 15
+			public const int MenuItem_actionViewClass = 15;
+			
+			// aapt resource value: 16
+			public const int MenuItem_alphabeticModifiers = 16;
 			
 			// aapt resource value: 9
 			public const int MenuItem_android_alphabeticShortcut = 9;
@@ -8820,24 +11307,25 @@ namespace SextantSample.Droid
 			// aapt resource value: 4
 			public const int MenuItem_android_visible = 4;
 			
+			// aapt resource value: 17
+			public const int MenuItem_contentDescription = 17;
+			
+			// aapt resource value: 18
+			public const int MenuItem_iconTint = 18;
+			
 			// aapt resource value: 19
-			public const int MenuItem_contentDescription = 19;
-			
-			// aapt resource value: 21
-			public const int MenuItem_iconTint = 21;
-			
-			// aapt resource value: 22
-			public const int MenuItem_iconTintMode = 22;
-			
-			// aapt resource value: 14
-			public const int MenuItem_numericModifiers = 14;
-			
-			// aapt resource value: 15
-			public const int MenuItem_showAsAction = 15;
+			public const int MenuItem_iconTintMode = 19;
 			
 			// aapt resource value: 20
-			public const int MenuItem_tooltipText = 20;
+			public const int MenuItem_numericModifiers = 20;
 			
+			// aapt resource value: 21
+			public const int MenuItem_showAsAction = 21;
+			
+			// aapt resource value: 22
+			public const int MenuItem_tooltipText = 22;
+			
+			// aapt resource value: { 0x10100AE,0x101012C,0x101012D,0x101012E,0x101012F,0x1010130,0x1010131,0x7F030150,0x7F03017F }
 			public static int[] MenuView = new int[] {
 					16842926,
 					16843052,
@@ -8846,8 +11334,8 @@ namespace SextantSample.Droid
 					16843055,
 					16843056,
 					16843057,
-					2130772196,
-					2130772197};
+					2130903376,
+					2130903423};
 			
 			// aapt resource value: 4
 			public const int MenuView_android_headerBackground = 4;
@@ -8876,17 +11364,20 @@ namespace SextantSample.Droid
 			// aapt resource value: 8
 			public const int MenuView_subMenuArrow = 8;
 			
+			// aapt resource value: { 0x10100D4,0x10100DD,0x101011F,0x7F0300B5,0x7F0300DF,0x7F0300FB,0x7F0300FC,0x7F0300FE,0x7F030100,0x7F030103,0x7F030106,0x7F030139 }
 			public static int[] NavigationView = new int[] {
 					16842964,
 					16842973,
 					16843039,
-					2130772030,
-					2130772291,
-					2130772292,
-					2130772293,
-					2130772294,
-					2130772295,
-					2130772296};
+					2130903221,
+					2130903263,
+					2130903291,
+					2130903292,
+					2130903294,
+					2130903296,
+					2130903299,
+					2130903302,
+					2130903353};
 			
 			// aapt resource value: 0
 			public const int NavigationView_android_background = 0;
@@ -8900,28 +11391,42 @@ namespace SextantSample.Droid
 			// aapt resource value: 3
 			public const int NavigationView_elevation = 3;
 			
-			// aapt resource value: 9
-			public const int NavigationView_headerLayout = 9;
-			
-			// aapt resource value: 7
-			public const int NavigationView_itemBackground = 7;
+			// aapt resource value: 4
+			public const int NavigationView_headerLayout = 4;
 			
 			// aapt resource value: 5
-			public const int NavigationView_itemIconTint = 5;
-			
-			// aapt resource value: 8
-			public const int NavigationView_itemTextAppearance = 8;
+			public const int NavigationView_itemBackground = 5;
 			
 			// aapt resource value: 6
-			public const int NavigationView_itemTextColor = 6;
+			public const int NavigationView_itemHorizontalPadding = 6;
 			
-			// aapt resource value: 4
-			public const int NavigationView_menu = 4;
+			// aapt resource value: 7
+			public const int NavigationView_itemIconPadding = 7;
 			
+			// aapt resource value: 8
+			public const int NavigationView_itemIconTint = 8;
+			
+			// aapt resource value: 9
+			public const int NavigationView_itemTextAppearance = 9;
+			
+			// aapt resource value: 10
+			public const int NavigationView_itemTextColor = 10;
+			
+			// aapt resource value: 11
+			public const int NavigationView_menu = 11;
+			
+			// aapt resource value: { 0x1010176,0x10102C9,0x7F030140 }
 			public static int[] PopupWindow = new int[] {
 					16843126,
 					16843465,
-					2130772198};
+					2130903360};
+			
+			// aapt resource value: { 0x7F030176 }
+			public static int[] PopupWindowBackgroundState = new int[] {
+					2130903414};
+			
+			// aapt resource value: 0
+			public const int PopupWindowBackgroundState_state_above_anchor = 0;
 			
 			// aapt resource value: 1
 			public const int PopupWindow_android_popupAnimationStyle = 1;
@@ -8932,15 +11437,10 @@ namespace SextantSample.Droid
 			// aapt resource value: 2
 			public const int PopupWindow_overlapAnchor = 2;
 			
-			public static int[] PopupWindowBackgroundState = new int[] {
-					2130772199};
-			
-			// aapt resource value: 0
-			public const int PopupWindowBackgroundState_state_above_anchor = 0;
-			
+			// aapt resource value: { 0x7F030141,0x7F030144 }
 			public static int[] RecycleListView = new int[] {
-					2130772200,
-					2130772201};
+					2130903361,
+					2130903364};
 			
 			// aapt resource value: 0
 			public const int RecycleListView_paddingBottomNoButtons = 0;
@@ -8948,18 +11448,19 @@ namespace SextantSample.Droid
 			// aapt resource value: 1
 			public const int RecycleListView_paddingTopNoTitle = 1;
 			
+			// aapt resource value: { 0x10100C4,0x10100F1,0x7F0300CA,0x7F0300CB,0x7F0300CC,0x7F0300CD,0x7F0300CE,0x7F03010B,0x7F03015A,0x7F03016F,0x7F030175 }
 			public static int[] RecyclerView = new int[] {
 					16842948,
 					16842993,
-					2130771968,
-					2130771969,
-					2130771970,
-					2130771971,
-					2130771972,
-					2130771973,
-					2130771974,
-					2130771975,
-					2130771976};
+					2130903242,
+					2130903243,
+					2130903244,
+					2130903245,
+					2130903246,
+					2130903307,
+					2130903386,
+					2130903407,
+					2130903413};
 			
 			// aapt resource value: 1
 			public const int RecyclerView_android_descendantFocusability = 1;
@@ -8967,63 +11468,66 @@ namespace SextantSample.Droid
 			// aapt resource value: 0
 			public const int RecyclerView_android_orientation = 0;
 			
-			// aapt resource value: 6
-			public const int RecyclerView_fastScrollEnabled = 6;
-			
-			// aapt resource value: 9
-			public const int RecyclerView_fastScrollHorizontalThumbDrawable = 9;
-			
-			// aapt resource value: 10
-			public const int RecyclerView_fastScrollHorizontalTrackDrawable = 10;
-			
-			// aapt resource value: 7
-			public const int RecyclerView_fastScrollVerticalThumbDrawable = 7;
-			
-			// aapt resource value: 8
-			public const int RecyclerView_fastScrollVerticalTrackDrawable = 8;
-			
 			// aapt resource value: 2
-			public const int RecyclerView_layoutManager = 2;
-			
-			// aapt resource value: 4
-			public const int RecyclerView_reverseLayout = 4;
+			public const int RecyclerView_fastScrollEnabled = 2;
 			
 			// aapt resource value: 3
-			public const int RecyclerView_spanCount = 3;
+			public const int RecyclerView_fastScrollHorizontalThumbDrawable = 3;
+			
+			// aapt resource value: 4
+			public const int RecyclerView_fastScrollHorizontalTrackDrawable = 4;
 			
 			// aapt resource value: 5
-			public const int RecyclerView_stackFromEnd = 5;
+			public const int RecyclerView_fastScrollVerticalThumbDrawable = 5;
 			
+			// aapt resource value: 6
+			public const int RecyclerView_fastScrollVerticalTrackDrawable = 6;
+			
+			// aapt resource value: 7
+			public const int RecyclerView_layoutManager = 7;
+			
+			// aapt resource value: 8
+			public const int RecyclerView_reverseLayout = 8;
+			
+			// aapt resource value: 9
+			public const int RecyclerView_spanCount = 9;
+			
+			// aapt resource value: 10
+			public const int RecyclerView_stackFromEnd = 10;
+			
+			// aapt resource value: { 0x7F0300F9 }
 			public static int[] ScrimInsetsFrameLayout = new int[] {
-					2130772297};
+					2130903289};
 			
 			// aapt resource value: 0
 			public const int ScrimInsetsFrameLayout_insetForeground = 0;
 			
+			// aapt resource value: { 0x7F03003A }
 			public static int[] ScrollingViewBehavior_Layout = new int[] {
-					2130772298};
+					2130903098};
 			
 			// aapt resource value: 0
 			public const int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
 			
+			// aapt resource value: { 0x10100DA,0x101011F,0x1010220,0x1010264,0x7F030077,0x7F03008F,0x7F0300A5,0x7F0300DE,0x7F0300F5,0x7F03010A,0x7F030154,0x7F030155,0x7F03015F,0x7F030160,0x7F030180,0x7F030185,0x7F0301E0 }
 			public static int[] SearchView = new int[] {
 					16842970,
 					16843039,
 					16843296,
 					16843364,
-					2130772202,
-					2130772203,
-					2130772204,
-					2130772205,
-					2130772206,
-					2130772207,
-					2130772208,
-					2130772209,
-					2130772210,
-					2130772211,
-					2130772212,
-					2130772213,
-					2130772214};
+					2130903159,
+					2130903183,
+					2130903205,
+					2130903262,
+					2130903285,
+					2130903306,
+					2130903380,
+					2130903381,
+					2130903391,
+					2130903392,
+					2130903424,
+					2130903429,
+					2130903520};
 			
 			// aapt resource value: 0
 			public const int SearchView_android_focusable = 0;
@@ -9037,49 +11541,55 @@ namespace SextantSample.Droid
 			// aapt resource value: 1
 			public const int SearchView_android_maxWidth = 1;
 			
-			// aapt resource value: 8
-			public const int SearchView_closeIcon = 8;
-			
-			// aapt resource value: 13
-			public const int SearchView_commitIcon = 13;
-			
-			// aapt resource value: 7
-			public const int SearchView_defaultQueryHint = 7;
-			
-			// aapt resource value: 9
-			public const int SearchView_goIcon = 9;
+			// aapt resource value: 4
+			public const int SearchView_closeIcon = 4;
 			
 			// aapt resource value: 5
-			public const int SearchView_iconifiedByDefault = 5;
-			
-			// aapt resource value: 4
-			public const int SearchView_layout = 4;
-			
-			// aapt resource value: 15
-			public const int SearchView_queryBackground = 15;
+			public const int SearchView_commitIcon = 5;
 			
 			// aapt resource value: 6
-			public const int SearchView_queryHint = 6;
+			public const int SearchView_defaultQueryHint = 6;
 			
-			// aapt resource value: 11
-			public const int SearchView_searchHintIcon = 11;
+			// aapt resource value: 7
+			public const int SearchView_goIcon = 7;
+			
+			// aapt resource value: 8
+			public const int SearchView_iconifiedByDefault = 8;
+			
+			// aapt resource value: 9
+			public const int SearchView_layout = 9;
 			
 			// aapt resource value: 10
-			public const int SearchView_searchIcon = 10;
+			public const int SearchView_queryBackground = 10;
 			
-			// aapt resource value: 16
-			public const int SearchView_submitBackground = 16;
-			
-			// aapt resource value: 14
-			public const int SearchView_suggestionRowLayout = 14;
+			// aapt resource value: 11
+			public const int SearchView_queryHint = 11;
 			
 			// aapt resource value: 12
-			public const int SearchView_voiceIcon = 12;
+			public const int SearchView_searchHintIcon = 12;
 			
+			// aapt resource value: 13
+			public const int SearchView_searchIcon = 13;
+			
+			// aapt resource value: 14
+			public const int SearchView_submitBackground = 14;
+			
+			// aapt resource value: 15
+			public const int SearchView_suggestionRowLayout = 15;
+			
+			// aapt resource value: 16
+			public const int SearchView_voiceIcon = 16;
+			
+			// aapt resource value: { 0x7F03016D,0x7F03016E }
+			public static int[] Snackbar = new int[] {
+					2130903405,
+					2130903406};
+			
+			// aapt resource value: { 0x101011F,0x7F0300B5,0x7F030128 }
 			public static int[] SnackbarLayout = new int[] {
 					16843039,
-					2130772030,
-					2130772299};
+					2130903221,
+					2130903336};
 			
 			// aapt resource value: 0
 			public const int SnackbarLayout_android_maxWidth = 0;
@@ -9090,12 +11600,19 @@ namespace SextantSample.Droid
 			// aapt resource value: 2
 			public const int SnackbarLayout_maxActionInlineWidth = 2;
 			
+			// aapt resource value: 0
+			public const int Snackbar_snackbarButtonStyle = 0;
+			
+			// aapt resource value: 1
+			public const int Snackbar_snackbarStyle = 1;
+			
+			// aapt resource value: { 0x10100B2,0x1010176,0x101017B,0x1010262,0x7F03014E }
 			public static int[] Spinner = new int[] {
 					16842930,
 					16843126,
 					16843131,
 					16843362,
-					2130772031};
+					2130903374};
 			
 			// aapt resource value: 3
 			public const int Spinner_android_dropDownWidth = 3;
@@ -9112,21 +11629,56 @@ namespace SextantSample.Droid
 			// aapt resource value: 4
 			public const int Spinner_popupTheme = 4;
 			
+			// aapt resource value: { 0x101011C,0x1010194,0x1010195,0x1010196,0x101030C,0x101030D }
+			public static int[] StateListDrawable = new int[] {
+					16843036,
+					16843156,
+					16843157,
+					16843158,
+					16843532,
+					16843533};
+			
+			// aapt resource value: { 0x1010199 }
+			public static int[] StateListDrawableItem = new int[] {
+					16843161};
+			
+			// aapt resource value: 0
+			public const int StateListDrawableItem_android_drawable = 0;
+			
+			// aapt resource value: 3
+			public const int StateListDrawable_android_constantSize = 3;
+			
+			// aapt resource value: 0
+			public const int StateListDrawable_android_dither = 0;
+			
+			// aapt resource value: 4
+			public const int StateListDrawable_android_enterFadeDuration = 4;
+			
+			// aapt resource value: 5
+			public const int StateListDrawable_android_exitFadeDuration = 5;
+			
+			// aapt resource value: 2
+			public const int StateListDrawable_android_variablePadding = 2;
+			
+			// aapt resource value: 1
+			public const int StateListDrawable_android_visible = 1;
+			
+			// aapt resource value: { 0x1010124,0x1010125,0x1010142,0x7F030168,0x7F030173,0x7F030186,0x7F030187,0x7F030189,0x7F0301C1,0x7F0301C2,0x7F0301C3,0x7F0301DA,0x7F0301DB,0x7F0301DC }
 			public static int[] SwitchCompat = new int[] {
 					16843044,
 					16843045,
 					16843074,
-					2130772215,
-					2130772216,
-					2130772217,
-					2130772218,
-					2130772219,
-					2130772220,
-					2130772221,
-					2130772222,
-					2130772223,
-					2130772224,
-					2130772225};
+					2130903400,
+					2130903411,
+					2130903430,
+					2130903431,
+					2130903433,
+					2130903489,
+					2130903490,
+					2130903491,
+					2130903514,
+					2130903515,
+					2130903516};
 			
 			// aapt resource value: 1
 			public const int SwitchCompat_android_textOff = 1;
@@ -9137,39 +11689,40 @@ namespace SextantSample.Droid
 			// aapt resource value: 2
 			public const int SwitchCompat_android_thumb = 2;
 			
-			// aapt resource value: 13
-			public const int SwitchCompat_showText = 13;
+			// aapt resource value: 3
+			public const int SwitchCompat_showText = 3;
 			
-			// aapt resource value: 12
-			public const int SwitchCompat_splitTrack = 12;
+			// aapt resource value: 4
+			public const int SwitchCompat_splitTrack = 4;
 			
-			// aapt resource value: 10
-			public const int SwitchCompat_switchMinWidth = 10;
+			// aapt resource value: 5
+			public const int SwitchCompat_switchMinWidth = 5;
 			
-			// aapt resource value: 11
-			public const int SwitchCompat_switchPadding = 11;
+			// aapt resource value: 6
+			public const int SwitchCompat_switchPadding = 6;
 			
-			// aapt resource value: 9
-			public const int SwitchCompat_switchTextAppearance = 9;
+			// aapt resource value: 7
+			public const int SwitchCompat_switchTextAppearance = 7;
 			
 			// aapt resource value: 8
 			public const int SwitchCompat_thumbTextPadding = 8;
 			
-			// aapt resource value: 3
-			public const int SwitchCompat_thumbTint = 3;
+			// aapt resource value: 9
+			public const int SwitchCompat_thumbTint = 9;
 			
-			// aapt resource value: 4
-			public const int SwitchCompat_thumbTintMode = 4;
+			// aapt resource value: 10
+			public const int SwitchCompat_thumbTintMode = 10;
 			
-			// aapt resource value: 5
-			public const int SwitchCompat_track = 5;
+			// aapt resource value: 11
+			public const int SwitchCompat_track = 11;
 			
-			// aapt resource value: 6
-			public const int SwitchCompat_trackTint = 6;
+			// aapt resource value: 12
+			public const int SwitchCompat_trackTint = 12;
 			
-			// aapt resource value: 7
-			public const int SwitchCompat_trackTintMode = 7;
+			// aapt resource value: 13
+			public const int SwitchCompat_trackTintMode = 13;
 			
+			// aapt resource value: { 0x1010002,0x10100F2,0x101014F }
 			public static int[] TabItem = new int[] {
 					16842754,
 					16842994,
@@ -9184,72 +11737,110 @@ namespace SextantSample.Droid
 			// aapt resource value: 2
 			public const int TabItem_android_text = 2;
 			
+			// aapt resource value: { 0x7F03018A,0x7F03018B,0x7F03018C,0x7F03018D,0x7F03018E,0x7F03018F,0x7F030190,0x7F030191,0x7F030192,0x7F030193,0x7F030194,0x7F030195,0x7F030196,0x7F030197,0x7F030198,0x7F030199,0x7F03019A,0x7F03019B,0x7F03019C,0x7F03019D,0x7F03019E,0x7F03019F,0x7F0301A1,0x7F0301A2,0x7F0301A3 }
 			public static int[] TabLayout = new int[] {
-					2130772300,
-					2130772301,
-					2130772302,
-					2130772303,
-					2130772304,
-					2130772305,
-					2130772306,
-					2130772307,
-					2130772308,
-					2130772309,
-					2130772310,
-					2130772311,
-					2130772312,
-					2130772313,
-					2130772314,
-					2130772315};
-			
-			// aapt resource value: 3
-			public const int TabLayout_tabBackground = 3;
-			
-			// aapt resource value: 2
-			public const int TabLayout_tabContentStart = 2;
-			
-			// aapt resource value: 5
-			public const int TabLayout_tabGravity = 5;
+					2130903434,
+					2130903435,
+					2130903436,
+					2130903437,
+					2130903438,
+					2130903439,
+					2130903440,
+					2130903441,
+					2130903442,
+					2130903443,
+					2130903444,
+					2130903445,
+					2130903446,
+					2130903447,
+					2130903448,
+					2130903449,
+					2130903450,
+					2130903451,
+					2130903452,
+					2130903453,
+					2130903454,
+					2130903455,
+					2130903457,
+					2130903458,
+					2130903459};
 			
 			// aapt resource value: 0
-			public const int TabLayout_tabIndicatorColor = 0;
+			public const int TabLayout_tabBackground = 0;
 			
 			// aapt resource value: 1
-			public const int TabLayout_tabIndicatorHeight = 1;
+			public const int TabLayout_tabContentStart = 1;
 			
-			// aapt resource value: 7
-			public const int TabLayout_tabMaxWidth = 7;
+			// aapt resource value: 2
+			public const int TabLayout_tabGravity = 2;
 			
-			// aapt resource value: 6
-			public const int TabLayout_tabMinWidth = 6;
+			// aapt resource value: 3
+			public const int TabLayout_tabIconTint = 3;
 			
 			// aapt resource value: 4
-			public const int TabLayout_tabMode = 4;
+			public const int TabLayout_tabIconTintMode = 4;
+			
+			// aapt resource value: 5
+			public const int TabLayout_tabIndicator = 5;
+			
+			// aapt resource value: 6
+			public const int TabLayout_tabIndicatorAnimationDuration = 6;
+			
+			// aapt resource value: 7
+			public const int TabLayout_tabIndicatorColor = 7;
+			
+			// aapt resource value: 8
+			public const int TabLayout_tabIndicatorFullWidth = 8;
+			
+			// aapt resource value: 9
+			public const int TabLayout_tabIndicatorGravity = 9;
+			
+			// aapt resource value: 10
+			public const int TabLayout_tabIndicatorHeight = 10;
+			
+			// aapt resource value: 11
+			public const int TabLayout_tabInlineLabel = 11;
+			
+			// aapt resource value: 12
+			public const int TabLayout_tabMaxWidth = 12;
+			
+			// aapt resource value: 13
+			public const int TabLayout_tabMinWidth = 13;
+			
+			// aapt resource value: 14
+			public const int TabLayout_tabMode = 14;
 			
 			// aapt resource value: 15
 			public const int TabLayout_tabPadding = 15;
 			
-			// aapt resource value: 14
-			public const int TabLayout_tabPaddingBottom = 14;
+			// aapt resource value: 16
+			public const int TabLayout_tabPaddingBottom = 16;
 			
-			// aapt resource value: 13
-			public const int TabLayout_tabPaddingEnd = 13;
+			// aapt resource value: 17
+			public const int TabLayout_tabPaddingEnd = 17;
 			
-			// aapt resource value: 11
-			public const int TabLayout_tabPaddingStart = 11;
+			// aapt resource value: 18
+			public const int TabLayout_tabPaddingStart = 18;
 			
-			// aapt resource value: 12
-			public const int TabLayout_tabPaddingTop = 12;
+			// aapt resource value: 19
+			public const int TabLayout_tabPaddingTop = 19;
 			
-			// aapt resource value: 10
-			public const int TabLayout_tabSelectedTextColor = 10;
+			// aapt resource value: 20
+			public const int TabLayout_tabRippleColor = 20;
 			
-			// aapt resource value: 8
-			public const int TabLayout_tabTextAppearance = 8;
+			// aapt resource value: 21
+			public const int TabLayout_tabSelectedTextColor = 21;
 			
-			// aapt resource value: 9
-			public const int TabLayout_tabTextColor = 9;
+			// aapt resource value: 22
+			public const int TabLayout_tabTextAppearance = 22;
 			
+			// aapt resource value: 23
+			public const int TabLayout_tabTextColor = 23;
+			
+			// aapt resource value: 24
+			public const int TabLayout_tabUnboundedRipple = 24;
+			
+			// aapt resource value: { 0x1010095,0x1010096,0x1010097,0x1010098,0x101009A,0x101009B,0x1010161,0x1010162,0x1010163,0x1010164,0x10103AC,0x7F0300D2,0x7F0301A4 }
 			public static int[] TextAppearance = new int[] {
 					16842901,
 					16842902,
@@ -9262,8 +11853,8 @@ namespace SextantSample.Droid
 					16843107,
 					16843108,
 					16843692,
-					2130772047,
-					2130772053};
+					2130903250,
+					2130903460};
 			
 			// aapt resource value: 10
 			public const int TextAppearance_android_fontFamily = 10;
@@ -9298,29 +11889,42 @@ namespace SextantSample.Droid
 			// aapt resource value: 1
 			public const int TextAppearance_android_typeface = 1;
 			
-			// aapt resource value: 12
-			public const int TextAppearance_fontFamily = 12;
-			
 			// aapt resource value: 11
-			public const int TextAppearance_textAllCaps = 11;
+			public const int TextAppearance_fontFamily = 11;
 			
+			// aapt resource value: 12
+			public const int TextAppearance_textAllCaps = 12;
+			
+			// aapt resource value: { 0x101009A,0x1010150,0x7F030043,0x7F030044,0x7F030045,0x7F030046,0x7F030047,0x7F030048,0x7F030049,0x7F03004A,0x7F03004B,0x7F0300A0,0x7F0300A1,0x7F0300A2,0x7F0300A3,0x7F0300B8,0x7F0300B9,0x7F0300E1,0x7F0300E2,0x7F0300E3,0x7F0300E7,0x7F0300E8,0x7F0300E9,0x7F030148,0x7F030149,0x7F03014A,0x7F03014B,0x7F03014C }
 			public static int[] TextInputLayout = new int[] {
 					16842906,
 					16843088,
-					2130772316,
-					2130772317,
-					2130772318,
-					2130772319,
-					2130772320,
-					2130772321,
-					2130772322,
-					2130772323,
-					2130772324,
-					2130772325,
-					2130772326,
-					2130772327,
-					2130772328,
-					2130772329};
+					2130903107,
+					2130903108,
+					2130903109,
+					2130903110,
+					2130903111,
+					2130903112,
+					2130903113,
+					2130903114,
+					2130903115,
+					2130903200,
+					2130903201,
+					2130903202,
+					2130903203,
+					2130903224,
+					2130903225,
+					2130903265,
+					2130903266,
+					2130903267,
+					2130903271,
+					2130903272,
+					2130903273,
+					2130903368,
+					2130903369,
+					2130903370,
+					2130903371,
+					2130903372};
 			
 			// aapt resource value: 1
 			public const int TextInputLayout_android_hint = 1;
@@ -9328,78 +11932,130 @@ namespace SextantSample.Droid
 			// aapt resource value: 0
 			public const int TextInputLayout_android_textColorHint = 0;
 			
-			// aapt resource value: 6
-			public const int TextInputLayout_counterEnabled = 6;
-			
-			// aapt resource value: 7
-			public const int TextInputLayout_counterMaxLength = 7;
-			
-			// aapt resource value: 9
-			public const int TextInputLayout_counterOverflowTextAppearance = 9;
-			
-			// aapt resource value: 8
-			public const int TextInputLayout_counterTextAppearance = 8;
-			
-			// aapt resource value: 4
-			public const int TextInputLayout_errorEnabled = 4;
-			
-			// aapt resource value: 5
-			public const int TextInputLayout_errorTextAppearance = 5;
-			
-			// aapt resource value: 10
-			public const int TextInputLayout_hintAnimationEnabled = 10;
+			// aapt resource value: 2
+			public const int TextInputLayout_boxBackgroundColor = 2;
 			
 			// aapt resource value: 3
-			public const int TextInputLayout_hintEnabled = 3;
+			public const int TextInputLayout_boxBackgroundMode = 3;
 			
-			// aapt resource value: 2
-			public const int TextInputLayout_hintTextAppearance = 2;
+			// aapt resource value: 4
+			public const int TextInputLayout_boxCollapsedPaddingTop = 4;
 			
-			// aapt resource value: 13
-			public const int TextInputLayout_passwordToggleContentDescription = 13;
+			// aapt resource value: 5
+			public const int TextInputLayout_boxCornerRadiusBottomEnd = 5;
 			
-			// aapt resource value: 12
-			public const int TextInputLayout_passwordToggleDrawable = 12;
+			// aapt resource value: 6
+			public const int TextInputLayout_boxCornerRadiusBottomStart = 6;
+			
+			// aapt resource value: 7
+			public const int TextInputLayout_boxCornerRadiusTopEnd = 7;
+			
+			// aapt resource value: 8
+			public const int TextInputLayout_boxCornerRadiusTopStart = 8;
+			
+			// aapt resource value: 9
+			public const int TextInputLayout_boxStrokeColor = 9;
+			
+			// aapt resource value: 10
+			public const int TextInputLayout_boxStrokeWidth = 10;
 			
 			// aapt resource value: 11
-			public const int TextInputLayout_passwordToggleEnabled = 11;
+			public const int TextInputLayout_counterEnabled = 11;
+			
+			// aapt resource value: 12
+			public const int TextInputLayout_counterMaxLength = 12;
+			
+			// aapt resource value: 13
+			public const int TextInputLayout_counterOverflowTextAppearance = 13;
 			
 			// aapt resource value: 14
-			public const int TextInputLayout_passwordToggleTint = 14;
+			public const int TextInputLayout_counterTextAppearance = 14;
 			
 			// aapt resource value: 15
-			public const int TextInputLayout_passwordToggleTintMode = 15;
+			public const int TextInputLayout_errorEnabled = 15;
 			
+			// aapt resource value: 16
+			public const int TextInputLayout_errorTextAppearance = 16;
+			
+			// aapt resource value: 17
+			public const int TextInputLayout_helperText = 17;
+			
+			// aapt resource value: 18
+			public const int TextInputLayout_helperTextEnabled = 18;
+			
+			// aapt resource value: 19
+			public const int TextInputLayout_helperTextTextAppearance = 19;
+			
+			// aapt resource value: 20
+			public const int TextInputLayout_hintAnimationEnabled = 20;
+			
+			// aapt resource value: 21
+			public const int TextInputLayout_hintEnabled = 21;
+			
+			// aapt resource value: 22
+			public const int TextInputLayout_hintTextAppearance = 22;
+			
+			// aapt resource value: 23
+			public const int TextInputLayout_passwordToggleContentDescription = 23;
+			
+			// aapt resource value: 24
+			public const int TextInputLayout_passwordToggleDrawable = 24;
+			
+			// aapt resource value: 25
+			public const int TextInputLayout_passwordToggleEnabled = 25;
+			
+			// aapt resource value: 26
+			public const int TextInputLayout_passwordToggleTint = 26;
+			
+			// aapt resource value: 27
+			public const int TextInputLayout_passwordToggleTintMode = 27;
+			
+			// aapt resource value: { 0x1010034,0x7F0300B6,0x7F0300B7 }
+			public static int[] ThemeEnforcement = new int[] {
+					16842804,
+					2130903222,
+					2130903223};
+			
+			// aapt resource value: 0
+			public const int ThemeEnforcement_android_textAppearance = 0;
+			
+			// aapt resource value: 1
+			public const int ThemeEnforcement_enforceMaterialTheme = 1;
+			
+			// aapt resource value: 2
+			public const int ThemeEnforcement_enforceTextAppearance = 2;
+			
+			// aapt resource value: { 0x10100AF,0x1010140,0x7F030051,0x7F03007F,0x7F030080,0x7F030091,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F030124,0x7F030125,0x7F030129,0x7F03013B,0x7F03013C,0x7F03014E,0x7F030181,0x7F030182,0x7F030183,0x7F0301C9,0x7F0301CB,0x7F0301CC,0x7F0301CD,0x7F0301CE,0x7F0301CF,0x7F0301D0,0x7F0301D1,0x7F0301D2 }
 			public static int[] Toolbar = new int[] {
 					16842927,
 					16843072,
-					2130772005,
-					2130772008,
-					2130772012,
-					2130772024,
-					2130772025,
-					2130772026,
-					2130772027,
-					2130772028,
-					2130772029,
-					2130772031,
-					2130772226,
-					2130772227,
-					2130772228,
-					2130772229,
-					2130772230,
-					2130772231,
-					2130772232,
-					2130772233,
-					2130772234,
-					2130772235,
-					2130772236,
-					2130772237,
-					2130772238,
-					2130772239,
-					2130772240,
-					2130772241,
-					2130772242};
+					2130903121,
+					2130903167,
+					2130903168,
+					2130903185,
+					2130903186,
+					2130903187,
+					2130903188,
+					2130903189,
+					2130903190,
+					2130903332,
+					2130903333,
+					2130903337,
+					2130903355,
+					2130903356,
+					2130903374,
+					2130903425,
+					2130903426,
+					2130903427,
+					2130903497,
+					2130903499,
+					2130903500,
+					2130903501,
+					2130903502,
+					2130903503,
+					2130903504,
+					2130903505,
+					2130903506};
 			
 			// aapt resource value: 0
 			public const int Toolbar_android_gravity = 0;
@@ -9407,20 +12063,20 @@ namespace SextantSample.Droid
 			// aapt resource value: 1
 			public const int Toolbar_android_minHeight = 1;
 			
-			// aapt resource value: 21
-			public const int Toolbar_buttonGravity = 21;
+			// aapt resource value: 2
+			public const int Toolbar_buttonGravity = 2;
 			
-			// aapt resource value: 23
-			public const int Toolbar_collapseContentDescription = 23;
+			// aapt resource value: 3
+			public const int Toolbar_collapseContentDescription = 3;
 			
-			// aapt resource value: 22
-			public const int Toolbar_collapseIcon = 22;
+			// aapt resource value: 4
+			public const int Toolbar_collapseIcon = 4;
+			
+			// aapt resource value: 5
+			public const int Toolbar_contentInsetEnd = 5;
 			
 			// aapt resource value: 6
-			public const int Toolbar_contentInsetEnd = 6;
-			
-			// aapt resource value: 10
-			public const int Toolbar_contentInsetEndWithActions = 10;
+			public const int Toolbar_contentInsetEndWithActions = 6;
 			
 			// aapt resource value: 7
 			public const int Toolbar_contentInsetLeft = 7;
@@ -9428,92 +12084,79 @@ namespace SextantSample.Droid
 			// aapt resource value: 8
 			public const int Toolbar_contentInsetRight = 8;
 			
-			// aapt resource value: 5
-			public const int Toolbar_contentInsetStart = 5;
-			
 			// aapt resource value: 9
-			public const int Toolbar_contentInsetStartWithNavigation = 9;
+			public const int Toolbar_contentInsetStart = 9;
 			
-			// aapt resource value: 4
-			public const int Toolbar_logo = 4;
-			
-			// aapt resource value: 26
-			public const int Toolbar_logoDescription = 26;
-			
-			// aapt resource value: 20
-			public const int Toolbar_maxButtonHeight = 20;
-			
-			// aapt resource value: 25
-			public const int Toolbar_navigationContentDescription = 25;
-			
-			// aapt resource value: 24
-			public const int Toolbar_navigationIcon = 24;
+			// aapt resource value: 10
+			public const int Toolbar_contentInsetStartWithNavigation = 10;
 			
 			// aapt resource value: 11
-			public const int Toolbar_popupTheme = 11;
-			
-			// aapt resource value: 3
-			public const int Toolbar_subtitle = 3;
-			
-			// aapt resource value: 13
-			public const int Toolbar_subtitleTextAppearance = 13;
-			
-			// aapt resource value: 28
-			public const int Toolbar_subtitleTextColor = 28;
-			
-			// aapt resource value: 2
-			public const int Toolbar_title = 2;
-			
-			// aapt resource value: 14
-			public const int Toolbar_titleMargin = 14;
-			
-			// aapt resource value: 18
-			public const int Toolbar_titleMarginBottom = 18;
-			
-			// aapt resource value: 16
-			public const int Toolbar_titleMarginEnd = 16;
-			
-			// aapt resource value: 15
-			public const int Toolbar_titleMarginStart = 15;
-			
-			// aapt resource value: 17
-			public const int Toolbar_titleMarginTop = 17;
-			
-			// aapt resource value: 19
-			public const int Toolbar_titleMargins = 19;
+			public const int Toolbar_logo = 11;
 			
 			// aapt resource value: 12
-			public const int Toolbar_titleTextAppearance = 12;
+			public const int Toolbar_logoDescription = 12;
+			
+			// aapt resource value: 13
+			public const int Toolbar_maxButtonHeight = 13;
+			
+			// aapt resource value: 14
+			public const int Toolbar_navigationContentDescription = 14;
+			
+			// aapt resource value: 15
+			public const int Toolbar_navigationIcon = 15;
+			
+			// aapt resource value: 16
+			public const int Toolbar_popupTheme = 16;
+			
+			// aapt resource value: 17
+			public const int Toolbar_subtitle = 17;
+			
+			// aapt resource value: 18
+			public const int Toolbar_subtitleTextAppearance = 18;
+			
+			// aapt resource value: 19
+			public const int Toolbar_subtitleTextColor = 19;
+			
+			// aapt resource value: 20
+			public const int Toolbar_title = 20;
+			
+			// aapt resource value: 21
+			public const int Toolbar_titleMargin = 21;
+			
+			// aapt resource value: 22
+			public const int Toolbar_titleMarginBottom = 22;
+			
+			// aapt resource value: 23
+			public const int Toolbar_titleMarginEnd = 23;
+			
+			// aapt resource value: 26
+			public const int Toolbar_titleMargins = 26;
+			
+			// aapt resource value: 24
+			public const int Toolbar_titleMarginStart = 24;
+			
+			// aapt resource value: 25
+			public const int Toolbar_titleMarginTop = 25;
 			
 			// aapt resource value: 27
-			public const int Toolbar_titleTextColor = 27;
+			public const int Toolbar_titleTextAppearance = 27;
 			
+			// aapt resource value: 28
+			public const int Toolbar_titleTextColor = 28;
+			
+			// aapt resource value: { 0x1010000,0x10100DA,0x7F030142,0x7F030143,0x7F0301BF }
 			public static int[] View = new int[] {
 					16842752,
 					16842970,
-					2130772243,
-					2130772244,
-					2130772245};
+					2130903362,
+					2130903363,
+					2130903487};
 			
-			// aapt resource value: 1
-			public const int View_android_focusable = 1;
-			
-			// aapt resource value: 0
-			public const int View_android_theme = 0;
-			
-			// aapt resource value: 3
-			public const int View_paddingEnd = 3;
-			
-			// aapt resource value: 2
-			public const int View_paddingStart = 2;
-			
-			// aapt resource value: 4
-			public const int View_theme = 4;
-			
+			// aapt resource value: { 0x10100D4,0x7F030034,0x7F030035 }
 			public static int[] ViewBackgroundHelper = new int[] {
 					16842964,
-					2130772246,
-					2130772247};
+					2130903092,
+					2130903093};
 			
 			// aapt resource value: 0
 			public const int ViewBackgroundHelper_android_background = 0;
@@ -9524,6 +12167,7 @@ namespace SextantSample.Droid
 			// aapt resource value: 2
 			public const int ViewBackgroundHelper_backgroundTintMode = 2;
 			
+			// aapt resource value: { 0x10100D0,0x10100F2,0x10100F3 }
 			public static int[] ViewStubCompat = new int[] {
 					16842960,
 					16842994,
@@ -9537,6 +12181,21 @@ namespace SextantSample.Droid
 			
 			// aapt resource value: 1
 			public const int ViewStubCompat_android_layout = 1;
+			
+			// aapt resource value: 1
+			public const int View_android_focusable = 1;
+			
+			// aapt resource value: 0
+			public const int View_android_theme = 0;
+			
+			// aapt resource value: 2
+			public const int View_paddingEnd = 2;
+			
+			// aapt resource value: 3
+			public const int View_paddingStart = 3;
+			
+			// aapt resource value: 4
+			public const int View_theme = 4;
 			
 			static Styleable()
 			{

--- a/Sample/SextantSample.Android/SextantSample.Android.csproj
+++ b/Sample/SextantSample.Android/SextantSample.Android.csproj
@@ -1,117 +1,121 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{4A684BB2-2CB4-4B04-8541-FF0FA677DD49}</ProjectGuid>
-        <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <TemplateGuid>{c9e5eea5-ca05-42a1-839b-61506e0a37df}</TemplateGuid>
-        <OutputType>Library</OutputType>
-        <RootNamespace>SextantSample.Droid</RootNamespace>
-        <AssemblyName>SextantSample.Android</AssemblyName>
-        <AndroidApplication>True</AndroidApplication>
-        <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
-        <AndroidResgenClass>Resource</AndroidResgenClass>
-        <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-        <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
-        <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-        <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
-        <NuGetPackageImportStamp>
-        </NuGetPackageImportStamp>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug</OutputPath>
-        <DefineConstants>DEBUG;LOGGING</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <AndroidLinkMode>None</AndroidLinkMode>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release</OutputPath>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <AndroidManagedSymbols>true</AndroidManagedSymbols>
-        <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sample Release|AnyCPU' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Sample Release</OutputPath>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <AndroidManagedSymbols>true</AndroidManagedSymbols>
-        <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-        <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
-        <AndroidSupportedAbis>armeabi-v7a</AndroidSupportedAbis>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="Mono.Android" />
-        <Reference Include="System" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Xml.Linq" />
-        <Reference Include="System.Xml" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="System.Reactive" Version="4.2.*" />
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
-        <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
-        <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
-        <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />
-        <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.3" />
-        <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />
-        <PackageReference Include="ReactiveUI.XamForms" Version="10.*" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="MainActivity.cs" />
-        <Compile Include="Resources\Resource.Designer.cs" />
-        <Compile Include="Properties\AssemblyInfo.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="Resources\AboutResources.txt" />
-        <None Include="Assets\AboutAssets.txt" />
-        <None Include="Properties\AndroidManifest.xml" />
-    </ItemGroup>
-    <ItemGroup>
-        <AndroidResource Include="Resources\layout\Tabbar.axml" />
-        <AndroidResource Include="Resources\layout\Toolbar.axml" />
-        <AndroidResource Include="Resources\values\styles.xml" />
-        <AndroidResource Include="Resources\values\colors.xml" />
-        <AndroidResource Include="Resources\mipmap-anydpi-v26\icon.xml" />
-        <AndroidResource Include="Resources\mipmap-anydpi-v26\icon_round.xml" />
-        <AndroidResource Include="Resources\mipmap-hdpi\Icon.png" />
-        <AndroidResource Include="Resources\mipmap-hdpi\launcher_foreground.png" />
-        <AndroidResource Include="Resources\mipmap-mdpi\Icon.png" />
-        <AndroidResource Include="Resources\mipmap-mdpi\launcher_foreground.png" />
-        <AndroidResource Include="Resources\mipmap-xhdpi\Icon.png" />
-        <AndroidResource Include="Resources\mipmap-xhdpi\launcher_foreground.png" />
-        <AndroidResource Include="Resources\mipmap-xxhdpi\Icon.png" />
-        <AndroidResource Include="Resources\mipmap-xxhdpi\launcher_foreground.png" />
-        <AndroidResource Include="Resources\mipmap-xxxhdpi\Icon.png" />
-        <AndroidResource Include="Resources\mipmap-xxxhdpi\launcher_foreground.png" />
-    </ItemGroup>
-    <ItemGroup>
-        <Folder Include="Resources\drawable-hdpi\" />
-        <Folder Include="Resources\drawable-xhdpi\" />
-        <Folder Include="Resources\drawable-xxhdpi\" />
-        <Folder Include="Resources\drawable-xxxhdpi\" />
-        <Folder Include="Resources\drawable\" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Sextant\Sextant.csproj">
-            <Project>{D6B84899-4AFC-4E6C-9C3F-005F21DF5A52}</Project>
-            <Name>Sextant</Name>
-        </ProjectReference>
-        <ProjectReference Include="..\SextantSample\SextantSample.csproj">
-            <Project>{44FA03FD-7A52-41AD-9332-1B34FFDEE67B}</Project>
-            <Name>SextantSample</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4A684BB2-2CB4-4B04-8541-FF0FA677DD49}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TemplateGuid>{c9e5eea5-ca05-42a1-839b-61506e0a37df}</TemplateGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>SextantSample.Droid</RootNamespace>
+    <AssemblyName>SextantSample.Android</AssemblyName>
+    <AndroidApplication>True</AndroidApplication>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;LOGGING</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <BundleAssemblies>false</BundleAssemblies>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidManagedSymbols>true</AndroidManagedSymbols>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Sample Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Sample Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidManagedSymbols>true</AndroidManagedSymbols>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    <AndroidSupportedAbis>armeabi-v7a</AndroidSupportedAbis>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Mono.Android" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Reactive" Version="4.2.*" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+    <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />
+    <PackageReference Include="ReactiveUI.XamForms" Version="10.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainActivity.cs" />
+    <Compile Include="Resources\Resource.Designer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\AboutResources.txt" />
+    <None Include="Assets\AboutAssets.txt" />
+    <None Include="Properties\AndroidManifest.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\Tabbar.axml" />
+    <AndroidResource Include="Resources\layout\Toolbar.axml" />
+    <AndroidResource Include="Resources\values\styles.xml" />
+    <AndroidResource Include="Resources\values\colors.xml" />
+    <AndroidResource Include="Resources\mipmap-anydpi-v26\icon.xml" />
+    <AndroidResource Include="Resources\mipmap-anydpi-v26\icon_round.xml" />
+    <AndroidResource Include="Resources\mipmap-hdpi\Icon.png" />
+    <AndroidResource Include="Resources\mipmap-hdpi\launcher_foreground.png" />
+    <AndroidResource Include="Resources\mipmap-mdpi\Icon.png" />
+    <AndroidResource Include="Resources\mipmap-mdpi\launcher_foreground.png" />
+    <AndroidResource Include="Resources\mipmap-xhdpi\Icon.png" />
+    <AndroidResource Include="Resources\mipmap-xhdpi\launcher_foreground.png" />
+    <AndroidResource Include="Resources\mipmap-xxhdpi\Icon.png" />
+    <AndroidResource Include="Resources\mipmap-xxhdpi\launcher_foreground.png" />
+    <AndroidResource Include="Resources\mipmap-xxxhdpi\Icon.png" />
+    <AndroidResource Include="Resources\mipmap-xxxhdpi\launcher_foreground.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\drawable-hdpi\" />
+    <Folder Include="Resources\drawable-xhdpi\" />
+    <Folder Include="Resources\drawable-xxhdpi\" />
+    <Folder Include="Resources\drawable-xxxhdpi\" />
+    <Folder Include="Resources\drawable\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sextant\Sextant.csproj">
+      <Project>{D6B84899-4AFC-4E6C-9C3F-005F21DF5A52}</Project>
+      <Name>Sextant</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SextantSample\SextantSample.csproj">
+      <Project>{44FA03FD-7A52-41AD-9332-1B34FFDEE67B}</Project>
+      <Name>SextantSample</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Sample/SextantSample/SextantSample.csproj
+++ b/Sample/SextantSample/SextantSample.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.Forms" Version="4.1.*" />
+        <PackageReference Include="Xamarin.Forms" Version="4.2.*" />
         <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
         <PackageReference Include="ReactiveUI.XamForms" Version="10.*" />
     </ItemGroup>


### PR DESCRIPTION
- Changed Droid sample target framework to 9 as it was making the wrong main thread scheduler to be resolved by scheduling with `RxApp.MainThreadScheduler`
- Consolidated using Xamarin 4.2.* on the sample (as the other projects do)

**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
#171


**What is the new behavior?**
The `RxApp.MainThreadScheduler` resolves correctly to the main thread.


**What might this PR break?**


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

