### PR TITLE
housekeeping: USample to ReactiveUI 11.*

### DIFF
--- a/Sample/SextantSample.iOS/SextantSample.iOS.csproj
+++ b/Sample/SextantSample.iOS/SextantSample.iOS.csproj
@@ -162,7 +162,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.XamForms" Version="11.1.1" />
+    <PackageReference Include="ReactiveUI.XamForms" Version="11.*" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Moving ReactiveUI.XamForms back to the 11.* wildcard.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

ReactiveUI.XamForms targets 11.1.1

**What is the new behavior?**
<!-- If this is a feature change -->


ReactiveUI.XamForms targets 11.* wildcard.

**What might this PR break?**

Nothing

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

