### PR TITLE
fix: Pop not firing WhenNavigatedTo

### DIFF
--- a/src/Sextant.Mocks/Mocks/NavigableViewModelMock.cs
+++ b/src/Sextant.Mocks/Mocks/NavigableViewModelMock.cs
@@ -24,7 +24,7 @@ namespace Sextant.Mocks
         /// Initializes a new instance of the <see cref="NavigableViewModelMock"/> class.
         /// </summary>
         /// <param name="id">The id of the page.</param>
-        public NavigableViewModelMock(string id = null)
+        public NavigableViewModelMock(string? id = null)
         {
             _id = id;
             _navigatedTo = new Subject<Unit>();

--- a/src/Sextant.Mocks/Mocks/NavigationViewMock.cs
+++ b/src/Sextant.Mocks/Mocks/NavigationViewMock.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace Sextant.Mocks
+{
+    /// <summary>
+    /// Mock <see cref="IView"/> implementation.
+    /// </summary>
+    public class NavigationViewMock : IView, IDisposable
+    {
+        private Subject<IViewModel> _pagePoppedSubject;
+        private Stack<IViewModel> _pageStack;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NavigationViewMock"/> class.
+        /// </summary>
+        public NavigationViewMock()
+        {
+            _pagePoppedSubject = new Subject<IViewModel>();
+            _pageStack = new Stack<IViewModel>();
+
+            PagePopped = _pagePoppedSubject.AsObservable();
+        }
+
+        /// <inheritdoc/>
+        public IScheduler MainThreadScheduler { get; } = CurrentThreadScheduler.Instance;
+
+        /// <inheritdoc/>
+        public IObservable<IViewModel?> PagePopped { get; }
+
+        /// <inheritdoc/>
+        public IObservable<Unit> PopModal() => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        public IObservable<Unit> PopPage(bool animate = true) =>
+            Observable
+                .Return(Unit.Default)
+                .Do(_ => _pagePoppedSubject.OnNext(_pageStack.Pop()));
+
+        /// <inheritdoc/>
+        public IObservable<Unit> PopToRootPage(bool animate = true) => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        public IObservable<Unit> PushModal(IViewModel modalViewModel, string? contract, bool withNavigationPage = true) => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        public IObservable<Unit> PushPage(IViewModel viewModel, string? contract, bool resetStack, bool animate = true) =>
+            Observable
+                .Return(Unit.Default)
+                .Do(_ => _pageStack.Push(viewModel));
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _pagePoppedSubject?.Dispose();
+            }
+        }
+    }
+}

--- a/src/Sextant.Mocks/Mocks/PageView.cs
+++ b/src/Sextant.Mocks/Mocks/PageView.cs
@@ -17,16 +17,16 @@ namespace Sextant.Mocks
         /// Gets or sets the ViewModel corresponding to this specific View. This should be
         /// a DependencyProperty if you're using XAML.
         /// </summary>
-        object IViewFor.ViewModel
+        object? IViewFor.ViewModel
         {
             get => ViewModel;
-            set => ViewModel = (NavigableViewModelMock)value;
+            set => ViewModel = (NavigableViewModelMock?)value;
         }
 
         /// <summary>
         /// Gets or sets the ViewModel corresponding to this specific View. This should be
         /// a DependencyProperty if you're using XAML.
         /// </summary>
-        public NavigableViewModelMock ViewModel { get; set; }
+        public NavigableViewModelMock? ViewModel { get; set; }
     }
 }

--- a/src/Sextant.Mocks/Mocks/ParameterViewModel.cs
+++ b/src/Sextant.Mocks/Mocks/ParameterViewModel.cs
@@ -18,16 +18,16 @@ namespace Sextant.Mocks
     /// <seealso cref="IViewModel" />
     public class ParameterViewModel : ReactiveObject, INavigable
     {
-        private string _text;
+        private string? _text;
         private int _meaning;
 
         /// <inheritdoc />
-        public string Id { get; }
+        public string? Id { get; }
 
         /// <summary>
         /// Gets or sets the text.
         /// </summary>
-        public string Text { get => _text; set => this.RaiseAndSetIfChanged(ref _text, value); }
+        public string? Text { get => _text; set => this.RaiseAndSetIfChanged(ref _text, value); }
 
         /// <summary>
         /// Gets or sets the meaning.

--- a/src/Sextant.Mocks/Sextant.Mocks.csproj
+++ b/src/Sextant.Mocks/Sextant.Mocks.csproj
@@ -3,7 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA1034</NoWarn>
+    <WarningsAsErrors>CS8625;CS8604;CS8600;CS8614;CS8603;CS8618;CS8619</WarningsAsErrors>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -505,18 +505,22 @@ namespace Sextant.Tests
             /// </summary>
             /// <returns>A completion notification.</returns>
             [Fact]
-            public async Task Should_Not_Call_When_Navigated_To()
+            public async Task Should_Call_When_Navigated_To()
             {
                 // Given
-                var viewModel = Substitute.For<INavigable>();
+                var firstViewModel = Substitute.For<INavigable>();
+                var secondViewModel = Substitute.For<INavigable>();
                 var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithPushed(viewModel);
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
 
                 // When
+                await sut.PushPage(firstViewModel, navigationParameter);
+                await sut.PushPage(secondViewModel);
                 await sut.PopPage(navigationParameter);
 
                 // Then
-                await viewModel.DidNotReceive().WhenNavigatedTo(navigationParameter);
+                await firstViewModel.Received(2).WhenNavigatedTo(Arg.Any<INavigationParameter>());
+                await secondViewModel.Received().WhenNavigatedFrom(navigationParameter);
             }
 
             /// <summary>

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -505,6 +505,28 @@ namespace Sextant.Tests
             /// </summary>
             /// <returns>A completion notification.</returns>
             [Fact]
+            public async Task Should_Not_Call_When_Navigated_To()
+            {
+                // Given
+                var firstViewModel = Substitute.For<INavigable>();
+                var secondViewModel = Substitute.For<INavigable>();
+                var navigationParameter = Substitute.For<INavigationParameter>();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
+
+                // When
+                await sut.PushPage(firstViewModel);
+                await sut.PushPage(secondViewModel);
+                await sut.PopPage(navigationParameter);
+
+                // Then
+                await secondViewModel.DidNotReceive().WhenNavigatedTo(navigationParameter);
+            }
+
+            /// <summary>
+            /// Tests to make sure we receive a push page notification.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
             public async Task Should_Call_When_Navigated_To()
             {
                 // Given

--- a/src/Sextant.XamForms/NavigationView.cs
+++ b/src/Sextant.XamForms/NavigationView.cs
@@ -48,10 +48,11 @@ namespace Sextant.XamForms
             _viewLocator = viewLocator;
             _logger = this.Log();
 
-            PagePopped = Observable
-                .FromEventPattern<NavigationEventArgs>(x => Popped += x, x => Popped -= x)
-                .Select(ep => ep.EventArgs.Page.BindingContext as IViewModel)
-                .WhereNotNull();
+            PagePopped =
+                Observable
+                    .FromEventPattern<NavigationEventArgs>(x => Popped += x, x => Popped -= x)
+                    .Select(ep => ep.EventArgs.Page.BindingContext as IViewModel)
+                    .WhereNotNull();
         }
 
         /// <summary>
@@ -67,10 +68,11 @@ namespace Sextant.XamForms
             _viewLocator = viewLocator;
             _logger = this.Log();
 
-            PagePopped = Observable
-                .FromEventPattern<NavigationEventArgs>(x => Popped += x, x => Popped -= x)
-                .Select(ep => ep.EventArgs.Page.BindingContext as IViewModel)
-                .WhereNotNull();
+            PagePopped =
+                Observable
+                    .FromEventPattern<NavigationEventArgs>(x => Popped += x, x => Popped -= x)
+                    .Select(ep => ep.EventArgs.Page.BindingContext as IViewModel)
+                    .WhereNotNull();
         }
 
         /// <inheritdoc />

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -122,18 +122,28 @@ namespace Sextant
                 throw new ArgumentNullException(nameof(parameter));
             }
 
-            var topPage = TopPage().FirstOrDefaultAsync().Wait();
+            IViewModel poppedPage = TopPage().FirstOrDefaultAsync().Wait();
             return View
                 .PopPage(animate)
                 .Do(_ =>
                 {
-                    if (topPage is INavigable navigable)
+                    if (poppedPage is INavigable navigable)
                     {
                         navigable
                             .WhenNavigatedFrom(parameter)
                             .ObserveOn(View.MainThreadScheduler)
-                            .Subscribe(navigated =>
+                            .Subscribe(navigatedFrom =>
                                 Logger.Debug($"Called `WhenNavigatedFrom` on '{navigable.Id}' passing parameter {parameter}"));
+                    }
+
+                    IViewModel topPage = TopPage().FirstOrDefaultAsync().Wait();
+                    if (topPage is INavigated navigated)
+                    {
+                        navigated
+                            .WhenNavigatedTo(parameter)
+                            .ObserveOn(View.MainThreadScheduler)
+                            .Subscribe(navigatedTo =>
+                                Logger.Debug($"Called `WhenNavigatedTo` passing parameter {parameter}"));
                     }
                 });
         }

--- a/src/Sextant/Navigation/ViewStackServiceBase.cs
+++ b/src/Sextant/Navigation/ViewStackServiceBase.cs
@@ -34,15 +34,18 @@ namespace Sextant
             ModalSubject = new BehaviorSubject<IImmutableList<IViewModel>>(ImmutableList<IViewModel>.Empty);
             PageSubject = new BehaviorSubject<IImmutableList<IViewModel>>(ImmutableList<IViewModel>.Empty);
 
-            View.PagePopped.Do(poppedPage =>
-            {
-                var currentPageStack = PageSubject.Value;
-                if (currentPageStack.Count > 0 && poppedPage == currentPageStack[currentPageStack.Count - 1])
+            View
+                .PagePopped
+                .Do(poppedPage =>
                 {
-                    var removedPage = PopStackAndTick(PageSubject);
-                    Logger.Debug(CultureInfo.InvariantCulture, "Removed page '{0}' from stack.", removedPage.Id);
-                }
-            }).SubscribeSafe();
+                    var currentPageStack = PageSubject.Value;
+                    if (currentPageStack.Count > 0 && poppedPage == currentPageStack[currentPageStack.Count - 1])
+                    {
+                        var removedPage = PopStackAndTick(PageSubject);
+                        Logger.Debug(CultureInfo.InvariantCulture, "Removed page '{0}' from stack.", removedPage.Id);
+                    }
+                })
+                .SubscribeSafe();
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fixes the `PopPage(INavigationParameter parameter)` not firing the `INavigable` `WhenNavigatedTo` function.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Resolves: #190 

**What is the new behavior?**
<!-- If this is a feature change -->

Popping an `INavigable` implementation should call the associated `WhenNavigatedTo` method when navigating back to the view model.

**What might this PR break?**

`PopPage(INavigationParameter parameter)`

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

