### PR TITLE
housekeeping: Upgraded Xamarin.Forms to v4.5

### DIFF
--- a/Sample/SextantSample/SextantSample.csproj
+++ b/Sample/SextantSample/SextantSample.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.Forms" Version="4.3.*" />
+        <PackageReference Include="Xamarin.Forms" Version="4.5.*" />
         <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
         <PackageReference Include="ReactiveUI.XamForms" Version="11.*" />
         <PackageReference Include="Pharmacist.MsBuild" Version="1.*" PrivateAssets="all" />

--- a/src/Sextant.XamForms/Sextant.XamForms.csproj
+++ b/src/Sextant.XamForms/Sextant.XamForms.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
-    <PackageReference Include="Xamarin.Forms" Version="4.4.*" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrades Xamarin.Forms minimum version to v4.5.*

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Xamarin.Forms minimum version is 4.4.*

**What is the new behavior?**
<!-- If this is a feature change -->

Xamarin.Forms minimum version is 4.5.*

**What might this PR break?**

Sextant.XamForms

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

