### PR TITLE
fix: SextantSample ViewModel namespacing

### DIFF
--- a/Sample/SextantSample/Views/FirstModalView.xaml
+++ b/Sample/SextantSample/Views/FirstModalView.xaml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rxui:ReactiveContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:vm="clr-namespace:SextantSample.ViewModels"
              xmlns:rxui="clr-namespace:ReactiveUI.XamForms;assembly=ReactiveUI.XamForms"
-             x:TypeArguments="vm:FirstModalViewModel"
+             xmlns:viewModels="clr-namespace:SextantSample.ViewModels;assembly=SextantSample.ViewModels"
+             x:TypeArguments="viewModels:FirstModalViewModel"
              x:Class="SextantSample.Views.FirstModalView"
              Title="First Modal">
     <ContentPage.Content>

--- a/Sample/SextantSample/Views/GreenView.xaml
+++ b/Sample/SextantSample/Views/GreenView.xaml
@@ -3,7 +3,7 @@
 <xamForms:ReactiveContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:xamForms="clr-namespace:ReactiveUI.XamForms;assembly=ReactiveUI.XamForms"
-             xmlns:viewModels="clr-namespace:SextantSample.ViewModels;assembly=SextantSample"
+             xmlns:viewModels="clr-namespace:SextantSample.ViewModels;assembly=SextantSample.ViewModels"
              x:TypeArguments="viewModels:GreenViewModel"
              x:Class="SextantSample.Views.GreenView">
     <ContentPage.Content>

--- a/Sample/SextantSample/Views/HomeView.xaml
+++ b/Sample/SextantSample/Views/HomeView.xaml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rxui:ReactiveContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:vm="clr-namespace:SextantSample.ViewModels"
              xmlns:rxui="clr-namespace:ReactiveUI.XamForms;assembly=ReactiveUI.XamForms"
-             x:TypeArguments="vm:HomeViewModel"
+             xmlns:viewModels="clr-namespace:SextantSample.ViewModels;assembly=SextantSample.ViewModels"
+             x:TypeArguments="viewModels:HomeViewModel"
              x:Class="SextantSample.Views.HomeView"
              Title="Home">
     <ContentPage.Content>

--- a/Sample/SextantSample/Views/RedView.xaml
+++ b/Sample/SextantSample/Views/RedView.xaml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rxui:ReactiveContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:vm="clr-namespace:SextantSample.ViewModels"
              xmlns:rxui="clr-namespace:ReactiveUI.XamForms;assembly=ReactiveUI.XamForms"
-             x:TypeArguments="vm:RedViewModel"
+             xmlns:viewModels="clr-namespace:SextantSample.ViewModels;assembly=SextantSample.ViewModels"
+             x:TypeArguments="viewModels:RedViewModel"
              x:Class="SextantSample.Views.RedView"
              Title="First Modal">
     <ContentPage.Content>

--- a/Sample/SextantSample/Views/SecondModalView.xaml
+++ b/Sample/SextantSample/Views/SecondModalView.xaml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rxui:ReactiveContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:vm="clr-namespace:SextantSample.ViewModels"
              xmlns:rxui="clr-namespace:ReactiveUI.XamForms;assembly=ReactiveUI.XamForms"
-             x:TypeArguments="vm:SecondModalViewModel"
+             xmlns:viewModels="clr-namespace:SextantSample.ViewModels;assembly=SextantSample.ViewModels"
+             x:TypeArguments="viewModels:SecondModalViewModel"
              x:Class="SextantSample.Views.SecondModalView"
              Title="Second Modal">
     <ContentPage.Content>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

The Xamarin.Forms Sample is broken.  It won't build due to namespacing issues.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

The Xamarin.Forms Sample works

**What is the new behavior?**
<!-- If this is a feature change -->

The namespaces are correctly resolved for the Xamarin.Forms sample and it builds.

**What might this PR break?**

Nothing.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

