### PR TITLE
fix: WhenNavigatingTo firing after page navigation

### DIFF
--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
@@ -52,7 +52,7 @@ namespace Sextant
     public interface IParameterViewStackService : Sextant.IViewStackService
     {
         System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = true);
-        System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable modal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true);
+        System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable navigableModal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true);
         System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
             where TViewModel : Sextant.INavigable;
         System.IObservable<System.Reactive.Unit> PushPage(Sextant.INavigable navigableViewModel, Sextant.INavigationParameter parameter, string? contract = null, bool resetStack = false, bool animate = true);

--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
@@ -52,7 +52,7 @@ namespace Sextant
     public interface IParameterViewStackService : Sextant.IViewStackService
     {
         System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = true);
-        System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable modal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true);
+        System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable navigableModal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true);
         System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
             where TViewModel : Sextant.INavigable;
         System.IObservable<System.Reactive.Unit> PushPage(Sextant.INavigable navigableViewModel, Sextant.INavigationParameter parameter, string? contract = null, bool resetStack = false, bool animate = true);

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -127,6 +127,31 @@ namespace Sextant.Tests
                 await viewModel.DidNotReceive().WhenNavigatedFrom(navigationParameter);
             }
 
+            /// <summary>
+            /// Tests to make sure we receive a navigation methods in the correct order.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
+            public async Task Should_Call_In_Order()
+            {
+                // Given
+                var view = Substitute.For<IView>();
+                var viewModel = Substitute.For<INavigable>();
+                var navigationParameter = Substitute.For<INavigationParameter>();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+
+                // When
+                await sut.PushPage(viewModel, navigationParameter);
+
+                // Then
+                Received.InOrder(() =>
+                {
+                    viewModel.WhenNavigatingTo(Arg.Any<INavigationParameter>());
+                    view.PushPage(Arg.Any<IViewModel>(), null, Arg.Any<bool>(), Arg.Any<bool>());
+                    viewModel.WhenNavigatedTo(Arg.Any<INavigationParameter>());
+                });
+            }
+
             /// <summary>Tests to make sure we receive a push page notification.</summary>
             /// <param name="contract">The contract.</param>
             /// <param name="reset">Reset the stack.</param>
@@ -581,6 +606,32 @@ namespace Sextant.Tests
 
                 // Then
                 await viewModel.DidNotReceive().WhenNavigatingTo(navigationParameter);
+            }
+
+            /// <summary>
+            /// Tests to make sure we receive a navigation methods in the correct order.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
+            public async Task Should_Call_In_Order()
+            {
+                // Given
+                var view = Substitute.For<IView>();
+                var viewModel = Substitute.For<INavigable>();
+                view.PagePopped.Returns(Observable.Return(viewModel));
+                var navigationParameter = Substitute.For<INavigationParameter>();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view).WithPushed(viewModel);
+
+                // When
+                await sut.PopPage(navigationParameter);
+
+                // Then
+                Received.InOrder(() =>
+                {
+                    view.PopPage(Arg.Any<bool>());
+                    viewModel.WhenNavigatedFrom(Arg.Any<INavigationParameter>());
+                    viewModel.WhenNavigatedTo(Arg.Any<INavigationParameter>());
+                });
             }
         }
     }

--- a/src/Sextant/Abstractions/IParameterViewStackService.cs
+++ b/src/Sextant/Abstractions/IParameterViewStackService.cs
@@ -39,12 +39,12 @@ namespace Sextant
         /// <summary>
         /// Pushes the <see cref="IViewModel" /> onto the stack.
         /// </summary>
-        /// <param name="modal">The modal.</param>
+        /// <param name="navigableModal">The modal.</param>
         /// <param name="parameter">The parameter.</param>
         /// <param name="contract">The contract.</param>
         /// <param name="withNavigationPage">Value indicating whether to wrap the modal in a navigation page.</param>
         /// <returns>An observable that signals when the push has been completed.</returns>
-        IObservable<Unit> PushModal(INavigable modal, INavigationParameter parameter, string? contract = null, bool withNavigationPage = true);
+        IObservable<Unit> PushModal(INavigable navigableModal, INavigationParameter parameter, string? contract = null, bool withNavigationPage = true);
 
         /// <summary>
         /// Pushes the <see cref="IViewModel" /> onto the stack.

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -47,15 +47,17 @@ namespace Sextant
                 throw new ArgumentNullException(nameof(parameter));
             }
 
+            navigableViewModel
+                .WhenNavigatingTo(parameter)
+                .ObserveOn(View.MainThreadScheduler)
+                .Subscribe(navigating =>
+                    Logger.Debug(
+                        $"Called `WhenNavigatingTo` on '{navigableViewModel.Id}' passing parameter {parameter}"));
+
             return View
                 .PushPage(navigableViewModel, contract, resetStack, animate)
                 .Do(_ =>
                 {
-                    navigableViewModel
-                        .WhenNavigatingTo(parameter)
-                        .ObserveOn(View.MainThreadScheduler)
-                        .Subscribe(navigating => Logger.Debug($"Called `WhenNavigatingTo` on '{navigableViewModel.Id}' passing parameter {parameter}"));
-
                     AddToStackAndTick(PageSubject, navigableViewModel, resetStack);
                     Logger.Debug($"Added page '{navigableViewModel.Id}' (contract '{contract}') to stack.");
 
@@ -79,15 +81,16 @@ namespace Sextant
                 throw new ArgumentNullException(nameof(parameter));
             }
 
+            navigableModal
+                .WhenNavigatingTo(parameter)
+                .ObserveOn(View.MainThreadScheduler)
+                .Subscribe(navigating =>
+                    Logger.Debug($"Called `WhenNavigatingTo` on '{navigableModal.Id}' passing parameter {parameter}"));
+
             return View
                 .PushModal(navigableModal, contract, withNavigationPage)
                 .Do(_ =>
                 {
-                    navigableModal
-                        .WhenNavigatingTo(parameter)
-                        .ObserveOn(View.MainThreadScheduler)
-                        .Subscribe(navigating => Logger.Debug($"Called `WhenNavigatingTo` on '{navigableModal.Id}' passing parameter {parameter}"));
-
                     AddToStackAndTick(ModalSubject, navigableModal, false);
                     Logger.Debug("Added modal '{modal.Id}' (contract '{contract}') to stack.");
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
fixes issue where `INavigable.WhenNavigatingTo` doesn't fire before the target page navigation.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->

![broken-when-navigating-to](https://user-images.githubusercontent.com/6969701/82715847-888aaa00-9c5a-11ea-9da2-3dff04d47205.gif)

**What is the new behavior?**
<!-- If this is a feature change -->

![fix-when-navigating-to](https://user-images.githubusercontent.com/6969701/82715822-6b55db80-9c5a-11ea-9c04-8f7d3fd7db8c.gif)

**What might this PR break?**

Nothing

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

