### PR TITLE
[WIP] - feature: Add IDestructible lifecycle extension point 

### DIFF
--- a/src/Sextant.Mocks/Mocks/IEverything.cs
+++ b/src/Sextant.Mocks/Mocks/IEverything.cs
@@ -1,3 +1,8 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
 namespace Sextant.Mocks
 {
     /// <summary>

--- a/src/Sextant.Mocks/Mocks/IEverything.cs
+++ b/src/Sextant.Mocks/Mocks/IEverything.cs
@@ -1,0 +1,9 @@
+namespace Sextant.Mocks
+{
+    /// <summary>
+    /// Interface representing everything.
+    /// </summary>
+    public interface IEverything : INavigable, IDestructible
+    {
+    }
+}

--- a/src/Sextant.Mocks/Mocks/NavigationViewMock.cs
+++ b/src/Sextant.Mocks/Mocks/NavigationViewMock.cs
@@ -1,3 +1,8 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Reactive;

--- a/src/Sextant.Mocks/Mocks/ParameterViewModel.cs
+++ b/src/Sextant.Mocks/Mocks/ParameterViewModel.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text;
 using ReactiveUI;
@@ -16,7 +17,7 @@ namespace Sextant.Mocks
     /// View model to test passing parameters.
     /// </summary>
     /// <seealso cref="IViewModel" />
-    public class ParameterViewModel : ReactiveObject, INavigable
+    public class ParameterViewModel : ReactiveObject, INavigable, IDestructible
     {
         private string? _text;
         private int _meaning;
@@ -34,6 +35,11 @@ namespace Sextant.Mocks
         /// </summary>
         public int Meaning { get => _meaning; set => this.RaiseAndSetIfChanged(ref _meaning, value); }
 
+        /// <summary>
+        /// Gets the disposable.
+        /// </summary>
+        public CompositeDisposable Disposable { get; } = new CompositeDisposable();
+
         /// <inheritdoc />
         public IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) => Observable.Return(Unit.Default).Do(_ => Unwrap(parameter));
 
@@ -42,6 +48,12 @@ namespace Sextant.Mocks
 
         /// <inheritdoc />
         public IObservable<Unit> WhenNavigatingTo(INavigationParameter parameter) => Observable.Return(Unit.Default).Do(_ => Unwrap(parameter));
+
+        /// <inheritdoc/>
+        public void Destroy()
+        {
+            Disposable?.Dispose();
+        }
 
         private void Unwrap(INavigationParameter parameter)
         {

--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
@@ -36,6 +36,10 @@ namespace Sextant
         public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, T> factory)
             where T : Sextant.IViewStackService { }
     }
+    public interface IDestructible
+    {
+        void Destroy();
+    }
     public interface INavigable : Sextant.INavigated, Sextant.INavigating, Sextant.IViewModel { }
     public interface INavigated
     {
@@ -115,6 +119,11 @@ namespace Sextant
     public static class SextantExtensions
     {
         public static void Initialize(this Sextant.Sextant sextant) { }
+    }
+    public static class ViewModelActionExtensions
+    {
+        public static object InvokeViewModelAction<T>(this object viewModel, System.Action<T> action)
+            where T :  class { }
     }
     public static class ViewModelFactory
     {

--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
@@ -95,13 +95,6 @@ namespace Sextant
         System.IObservable<Sextant.IViewModel> TopModal();
         System.IObservable<Sextant.IViewModel> TopPage();
     }
-    public static class LifeCycleExtensions
-    {
-        public static object InvokeViewModelAction<T>(this object viewModel, System.Action<T> action)
-            where T :  class { }
-        public static void InvokeViewModelAction<T>(this object viewModel, System.IObserver<T> action)
-            where T :  class { }
-    }
     public class NavigationParameter : System.Collections.Generic.Dictionary<string, object>, Sextant.INavigationParameter, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
     {
         public NavigationParameter() { }
@@ -126,6 +119,11 @@ namespace Sextant
     public static class SextantExtensions
     {
         public static void Initialize(this Sextant.Sextant sextant) { }
+    }
+    public static class ViewModelActionExtensions
+    {
+        public static object InvokeViewModelAction<T>(this object viewModel, System.Action<T> action)
+            where T :  class { }
     }
     public static class ViewModelFactory
     {

--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
@@ -36,6 +36,10 @@ namespace Sextant
         public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, T> factory)
             where T : Sextant.IViewStackService { }
     }
+    public interface IDestructible
+    {
+        void Destroy();
+    }
     public interface INavigable : Sextant.INavigated, Sextant.INavigating, Sextant.IViewModel { }
     public interface INavigated
     {
@@ -90,6 +94,13 @@ namespace Sextant
             where TViewModel : Sextant.IViewModel;
         System.IObservable<Sextant.IViewModel> TopModal();
         System.IObservable<Sextant.IViewModel> TopPage();
+    }
+    public static class LifeCycleExtensions
+    {
+        public static object InvokeViewModelAction<T>(this object viewModel, System.Action<T> action)
+            where T :  class { }
+        public static void InvokeViewModelAction<T>(this object viewModel, System.IObserver<T> action)
+            where T :  class { }
     }
     public class NavigationParameter : System.Collections.Generic.Dictionary<string, object>, Sextant.INavigationParameter, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
     {

--- a/src/Sextant.Tests/Navigation/DestructibleTests.cs
+++ b/src/Sextant.Tests/Navigation/DestructibleTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Sextant.Mocks;
+using Shouldly;
+using Xunit;
+
+namespace Sextant.Tests
+{
+    /// <summary>
+    /// Test a <see cref="IDestructible"/> implementation.
+    /// </summary>
+    public class DestructibleTests
+    {
+        /// <summary>
+        /// Tests the destroy method.
+        /// </summary>
+        public class TheDestroyMethod
+        {
+            /// <summary>
+            /// Should unwrap the parameters.
+            /// </summary>
+            [Fact]
+            public void Should_Destroy()
+            {
+                // Given
+                ParameterViewModel sut = new ParameterViewModel();
+
+                // When
+                sut.Disposable.IsDisposed.ShouldBeFalse();
+                sut.Destroy();
+
+                // Then
+                sut.Disposable.IsDisposed.ShouldBeTrue();
+            }
+        }
+    }
+}

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceFixture.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceFixture.cs
@@ -42,6 +42,14 @@ namespace Sextant.Tests
             return stack;
         }
 
+        public ParameterViewStackService WithModal<TViewModel>(TViewModel viewModel)
+            where TViewModel : INavigable
+        {
+            var stack = Build();
+            stack.PushModal(viewModel).Subscribe();
+            return stack;
+        }
+
         private ParameterViewStackService Build() => new ParameterViewStackService(_view);
     }
 }

--- a/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
@@ -166,6 +166,25 @@ namespace Sextant.Tests
                 result.ShouldBeOfType<InvalidOperationException>();
                 result?.Message.ShouldBe("Stack is empty.");
             }
+
+            /// <summary>
+            /// Tests to make sure we receive a push page notification.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
+            public async Task Should_Call_Destroy()
+            {
+                // Given
+                var viewModel = Substitute.For<IEverything>();
+                var view = Substitute.For<IView>();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view).WithModal(viewModel);
+
+                // When
+                await sut.PopModal();
+
+                // Then
+                viewModel.Received().Destroy();
+            }
         }
 
         /// <summary>
@@ -181,8 +200,8 @@ namespace Sextant.Tests
             public async Task Should_Pop_Page()
             {
                 // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushModal(new NavigableViewModelMock());
+                ViewStackService sut = new ViewStackServiceFixture().WithView(new NavigationViewMock());
+                await sut.PushPage(new NavigableViewModelMock());
 
                 // When
                 await sut.PopPage();
@@ -201,7 +220,7 @@ namespace Sextant.Tests
             {
                 // Given
                 ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushModal(new NavigableViewModelMock());
+                await sut.PushPage(new NavigableViewModelMock());
 
                 // When
                 await sut.PopPage();
@@ -226,6 +245,25 @@ namespace Sextant.Tests
 
                 // Then
                 result.ShouldBeOfType<Unit>();
+            }
+
+            /// <summary>
+            /// Tests to make sure we destroy the view model.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
+            public async Task Should_Call_Destroy()
+            {
+                // Given
+                var viewModel = Substitute.For<IEverything>();
+                var view = new NavigationViewMock();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view).WithPushed(viewModel);
+
+                // When
+                await sut.PopPage();
+
+                // Then
+                viewModel.Received().Destroy();
             }
         }
 
@@ -311,6 +349,34 @@ namespace Sextant.Tests
 
                 // Then
                 result.ShouldHaveSingleItem();
+            }
+
+            /// <summary>
+            /// Tests to make sure we destroy the view model.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
+            public async Task Should_Call_Destroy()
+            {
+                // Given
+                var viewModel1 = Substitute.For<IEverything>();
+                var viewModel2 = Substitute.For<IEverything>();
+                var viewModel3 = Substitute.For<IEverything>();
+                var view = Substitute.For<IView>();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+                await sut.PushPage(viewModel1);
+                await sut.PushPage(viewModel2);
+                await sut.PushPage(viewModel3);
+
+                // When
+                await sut.PopToRootPage();
+
+                // Then
+                Received.InOrder(() =>
+                {
+                    viewModel3.Destroy();
+                    viewModel2.Destroy();
+                });
             }
         }
 

--- a/src/Sextant/Abstractions/IDestructible.cs
+++ b/src/Sextant/Abstractions/IDestructible.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Sextant
+{
+    /// <summary>
+    /// Interface representing an object capable of being destroyed.
+    /// </summary>
+    public interface IDestructible
+    {
+        /// <summary>
+        /// Destroy the destructible object.
+        /// </summary>
+        public void Destroy();
+    }
+}

--- a/src/Sextant/Navigation/LifeCycleExtensions.cs
+++ b/src/Sextant/Navigation/LifeCycleExtensions.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Sextant
+{
+    /// <summary>
+    /// Class of extension method for object life cycle in Sextant.
+    /// </summary>
+    public static class ViewModelActionExtensions
+    {
+        /// <summary>
+        /// This is a thing I lifted from Prism.
+        /// </summary>
+        /// <param name="viewModel">The view model.</param>
+        /// <param name="action">An action.</param>
+        /// <typeparam name="T">A type.</typeparam>
+        /// <returns>The object.</returns>
+        public static object InvokeViewModelAction<T>(this object viewModel, Action<T> action)
+            where T : class
+        {
+            if (action == null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            if (viewModel is IViewModel element)
+            {
+                if (element is T viewModelAsT)
+                {
+                    action(viewModelAsT);
+                }
+            }
+
+            return viewModel;
+        }
+
+        /// <summary>
+        /// This is a thing I lifted from Prism.
+        /// </summary>
+        /// <param name="viewModel">The view model.</param>
+        /// <param name="action">An action.</param>
+        /// <typeparam name="T">A type.</typeparam>
+        public static void InvokeViewModelAction<T>(this object viewModel, IObserver<T> action)
+            where T : class
+        {
+            if (action == null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            if (viewModel is IViewModel element)
+            {
+                if (element is T viewModelAsT)
+                {
+                    action.OnNext(viewModelAsT);
+                }
+            }
+        }
+    }
+}

--- a/src/Sextant/Navigation/NavigationParameter.cs
+++ b/src/Sextant/Navigation/NavigationParameter.cs
@@ -3,11 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 
 namespace Sextant
 {

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -130,14 +130,13 @@ namespace Sextant
                 .PopPage(animate)
                 .Do(_ =>
                 {
-                    if (poppedPage is INavigable navigable)
-                    {
-                        navigable
-                            .WhenNavigatedFrom(parameter)
-                            .ObserveOn(View.MainThreadScheduler)
-                            .Subscribe(navigatedFrom =>
-                                Logger.Debug($"Called `WhenNavigatedFrom` on '{navigable.Id}' passing parameter {parameter}"));
-                    }
+                    poppedPage
+                            .InvokeViewModelAction<INavigable>(x =>
+                                x.WhenNavigatedFrom(parameter)
+                                    .ObserveOn(View.MainThreadScheduler)
+                                    .Subscribe(navigatedFrom =>
+                                        Logger.Debug($"Called `WhenNavigatedFrom` on '{poppedPage.Id}' passing parameter {parameter}")))
+                            .InvokeViewModelAction<IDestructible>(x => x.Destroy());
 
                     IViewModel topPage = TopPage().FirstOrDefaultAsync().Wait();
                     if (topPage is INavigated navigated)

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -4,12 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Reactive;
 using System.Reactive.Linq;
-using System.Text;
-using System.Threading;
-using ReactiveUI;
 
 namespace Sextant
 {

--- a/src/Sextant/Navigation/ViewModelActionExtensions.cs
+++ b/src/Sextant/Navigation/ViewModelActionExtensions.cs
@@ -37,28 +37,5 @@ namespace Sextant
 
             return viewModel;
         }
-
-        /// <summary>
-        /// This is a thing I lifted from Prism.
-        /// </summary>
-        /// <param name="viewModel">The view model.</param>
-        /// <param name="action">An action.</param>
-        /// <typeparam name="T">A type.</typeparam>
-        public static void InvokeViewModelAction<T>(this object viewModel, IObserver<T> action)
-            where T : class
-        {
-            if (action == null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
-
-            if (viewModel is IViewModel element)
-            {
-                if (element is T viewModelAsT)
-                {
-                    action.OnNext(viewModelAsT);
-                }
-            }
-        }
     }
 }

--- a/src/Sextant/Navigation/ViewStackServiceBase.cs
+++ b/src/Sextant/Navigation/ViewStackServiceBase.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reactive;


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Resolves: #197

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

There is no way to dispose of ViewModel subscriptions when a corresponding page is popped from the stack.

**What is the new behavior?**
<!-- If this is a feature change -->

There is an `IDestructible` interface that allows you to dispose of view model resources when the page is popped from the view.

**What might this PR break?**

Lifecycle events.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

