### PR TITLE
housekeeping: Deprecated System.Reactive.Linq extension methods

### DIFF
--- a/src/Sextant.XamForms/NavigationView.cs
+++ b/src/Sextant.XamForms/NavigationView.cs
@@ -52,7 +52,7 @@ namespace Sextant.XamForms
                 Observable
                     .FromEventPattern<NavigationEventArgs>(x => Popped += x, x => Popped -= x)
                     .Select(ep => ep.EventArgs.Page.BindingContext as IViewModel)
-                    .WhereNotNull();
+                    .Where(x => x != null);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Sextant.XamForms
                 Observable
                     .FromEventPattern<NavigationEventArgs>(x => Popped += x, x => Popped -= x)
                     .Select(ep => ep.EventArgs.Page.BindingContext as IViewModel)
-                    .WhereNotNull();
+                    .Where(x => x != null);
         }
 
         /// <inheritdoc />
@@ -86,7 +86,7 @@ namespace Sextant.XamForms
             Navigation
                 .PopModalAsync()
                 .ToObservable()
-                .ToSignal()
+                .Select(_ => Unit.Default)
                 .ObserveOn(_mainScheduler); // XF completes the pop operation on a background thread :/
 
         /// <inheritdoc />
@@ -94,7 +94,7 @@ namespace Sextant.XamForms
             Navigation
                 .PopAsync(animate)
                 .ToObservable()
-                .ToSignal()
+                .Select(_ => Unit.Default)
                 .ObserveOn(_mainScheduler); // XF completes the pop operation on a background thread :/
 
         /// <inheritdoc />
@@ -102,7 +102,7 @@ namespace Sextant.XamForms
              Navigation
                 .PopToRootAsync(animate)
                 .ToObservable()
-                .ToSignal()
+                .Select(_ => Unit.Default)
                 .ObserveOn(_mainScheduler);
 
         /// <inheritdoc />

--- a/src/Sextant/System/Reactive/Linq/ToSignalExtension.cs
+++ b/src/Sextant/System/Reactive/Linq/ToSignalExtension.cs
@@ -17,6 +17,7 @@ namespace System.Reactive.Linq
         /// <typeparam name="T">The current type of the observable.</typeparam>
         /// <param name="observable">The observable to convert.</param>
         /// <returns>The converted observable.</returns>
+        [Obsolete("This extension method causes conflicts in the System.Reactive.Linq namespace")]
         public static IObservable<Unit> ToSignal<T>(this IObservable<T> observable)
         {
             if (observable == null)

--- a/src/Sextant/System/Reactive/Linq/WhereNotNullExtension.cs
+++ b/src/Sextant/System/Reactive/Linq/WhereNotNullExtension.cs
@@ -16,6 +16,7 @@ namespace System.Reactive.Linq
         /// <typeparam name="T">The type of the observable.</typeparam>
         /// <param name="observable">The observable to add the condition to.</param>
         /// <returns>An observable which will not signal unless the value is not null.</returns>
+        [Obsolete("This extension method causes conflicts in the System.Reactive.Linq namespace")]
         public static IObservable<T> WhereNotNull<T>(this IObservable<T> observable)
         {
             return observable.Where(x => x != null);


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Deprecating custom extension methods.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

When the library was written it had a `WhereNotNull()` and `ToSignal()` operators.  They have been marked obsolete because they cause namespace conflicts if another package has a similarly named operator in the `System.Reactive.Linq` namespace.

**What is the new behavior?**
<!-- If this is a feature change -->

These operators are marked deprecated and will be removed in the next major version.

**What might this PR break?**

Nothing

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

