### PR TITLE
fix: ViewModelFactory not using passed contract

### DIFF
--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
@@ -31,9 +31,13 @@ namespace Sextant
             where TViewModel :  class, Sextant.IViewModel { }
         public static Splat.IMutableDependencyResolver RegisterViewModel<TViewModel>(this Splat.IMutableDependencyResolver dependencyResolver, TViewModel viewModel, string? contract = null)
             where TViewModel :  class, Sextant.IViewModel { }
+        public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver) { }
         public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.Abstractions.IViewModelFactory> factory) { }
         public static Splat.IMutableDependencyResolver RegisterViewStackService(this Splat.IMutableDependencyResolver dependencyResolver) { }
+        [System.Obsolete("Use the Func<IView, IViewModelFactory, T> variant.")]
         public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, T> factory)
+            where T : Sextant.IViewStackService { }
+        public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, Sextant.Abstractions.IViewModelFactory, T> factory)
             where T : Sextant.IViewStackService { }
     }
     public interface IDestructible
@@ -102,6 +106,7 @@ namespace Sextant
     public sealed class ParameterViewStackService : Sextant.ViewStackServiceBase, Sextant.IParameterViewStackService, Sextant.IViewStackService
     {
         public ParameterViewStackService(Sextant.IView view) { }
+        public ParameterViewStackService(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
         public System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = true) { }
         public System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable navigableModal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true) { }
         public System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
@@ -139,10 +144,12 @@ namespace Sextant
     public sealed class ViewStackService : Sextant.ViewStackServiceBase
     {
         public ViewStackService(Sextant.IView view) { }
+        public ViewStackService(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
     }
     public abstract class ViewStackServiceBase : Sextant.IViewStackService, Splat.IEnableLogger, System.IDisposable
     {
-        protected ViewStackServiceBase(Sextant.IView view) { }
+        protected ViewStackServiceBase(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
+        protected Sextant.Abstractions.IViewModelFactory Factory { get; }
         protected Splat.IFullLogger Logger { get; }
         public System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }
         protected System.Reactive.Subjects.BehaviorSubject<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalSubject { get; }

--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.net472.approved.txt
@@ -1,15 +1,7 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
-namespace Sextant.Abstractions
-{
-    public interface IViewModelFactory
-    {
-        TViewModel Create<TViewModel>(string? contract = null)
-            where TViewModel : Sextant.IViewModel;
-    }
-}
 namespace Sextant
 {
-    public class DefaultViewModelFactory : Sextant.Abstractions.IViewModelFactory
+    public class DefaultViewModelFactory : Sextant.IViewModelFactory
     {
         public DefaultViewModelFactory() { }
         public TViewModel Create<TViewModel>(string? contract = null)
@@ -32,12 +24,12 @@ namespace Sextant
         public static Splat.IMutableDependencyResolver RegisterViewModel<TViewModel>(this Splat.IMutableDependencyResolver dependencyResolver, TViewModel viewModel, string? contract = null)
             where TViewModel :  class, Sextant.IViewModel { }
         public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver) { }
-        public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.Abstractions.IViewModelFactory> factory) { }
+        public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IViewModelFactory> factory) { }
         public static Splat.IMutableDependencyResolver RegisterViewStackService(this Splat.IMutableDependencyResolver dependencyResolver) { }
         [System.Obsolete("Use the Func<IView, IViewModelFactory, T> variant.")]
         public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, T> factory)
             where T : Sextant.IViewStackService { }
-        public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, Sextant.Abstractions.IViewModelFactory, T> factory)
+        public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, Sextant.IViewModelFactory, T> factory)
             where T : Sextant.IViewStackService { }
     }
     public interface IDestructible
@@ -81,6 +73,11 @@ namespace Sextant
     {
         string Id { get; }
     }
+    public interface IViewModelFactory
+    {
+        TViewModel Create<TViewModel>(string? contract = null)
+            where TViewModel : Sextant.IViewModel;
+    }
     public interface IViewStackService
     {
         System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }
@@ -106,7 +103,7 @@ namespace Sextant
     public sealed class ParameterViewStackService : Sextant.ViewStackServiceBase, Sextant.IParameterViewStackService, Sextant.IViewStackService
     {
         public ParameterViewStackService(Sextant.IView view) { }
-        public ParameterViewStackService(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
+        public ParameterViewStackService(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
         public System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = true) { }
         public System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable navigableModal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true) { }
         public System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
@@ -132,7 +129,7 @@ namespace Sextant
     }
     public static class ViewModelFactory
     {
-        public static Sextant.Abstractions.IViewModelFactory Current { get; }
+        public static Sextant.IViewModelFactory Current { get; }
     }
     public class ViewModelFactoryNotFoundException : System.Exception
     {
@@ -144,12 +141,12 @@ namespace Sextant
     public sealed class ViewStackService : Sextant.ViewStackServiceBase
     {
         public ViewStackService(Sextant.IView view) { }
-        public ViewStackService(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
+        public ViewStackService(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
     }
     public abstract class ViewStackServiceBase : Sextant.IViewStackService, Splat.IEnableLogger, System.IDisposable
     {
-        protected ViewStackServiceBase(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
-        protected Sextant.Abstractions.IViewModelFactory Factory { get; }
+        protected ViewStackServiceBase(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
+        protected Sextant.IViewModelFactory Factory { get; }
         protected Splat.IFullLogger Logger { get; }
         public System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }
         protected System.Reactive.Subjects.BehaviorSubject<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalSubject { get; }

--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
@@ -1,15 +1,7 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
-namespace Sextant.Abstractions
-{
-    public interface IViewModelFactory
-    {
-        TViewModel Create<TViewModel>(string? contract = null)
-            where TViewModel : Sextant.IViewModel;
-    }
-}
 namespace Sextant
 {
-    public class DefaultViewModelFactory : Sextant.Abstractions.IViewModelFactory
+    public class DefaultViewModelFactory : Sextant.IViewModelFactory
     {
         public DefaultViewModelFactory() { }
         public TViewModel Create<TViewModel>(string? contract = null)
@@ -32,12 +24,12 @@ namespace Sextant
         public static Splat.IMutableDependencyResolver RegisterViewModel<TViewModel>(this Splat.IMutableDependencyResolver dependencyResolver, TViewModel viewModel, string? contract = null)
             where TViewModel :  class, Sextant.IViewModel { }
         public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver) { }
-        public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.Abstractions.IViewModelFactory> factory) { }
+        public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IViewModelFactory> factory) { }
         public static Splat.IMutableDependencyResolver RegisterViewStackService(this Splat.IMutableDependencyResolver dependencyResolver) { }
         [System.Obsolete("Use the Func<IView, IViewModelFactory, T> variant.")]
         public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, T> factory)
             where T : Sextant.IViewStackService { }
-        public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, Sextant.Abstractions.IViewModelFactory, T> factory)
+        public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, Sextant.IViewModelFactory, T> factory)
             where T : Sextant.IViewStackService { }
     }
     public interface IDestructible
@@ -81,6 +73,11 @@ namespace Sextant
     {
         string Id { get; }
     }
+    public interface IViewModelFactory
+    {
+        TViewModel Create<TViewModel>(string? contract = null)
+            where TViewModel : Sextant.IViewModel;
+    }
     public interface IViewStackService
     {
         System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }
@@ -106,7 +103,7 @@ namespace Sextant
     public sealed class ParameterViewStackService : Sextant.ViewStackServiceBase, Sextant.IParameterViewStackService, Sextant.IViewStackService
     {
         public ParameterViewStackService(Sextant.IView view) { }
-        public ParameterViewStackService(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
+        public ParameterViewStackService(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
         public System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = true) { }
         public System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable navigableModal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true) { }
         public System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
@@ -132,7 +129,7 @@ namespace Sextant
     }
     public static class ViewModelFactory
     {
-        public static Sextant.Abstractions.IViewModelFactory Current { get; }
+        public static Sextant.IViewModelFactory Current { get; }
     }
     public class ViewModelFactoryNotFoundException : System.Exception
     {
@@ -144,12 +141,12 @@ namespace Sextant
     public sealed class ViewStackService : Sextant.ViewStackServiceBase
     {
         public ViewStackService(Sextant.IView view) { }
-        public ViewStackService(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
+        public ViewStackService(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
     }
     public abstract class ViewStackServiceBase : Sextant.IViewStackService, Splat.IEnableLogger, System.IDisposable
     {
-        protected ViewStackServiceBase(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
-        protected Sextant.Abstractions.IViewModelFactory Factory { get; }
+        protected ViewStackServiceBase(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
+        protected Sextant.IViewModelFactory Factory { get; }
         protected Splat.IFullLogger Logger { get; }
         public System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }
         protected System.Reactive.Subjects.BehaviorSubject<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalSubject { get; }

--- a/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.SextantProject.netcoreapp2.2.approved.txt
@@ -31,9 +31,13 @@ namespace Sextant
             where TViewModel :  class, Sextant.IViewModel { }
         public static Splat.IMutableDependencyResolver RegisterViewModel<TViewModel>(this Splat.IMutableDependencyResolver dependencyResolver, TViewModel viewModel, string? contract = null)
             where TViewModel :  class, Sextant.IViewModel { }
+        public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver) { }
         public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.Abstractions.IViewModelFactory> factory) { }
         public static Splat.IMutableDependencyResolver RegisterViewStackService(this Splat.IMutableDependencyResolver dependencyResolver) { }
+        [System.Obsolete("Use the Func<IView, IViewModelFactory, T> variant.")]
         public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, T> factory)
+            where T : Sextant.IViewStackService { }
+        public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, Sextant.Abstractions.IViewModelFactory, T> factory)
             where T : Sextant.IViewStackService { }
     }
     public interface IDestructible
@@ -102,6 +106,7 @@ namespace Sextant
     public sealed class ParameterViewStackService : Sextant.ViewStackServiceBase, Sextant.IParameterViewStackService, Sextant.IViewStackService
     {
         public ParameterViewStackService(Sextant.IView view) { }
+        public ParameterViewStackService(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
         public System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = true) { }
         public System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable navigableModal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true) { }
         public System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
@@ -139,10 +144,12 @@ namespace Sextant
     public sealed class ViewStackService : Sextant.ViewStackServiceBase
     {
         public ViewStackService(Sextant.IView view) { }
+        public ViewStackService(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
     }
     public abstract class ViewStackServiceBase : Sextant.IViewStackService, Splat.IEnableLogger, System.IDisposable
     {
-        protected ViewStackServiceBase(Sextant.IView view) { }
+        protected ViewStackServiceBase(Sextant.IView view, Sextant.Abstractions.IViewModelFactory viewModelFactory) { }
+        protected Sextant.Abstractions.IViewModelFactory Factory { get; }
         protected Splat.IFullLogger Logger { get; }
         public System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }
         protected System.Reactive.Subjects.BehaviorSubject<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalSubject { get; }

--- a/src/Sextant.Tests/API/ApiApprovalTests.cs
+++ b/src/Sextant.Tests/API/ApiApprovalTests.cs
@@ -4,13 +4,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using PublicApiGenerator;
 using Shouldly;

--- a/src/Sextant.Tests/DependencyResolverMixinTests.cs
+++ b/src/Sextant.Tests/DependencyResolverMixinTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+using Sextant.Mocks;
+using Shouldly;
+using Splat;
+using Xunit;
+
+namespace Sextant.Tests
+{
+    /// <summary>
+    /// Tests the IMutableDependencyResolver extension class.
+    /// </summary>
+    public sealed class DependencyResolverMixinTests
+    {
+        /// <summary>
+        /// Tests the register view model factory method.
+        /// </summary>
+        public sealed class TheRegisterViewModelFactoryMethod
+        {
+            /// <summary>
+            /// Should register the view model factory.
+            /// </summary>
+            [Fact]
+            public void Should_Register_View_Model_Factory()
+            {
+                // Given
+                Locator.CurrentMutable.RegisterViewModelFactory();
+
+                // When
+                var result = ViewModelFactory.Current;
+
+                // Then
+                result.ShouldBeOfType<DefaultViewModelFactory>();
+            }
+
+            /// <summary>
+            /// Should register the view model factory.
+            /// </summary>
+            [Fact]
+            public void Should_Register_View_Model_Factory_With_Factory()
+            {
+                // Given
+                var viewModelFactory = new DefaultViewModelFactory();
+                Locator.CurrentMutable.RegisterViewModelFactory(() => viewModelFactory);
+
+                // When
+                var result = ViewModelFactory.Current;
+
+                // Then
+                result.ShouldBe(viewModelFactory);
+            }
+        }
+
+        /// <summary>
+        /// Tests the register view method.
+        /// </summary>
+        public sealed class TheRegisterViewMethod
+        {
+            /// <summary>
+            /// Should register the view stack service.
+            /// </summary>
+            [Fact]
+            public void Should_Register_View()
+            {
+                // Given
+                Locator.CurrentMutable.RegisterView<PageView, NavigableViewModelMock>();
+
+                // When
+                var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
+
+                // Then
+                result.ShouldBeOfType<PageView>();
+            }
+
+            /// <summary>
+            /// Should register the view stack service factory.
+            /// </summary>
+            [Fact]
+            public void Should_Register_View_Factory()
+            {
+                // Given
+                Locator.CurrentMutable.RegisterView<PageView, NavigableViewModelMock>(() => new PageView());
+
+                // When
+                var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
+
+                // Then
+                result.ShouldBeOfType<PageView>();
+            }
+        }
+    }
+}

--- a/src/Sextant.Tests/Navigation/DestructibleTests.cs
+++ b/src/Sextant.Tests/Navigation/DestructibleTests.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using NSubstitute;

--- a/src/Sextant.Tests/Navigation/NavigatedTests.cs
+++ b/src/Sextant.Tests/Navigation/NavigatedTests.cs
@@ -5,8 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 using Sextant.Mocks;
 using Shouldly;
 using Xunit;

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceFixture.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceFixture.cs
@@ -8,9 +8,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using NSubstitute;
 using ReactiveUI.Testing;
-using Sextant.Abstractions;
 using Sextant.Mocks;
-using Splat;
 
 namespace Sextant.Tests
 {

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceFixture.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceFixture.cs
@@ -8,6 +8,9 @@ using System.Reactive;
 using System.Reactive.Linq;
 using NSubstitute;
 using ReactiveUI.Testing;
+using Sextant.Abstractions;
+using Sextant.Mocks;
+using Splat;
 
 namespace Sextant.Tests
 {
@@ -17,6 +20,7 @@ namespace Sextant.Tests
     internal class ParameterViewStackServiceFixture : IBuilder
     {
         private IView _view;
+        private IViewModelFactory _viewModelFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterViewStackServiceFixture"/> class.
@@ -27,6 +31,8 @@ namespace Sextant.Tests
             _view.PushPage(Arg.Any<INavigable>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
                 .Returns(Observable.Return(Unit.Default));
             _view.PopPage().Returns(Observable.Return(Unit.Default));
+            _viewModelFactory = Substitute.For<IViewModelFactory>();
+            _viewModelFactory.Create<NavigableViewModelMock>(Arg.Any<string>()).Returns(new NavigableViewModelMock());
         }
 
         public static implicit operator ParameterViewStackService(ParameterViewStackServiceFixture fixture) =>
@@ -50,6 +56,9 @@ namespace Sextant.Tests
             return stack;
         }
 
-        private ParameterViewStackService Build() => new ParameterViewStackService(_view);
+        public ParameterViewStackService WithFactory(IViewModelFactory viewModelFactory) =>
+            this.With(ref _viewModelFactory, viewModelFactory);
+
+        private ParameterViewStackService Build() => new ParameterViewStackService(_view, _viewModelFactory);
     }
 }

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -193,8 +193,6 @@ namespace Sextant.Tests
             public ThePushPageGenericWithParameterMethod()
             {
                 Locator.CurrentMutable.UnregisterAll<NavigableViewModelMock>();
-                Locator.CurrentMutable.UnregisterAll<IViewModelFactory>();
-                Locator.CurrentMutable.Register(() => new DefaultViewModelFactory(), typeof(IViewModelFactory));
                 Locator.CurrentMutable.Register(() => new NavigableViewModelMock());
             }
 
@@ -227,7 +225,6 @@ namespace Sextant.Tests
             public async Task Should_Throw_If_Parameter_Null()
             {
                 // Given
-                var viewModel = Substitute.For<INavigable>();
                 ParameterViewStackService sut = new ParameterViewStackServiceFixture();
 
                 // When
@@ -240,7 +237,9 @@ namespace Sextant.Tests
                 result.ParamName.ShouldBe("parameter");
             }
 
-            /// <summary>Tests to make sure we receive a push page notification.</summary>
+            /// <summary>
+            /// Tests to make sure we receive a push page notification.
+            /// </summary>
             /// <param name="contract">The contract.</param>
             /// <param name="reset">Reset the stack.</param>
             /// <param name="animate">Animate the navigation.</param>
@@ -264,6 +263,26 @@ namespace Sextant.Tests
 
                 // Then
                 await view.Received().PushPage(Arg.Any<NavigableViewModelMock>(), contract, reset, animate);
+            }
+
+            /// <summary>
+            /// Tests the view model factory is called.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
+            public async Task Should_Call_ViewModel_Factory()
+            {
+                // Given
+                var factory = Substitute.For<IViewModelFactory>();
+                factory.Create<NavigableViewModelMock>().Returns(new NavigableViewModelMock());
+                var navigationParameter = Substitute.For<INavigationParameter>();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithFactory(factory);
+
+                // When
+                await sut.PushPage<NavigableViewModelMock>(navigationParameter);
+
+                // Then
+                factory.Received().Create<NavigableViewModelMock>();
             }
         }
 
@@ -479,6 +498,26 @@ namespace Sextant.Tests
 
                 // Then
                 await view.Received().PushModal(Arg.Any<NavigableViewModelMock>(), contract, withNavigation);
+            }
+
+            /// <summary>
+            /// Tests the view model factory is called.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
+            public async Task Should_Call_ViewModel_Factory()
+            {
+                // Given
+                var factory = Substitute.For<IViewModelFactory>();
+                factory.Create<NavigableViewModelMock>().Returns(new NavigableViewModelMock());
+                var navigationParameter = Substitute.For<INavigationParameter>();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithFactory(factory);
+
+                // When
+                await sut.PushModal<NavigableViewModelMock>(navigationParameter);
+
+                // Then
+                factory.Received().Create<NavigableViewModelMock>();
             }
         }
 

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -4,15 +4,10 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Text;
 using System.Threading.Tasks;
 using NSubstitute;
-using ReactiveUI.Testing;
-using Sextant.Abstractions;
 using Sextant.Mocks;
 using Shouldly;
 using Splat;

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -503,21 +503,25 @@ namespace Sextant.Tests
             /// <summary>
             /// Tests the view model factory is called.
             /// </summary>
+            /// <param name="contract">The contract.</param>
             /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_ViewModel_Factory()
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            [InlineData("contract")]
+            public async Task Should_Call_ViewModel_Factory(string? contract)
             {
                 // Given
                 var factory = Substitute.For<IViewModelFactory>();
-                factory.Create<NavigableViewModelMock>().Returns(new NavigableViewModelMock());
+                factory.Create<NavigableViewModelMock>(Arg.Any<string?>()).Returns(new NavigableViewModelMock());
                 var navigationParameter = Substitute.For<INavigationParameter>();
                 ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithFactory(factory);
 
                 // When
-                await sut.PushModal<NavigableViewModelMock>(navigationParameter);
+                await sut.PushModal<NavigableViewModelMock>(navigationParameter, contract);
 
                 // Then
-                factory.Received().Create<NavigableViewModelMock>();
+                factory.Received().Create<NavigableViewModelMock>(contract);
             }
         }
 

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -26,6 +26,49 @@ namespace Sextant.Tests
     public sealed class ParameterViewStackServiceTests
     {
         /// <summary>
+        /// Tests the construction of the object.
+        /// </summary>
+        public class TheConstructor
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TheConstructor"/> class.
+            /// </summary>
+            public TheConstructor()
+            {
+                Locator.GetLocator().UnregisterAll<IViewModelFactory>();
+            }
+
+            /// <summary>
+            /// Test that the object constructed uses the static instance of ViewModelFactory.
+            /// </summary>
+            [Fact]
+            public void Should_Throw_If_View_Model_Factory_Current_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null));
+
+                // Then
+                result.ShouldBeOfType<ViewModelFactoryNotFoundException>();
+            }
+
+            /// <summary>
+            /// Test that the object constructed uses the static instance of ViewModelFactory.
+            /// </summary>
+            [Fact]
+            public void Should_Resolve_View_Model_Factory()
+            {
+                // Given
+                Locator.CurrentMutable.RegisterViewModelFactory();
+
+                // When
+                var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null));
+
+                // Then
+                result.ShouldBeNull();
+            }
+        }
+
+        /// <summary>
         /// Tests the push page method that passes parameters.
         /// </summary>
         public class ThePushPageWithParameterMethod

--- a/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
@@ -8,6 +8,8 @@ using System.Reactive;
 using System.Reactive.Linq;
 using NSubstitute;
 using ReactiveUI.Testing;
+using Sextant.Abstractions;
+using Sextant.Mocks;
 
 namespace Sextant.Tests
 {
@@ -17,6 +19,7 @@ namespace Sextant.Tests
     internal sealed class ViewStackServiceFixture : IBuilder
     {
         private IView _view;
+        private IViewModelFactory _viewModelFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewStackServiceFixture"/> class.
@@ -25,6 +28,8 @@ namespace Sextant.Tests
         {
             _view = Substitute.For<IView>();
             _view.PushPage(Arg.Any<IViewModel>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>()).Returns(Observable.Return(Unit.Default));
+            _viewModelFactory = Substitute.For<IViewModelFactory>();
+            _viewModelFactory.Create<NavigableViewModelMock>(Arg.Any<string>()).Returns(new NavigableViewModelMock());
         }
 
         public static implicit operator ViewStackService(ViewStackServiceFixture fixture) => fixture.Build();
@@ -39,6 +44,6 @@ namespace Sextant.Tests
             return stack;
         }
 
-        private ViewStackService Build() => new ViewStackService(_view);
+        private ViewStackService Build() => new ViewStackService(_view, _viewModelFactory);
     }
 }

--- a/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
@@ -36,13 +36,8 @@ namespace Sextant.Tests
 
         public ViewStackServiceFixture WithView(IView view) => this.With(ref _view, view);
 
-        public ViewStackService Push<TViewModel>(TViewModel viewModel)
-            where TViewModel : IViewModel
-        {
-            var stack = Build();
-            stack.PushPage(viewModel).Subscribe();
-            return stack;
-        }
+        public ViewStackServiceFixture WithFactory(IViewModelFactory viewModelFactory) =>
+            this.With(ref _viewModelFactory, viewModelFactory);
 
         private ViewStackService Build() => new ViewStackService(_view, _viewModelFactory);
     }

--- a/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
@@ -3,12 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Reactive;
 using System.Reactive.Linq;
 using NSubstitute;
 using ReactiveUI.Testing;
-using Sextant.Abstractions;
 using Sextant.Mocks;
 
 namespace Sextant.Tests

--- a/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
@@ -10,7 +10,6 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using NSubstitute;
-using Sextant.Abstractions;
 using Sextant.Mocks;
 using Shouldly;
 using Splat;

--- a/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
@@ -24,6 +24,49 @@ namespace Sextant.Tests
     public sealed class ViewStackServiceTests
     {
         /// <summary>
+        /// Tests the construction of the object.
+        /// </summary>
+        public class TheConstructor
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TheConstructor"/> class.
+            /// </summary>
+            public TheConstructor()
+            {
+                Locator.GetLocator().UnregisterAll<IViewModelFactory>();
+            }
+
+            /// <summary>
+            /// Test that the object constructed uses the static instance of ViewModelFactory.
+            /// </summary>
+            [Fact]
+            public void Should_Throw_If_View_Model_Factory_Current_Null()
+            {
+                // Given, When
+                var result = Record.Exception(() => (ViewStackService)new ViewStackServiceFixture().WithFactory(null));
+
+                // Then
+                result.ShouldBeOfType<ViewModelFactoryNotFoundException>();
+            }
+
+            /// <summary>
+            /// Test that the object constructed uses the static instance of ViewModelFactory.
+            /// </summary>
+            [Fact]
+            public void Should_Resolve_View_Model_Factory()
+            {
+                // Given
+                Locator.CurrentMutable.RegisterViewModelFactory();
+
+                // When
+                var result = Record.Exception(() => (ViewStackService)new ViewStackServiceFixture().WithFactory(null));
+
+                // Then
+                result.ShouldBeNull();
+            }
+        }
+
+        /// <summary>
         /// Tests associated with the page stack property.
         /// </summary>
         public class ThePageStackProperty

--- a/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
@@ -625,6 +625,26 @@ namespace Sextant.Tests
                 // Then
                 await view.Received().PushModal(Arg.Any<NavigableViewModelMock>(), Arg.Any<string>(), Arg.Any<bool>());
             }
+
+            /// <summary>
+            /// Tests that the ViewModelFactory is called.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
+            public async Task Should_Call_ViewModel_Factory()
+            {
+                // Given
+                var factory = Substitute.For<IViewModelFactory>();
+                factory.Create<NavigableViewModelMock>(Arg.Any<string?>()).Returns(new NavigableViewModelMock());
+                var navigationParameter = Substitute.For<INavigationParameter>();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithFactory(factory);
+
+                // When
+                await sut.PushModal<NavigableViewModelMock>(navigationParameter);
+
+                // Then
+                factory.Received().Create<NavigableViewModelMock>();
+            }
         }
 
         /// <summary>
@@ -774,6 +794,26 @@ namespace Sextant.Tests
 
                 // Then
                 await view.Received().PushPage(Arg.Any<NavigableViewModelMock>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>());
+            }
+
+            /// <summary>
+            /// Tests the view model factory is called.
+            /// </summary>
+            /// <returns>A completion notification.</returns>
+            [Fact]
+            public async Task Should_Call_ViewModel_Factory()
+            {
+                // Given
+                var factory = Substitute.For<IViewModelFactory>();
+                factory.Create<NavigableViewModelMock>(Arg.Any<string?>()).Returns(new NavigableViewModelMock());
+                var navigationParameter = Substitute.For<INavigationParameter>();
+                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithFactory(factory);
+
+                // When
+                await sut.PushPage<NavigableViewModelMock>(navigationParameter);
+
+                // Then
+                factory.Received().Create<NavigableViewModelMock>();
             }
         }
 

--- a/src/Sextant.Tests/Sextant.Tests.csproj
+++ b/src/Sextant.Tests/Sextant.Tests.csproj
@@ -5,7 +5,11 @@
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA1034;CA2000</NoWarn>
     <IsPackable>false</IsPackable>    
   </PropertyGroup>
-  
+
+  <ItemGroup>
+    <Content Include="..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Sextant.Mocks\Sextant.Mocks.csproj" />
     <ProjectReference Include="..\Sextant\Sextant.csproj" />

--- a/src/Sextant.Tests/Sextant.Tests.csproj
+++ b/src/Sextant.Tests/Sextant.Tests.csproj
@@ -3,7 +3,8 @@
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net472</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA1034;CA2000</NoWarn>
-    <IsPackable>false</IsPackable>    
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sextant.Tests/ViewModelFactoryTests.cs
+++ b/src/Sextant.Tests/ViewModelFactoryTests.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Sextant.Abstractions;
 using Shouldly;
 using Splat;
 using Xunit;

--- a/src/Sextant.XamForms.Tests/API/ApiApprovalTests.cs
+++ b/src/Sextant.XamForms.Tests/API/ApiApprovalTests.cs
@@ -4,13 +4,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using PublicApiGenerator;
 using Shouldly;

--- a/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
+++ b/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
@@ -3,14 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using NSubstitute;
 using ReactiveUI;
-using Sextant.Abstractions;
 using Sextant.Mocks;
-using Sextant.XamForms;
 using Shouldly;
 using Splat;
 using Xamarin.Forms;

--- a/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
+++ b/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
@@ -72,6 +72,7 @@ namespace Sextant.XamForms.Tests
             public void Should_Register_Navigation_View()
             {
                 // Given
+                Locator.CurrentMutable.RegisterViewModelFactory();
                 Locator.CurrentMutable.RegisterNavigationView(() => new NavigationView(RxApp.MainThreadScheduler, RxApp.TaskpoolScheduler, ViewLocator.Current));
 
                 // When
@@ -105,6 +106,7 @@ namespace Sextant.XamForms.Tests
             {
                 // Given
                 Locator.CurrentMutable.RegisterNavigationView();
+                Locator.CurrentMutable.RegisterViewModelFactory();
                 Locator.CurrentMutable.RegisterViewStackService();
 
                 // When
@@ -121,14 +123,16 @@ namespace Sextant.XamForms.Tests
             public void Should_Register_View_Stack_Service_Factory()
             {
                 // Given
+                var viewModelFactory = new DefaultViewModelFactory();
                 Locator.CurrentMutable.RegisterNavigationView();
-                Locator.CurrentMutable.RegisterViewStackService<IViewStackService>(view => new ParameterViewStackService(view));
+                Locator.CurrentMutable.RegisterViewModelFactory(() => viewModelFactory);
+                Locator.CurrentMutable.RegisterViewStackService<IViewStackService>((view) => new ParameterViewStackService(view, viewModelFactory));
 
                 // When
-                var result = Locator.Current.GetService<IViewStackService>();
+                var result = ViewModelFactory.Current;
 
                 // Then
-                result.ShouldBeOfType<ParameterViewStackService>();
+                result.ShouldBe(viewModelFactory);
             }
         }
 

--- a/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
+++ b/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Text;
 using NSubstitute;
 using ReactiveUI;
+using Sextant.Abstractions;
 using Sextant.Mocks;
 using Sextant.XamForms;
 using Shouldly;
@@ -95,6 +96,7 @@ namespace Sextant.XamForms.Tests
             {
                 Locator.CurrentMutable.UnregisterAll<IView>();
                 Locator.CurrentMutable.UnregisterAll<IViewStackService>();
+                Locator.CurrentMutable.UnregisterAll<IViewModelFactory>();
                 Locator.CurrentMutable.UnregisterAll<IParameterViewStackService>();
             }
 
@@ -117,22 +119,39 @@ namespace Sextant.XamForms.Tests
             }
 
             /// <summary>
-            /// Should register the view stack service factory.
+            /// Tests the view stack service overload.
             /// </summary>
             [Fact]
-            public void Should_Register_View_Stack_Service_Factory()
+            public void Should_Register_View_Stack_Service_With_View()
             {
                 // Given
-                var viewModelFactory = new DefaultViewModelFactory();
                 Locator.CurrentMutable.RegisterNavigationView();
-                Locator.CurrentMutable.RegisterViewModelFactory(() => viewModelFactory);
-                _ = Locator.CurrentMutable.RegisterViewStackService<IViewStackService>((view, factory) => new ParameterViewStackService(view, factory));
+                Locator.CurrentMutable.RegisterViewModelFactory();
+                Locator.CurrentMutable.RegisterViewStackService<IViewStackService>(view => new ParameterViewStackService(view));
 
                 // When
-                var result = ViewModelFactory.Current;
+                var result = Locator.Current.GetService<IViewStackService>();
 
                 // Then
-                result.ShouldBe(viewModelFactory);
+                result.ShouldBeOfType<ParameterViewStackService>();
+            }
+
+            /// <summary>
+            /// Tests the view stack service overload.
+            /// </summary>
+            [Fact]
+            public void Should_Register_View_Stack_Service_With_Factory()
+            {
+                // Given
+                Locator.CurrentMutable.RegisterNavigationView();
+                Locator.CurrentMutable.RegisterViewModelFactory();
+                Locator.CurrentMutable.RegisterViewStackService<IViewStackService>((view, factory) => new ParameterViewStackService(view, factory));
+
+                // When
+                var result = Locator.Current.GetService<IViewStackService>();
+
+                // Then
+                result.ShouldBeOfType<ParameterViewStackService>();
             }
         }
 

--- a/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
+++ b/src/Sextant.XamForms.Tests/DependencyResolverMixinTests.cs
@@ -126,7 +126,7 @@ namespace Sextant.XamForms.Tests
                 var viewModelFactory = new DefaultViewModelFactory();
                 Locator.CurrentMutable.RegisterNavigationView();
                 Locator.CurrentMutable.RegisterViewModelFactory(() => viewModelFactory);
-                Locator.CurrentMutable.RegisterViewStackService<IViewStackService>((view) => new ParameterViewStackService(view, viewModelFactory));
+                _ = Locator.CurrentMutable.RegisterViewStackService<IViewStackService>((view, factory) => new ParameterViewStackService(view, factory));
 
                 // When
                 var result = ViewModelFactory.Current;

--- a/src/Sextant.XamForms.Tests/Sextant.XamForms.Tests.csproj
+++ b/src/Sextant.XamForms.Tests/Sextant.XamForms.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Sextant.Mocks\Sextant.Mocks.csproj" />
     <ProjectReference Include="..\Sextant.XamForms\Sextant.XamForms.csproj" />
     <ProjectReference Include="..\Sextant\Sextant.csproj" />

--- a/src/Sextant.XamForms.Tests/SextantExtensionTests.cs
+++ b/src/Sextant.XamForms.Tests/SextantExtensionTests.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Sextant.Abstractions;
-using Sextant.XamForms;
 using Shouldly;
 using Splat;
 using Xunit;

--- a/src/Sextant/Abstractions/IViewModelFactory.cs
+++ b/src/Sextant/Abstractions/IViewModelFactory.cs
@@ -3,7 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Sextant.Abstractions
+namespace Sextant
 {
     /// <summary>
     /// Interface that represents a view model factory.

--- a/src/Sextant/DefaultViewModelFactory.cs
+++ b/src/Sextant/DefaultViewModelFactory.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Sextant.Abstractions;
 using Splat;
 
 namespace Sextant

--- a/src/Sextant/DependencyResolverMixins.cs
+++ b/src/Sextant/DependencyResolverMixins.cs
@@ -42,7 +42,8 @@ namespace Sextant
             }
 
             IView view = Locator.Current.GetService<IView>(NavigationView);
-            dependencyResolver.RegisterLazySingleton<IViewStackService>(() => new ParameterViewStackService(view));
+            IViewModelFactory viewModelFactory = Locator.Current.GetService<IViewModelFactory>(NavigationView);
+            dependencyResolver.RegisterLazySingleton<IViewStackService>(() => new ParameterViewStackService(view, viewModelFactory));
             return dependencyResolver;
         }
 
@@ -59,7 +60,8 @@ namespace Sextant
             }
 
             IView view = Locator.Current.GetService<IView>(NavigationView);
-            dependencyResolver.RegisterLazySingleton<IParameterViewStackService>(() => new ParameterViewStackService(view));
+            IViewModelFactory viewModelFactory = Locator.Current.GetService<IViewModelFactory>(NavigationView);
+            dependencyResolver.RegisterLazySingleton<IParameterViewStackService>(() => new ParameterViewStackService(view, viewModelFactory));
             return dependencyResolver;
         }
 
@@ -70,6 +72,7 @@ namespace Sextant
         /// <param name="dependencyResolver">The dependency resolver.</param>
         /// <param name="factory">The factory.</param>
         /// <returns>The dependencyResolver.</returns>
+        [Obsolete("Use the Func<IView, IViewModelFactory, T> variant.")]
         public static IMutableDependencyResolver RegisterViewStackService<T>(this IMutableDependencyResolver dependencyResolver, Func<IView, T> factory)
             where T : IViewStackService
         {
@@ -85,6 +88,48 @@ namespace Sextant
 
             IView view = Locator.Current.GetService<IView>(NavigationView);
             dependencyResolver.RegisterLazySingleton(() => factory(view));
+            return dependencyResolver;
+        }
+
+        /// <summary>
+        /// Registers the view stack service.
+        /// </summary>
+        /// <typeparam name="T">The view stack service type.</typeparam>
+        /// <param name="dependencyResolver">The dependency resolver.</param>
+        /// <param name="factory">The factory.</param>
+        /// <returns>The dependencyResolver.</returns>
+        public static IMutableDependencyResolver RegisterViewStackService<T>(this IMutableDependencyResolver dependencyResolver, Func<IView, IViewModelFactory, T> factory)
+            where T : IViewStackService
+        {
+            if (dependencyResolver is null)
+            {
+                throw new ArgumentNullException(nameof(dependencyResolver));
+            }
+
+            if (factory is null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            IView view = Locator.Current.GetService<IView>(NavigationView);
+            IViewModelFactory viewModelFactory = Locator.Current.GetService<IViewModelFactory>(NavigationView);
+            dependencyResolver.RegisterLazySingleton(() => factory(view, viewModelFactory));
+            return dependencyResolver;
+        }
+
+        /// <summary>
+        /// Registers the view model factory.
+        /// </summary>
+        /// <param name="dependencyResolver">The dependency resolver.</param>
+        /// <returns>The dependencyResolver.</returns>
+        public static IMutableDependencyResolver RegisterViewModelFactory(this IMutableDependencyResolver dependencyResolver)
+        {
+            if (dependencyResolver is null)
+            {
+                throw new ArgumentNullException(nameof(dependencyResolver));
+            }
+
+            dependencyResolver.RegisterLazySingleton<IViewModelFactory>(() => new DefaultViewModelFactory());
             return dependencyResolver;
         }
 

--- a/src/Sextant/DependencyResolverMixins.cs
+++ b/src/Sextant/DependencyResolverMixins.cs
@@ -4,12 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive.Concurrency;
-using System.Text;
 using ReactiveUI;
-using Sextant.Abstractions;
 using Splat;
 
 namespace Sextant

--- a/src/Sextant/DependencyResolverMixins.cs
+++ b/src/Sextant/DependencyResolverMixins.cs
@@ -42,7 +42,7 @@ namespace Sextant
             }
 
             IView view = Locator.Current.GetService<IView>(NavigationView);
-            IViewModelFactory viewModelFactory = Locator.Current.GetService<IViewModelFactory>(NavigationView);
+            IViewModelFactory viewModelFactory = Locator.Current.GetService<IViewModelFactory>();
             dependencyResolver.RegisterLazySingleton<IViewStackService>(() => new ParameterViewStackService(view, viewModelFactory));
             return dependencyResolver;
         }
@@ -60,7 +60,7 @@ namespace Sextant
             }
 
             IView view = Locator.Current.GetService<IView>(NavigationView);
-            IViewModelFactory viewModelFactory = Locator.Current.GetService<IViewModelFactory>(NavigationView);
+            IViewModelFactory viewModelFactory = Locator.Current.GetService<IViewModelFactory>();
             dependencyResolver.RegisterLazySingleton<IParameterViewStackService>(() => new ParameterViewStackService(view, viewModelFactory));
             return dependencyResolver;
         }
@@ -87,7 +87,7 @@ namespace Sextant
             }
 
             IView view = Locator.Current.GetService<IView>(NavigationView);
-            dependencyResolver.RegisterLazySingleton(() => factory(view));
+            dependencyResolver.RegisterLazySingleton<T>(() => factory(view));
             return dependencyResolver;
         }
 
@@ -112,8 +112,8 @@ namespace Sextant
             }
 
             IView view = Locator.Current.GetService<IView>(NavigationView);
-            IViewModelFactory viewModelFactory = Locator.Current.GetService<IViewModelFactory>(NavigationView);
-            dependencyResolver.RegisterLazySingleton(() => factory(view, viewModelFactory));
+            IViewModelFactory viewModelFactory = Locator.Current.GetService<IViewModelFactory>();
+            dependencyResolver.RegisterLazySingleton<T>(() => factory(view, viewModelFactory));
             return dependencyResolver;
         }
 

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -112,7 +112,7 @@ namespace Sextant
         public IObservable<Unit> PushPage<TViewModel>(INavigationParameter parameter, string? contract = null, bool resetStack = false, bool animate = true)
             where TViewModel : INavigable
         {
-            var viewModel = Factory.Create<TViewModel>(contract);
+            TViewModel viewModel = Factory.Create<TViewModel>(contract);
             return PushPage(viewModel, parameter, contract, resetStack, animate);
         }
 
@@ -120,7 +120,7 @@ namespace Sextant
         public IObservable<Unit> PushModal<TViewModel>(INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
             where TViewModel : INavigable
         {
-            var viewModel = Factory.Create<TViewModel>(contract);
+            TViewModel viewModel = Factory.Create<TViewModel>(contract);
             return PushModal(viewModel, parameter, contract, withNavigationPage);
         }
 

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Reactive;
 using System.Reactive.Linq;
+using Sextant.Abstractions;
 
 namespace Sextant
 {
@@ -21,7 +22,17 @@ namespace Sextant
         /// </summary>
         /// <param name="view">The view.</param>
         public ParameterViewStackService(IView view)
-            : base(view)
+            : this(view, null!)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterViewStackService"/> class.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="viewModelFactory">The view model factory.</param>
+        public ParameterViewStackService(IView view, IViewModelFactory viewModelFactory)
+            : base(view, viewModelFactory)
         {
         }
 
@@ -101,7 +112,7 @@ namespace Sextant
         public IObservable<Unit> PushPage<TViewModel>(INavigationParameter parameter, string? contract = null, bool resetStack = false, bool animate = true)
             where TViewModel : INavigable
         {
-            var viewModel = ViewModelFactory.Current.Create<TViewModel>();
+            var viewModel = Factory.Create<TViewModel>(contract);
             return PushPage(viewModel, parameter, contract, resetStack, animate);
         }
 
@@ -109,7 +120,7 @@ namespace Sextant
         public IObservable<Unit> PushModal<TViewModel>(INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
             where TViewModel : INavigable
         {
-            var viewModel = ViewModelFactory.Current.Create<TViewModel>();
+            var viewModel = Factory.Create<TViewModel>(contract);
             return PushModal(viewModel, parameter, contract, withNavigationPage);
         }
 

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Reactive;
 using System.Reactive.Linq;
-using Sextant.Abstractions;
 
 namespace Sextant
 {

--- a/src/Sextant/Navigation/ViewStackService.cs
+++ b/src/Sextant/Navigation/ViewStackService.cs
@@ -3,8 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Sextant.Abstractions;
-
 namespace Sextant
 {
     /// <summary>

--- a/src/Sextant/Navigation/ViewStackService.cs
+++ b/src/Sextant/Navigation/ViewStackService.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Sextant.Abstractions;
+
 namespace Sextant
 {
     /// <summary>
@@ -17,7 +19,17 @@ namespace Sextant
         /// </summary>
         /// <param name="view">The view.</param>
         public ViewStackService(IView view)
-            : base(view)
+            : this(view, null!)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViewStackService"/> class.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="viewModelFactory">The view model factory.</param>
+        public ViewStackService(IView view, IViewModelFactory viewModelFactory)
+            : base(view, viewModelFactory)
         {
         }
     }

--- a/src/Sextant/Navigation/ViewStackServiceBase.cs
+++ b/src/Sextant/Navigation/ViewStackServiceBase.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using Sextant.Abstractions;
 using Splat;
 
 namespace Sextant
@@ -26,10 +27,12 @@ namespace Sextant
         /// Initializes a new instance of the <see cref="ViewStackServiceBase"/> class.
         /// </summary>
         /// <param name="view">The view.</param>
-        protected ViewStackServiceBase(IView view)
+        /// <param name="viewModelFactory">The view model factory.</param>
+        protected ViewStackServiceBase(IView view, IViewModelFactory viewModelFactory)
         {
             Logger = this.Log();
             View = view ?? throw new ArgumentNullException(nameof(view));
+            Factory = viewModelFactory ?? ViewModelFactory.Current ?? throw new ArgumentNullException(nameof(viewModelFactory));
             ModalSubject = new BehaviorSubject<IImmutableList<IViewModel>>(ImmutableList<IViewModel>.Empty);
             PageSubject = new BehaviorSubject<IImmutableList<IViewModel>>(ImmutableList<IViewModel>.Empty);
 
@@ -65,6 +68,11 @@ namespace Sextant
         /// Gets the logger.
         /// </summary>
         protected IFullLogger Logger { get; private set; }
+
+        /// <summary>
+        /// Gets the view model factory.
+        /// </summary>
+        protected IViewModelFactory Factory { get; }
 
         /// <summary>
         /// Gets the modal subject.
@@ -125,7 +133,7 @@ namespace Sextant
         public IObservable<Unit> PushModal<TViewModel>(string? contract = null, bool withNavigationPage = true)
             where TViewModel : IViewModel
         {
-            var viewmodel = ViewModelFactory.Current.Create<TViewModel>(contract);
+            var viewmodel = Factory.Create<TViewModel>(contract);
             return PushModal(viewmodel, contract, withNavigationPage);
         }
 
@@ -133,7 +141,7 @@ namespace Sextant
         public IObservable<Unit> PushPage<TViewModel>(string? contract = null, bool resetStack = false, bool animate = true)
             where TViewModel : IViewModel
         {
-            TViewModel viewModel = ViewModelFactory.Current.Create<TViewModel>();
+            TViewModel viewModel = Factory.Create<TViewModel>(contract);
 
             return PushPage(viewModel, contract, resetStack, animate);
         }

--- a/src/Sextant/Navigation/ViewStackServiceBase.cs
+++ b/src/Sextant/Navigation/ViewStackServiceBase.cs
@@ -133,7 +133,7 @@ namespace Sextant
         public IObservable<Unit> PushModal<TViewModel>(string? contract = null, bool withNavigationPage = true)
             where TViewModel : IViewModel
         {
-            var viewmodel = Factory.Create<TViewModel>(contract);
+            TViewModel viewmodel = Factory.Create<TViewModel>(contract);
             return PushModal(viewmodel, contract, withNavigationPage);
         }
 

--- a/src/Sextant/Navigation/ViewStackServiceBase.cs
+++ b/src/Sextant/Navigation/ViewStackServiceBase.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using Sextant.Abstractions;
 using Splat;
 
 namespace Sextant

--- a/src/Sextant/Navigation/ViewStackServiceBase.cs
+++ b/src/Sextant/Navigation/ViewStackServiceBase.cs
@@ -32,7 +32,7 @@ namespace Sextant
         {
             Logger = this.Log();
             View = view ?? throw new ArgumentNullException(nameof(view));
-            Factory = viewModelFactory ?? ViewModelFactory.Current ?? throw new ArgumentNullException(nameof(viewModelFactory));
+            Factory = viewModelFactory ?? ViewModelFactory.Current;
             ModalSubject = new BehaviorSubject<IImmutableList<IViewModel>>(ImmutableList<IViewModel>.Empty);
             PageSubject = new BehaviorSubject<IImmutableList<IViewModel>>(ImmutableList<IViewModel>.Empty);
 

--- a/src/Sextant/Platforms/netstandard2.0/SextantExtensions.cs
+++ b/src/Sextant/Platforms/netstandard2.0/SextantExtensions.cs
@@ -4,10 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Reactive.Concurrency;
-using System.Text;
-using Splat;
 
 namespace Sextant
 {

--- a/src/Sextant/Platforms/uap/NavigationView.xaml.cs
+++ b/src/Sextant/Platforms/uap/NavigationView.xaml.cs
@@ -115,7 +115,7 @@ namespace Sextant
                     // But we want the view that was just removed.  We need to send the old view's viewmodel to IViewStackService so that the ViewModel can be removed from the stack.
                     return _lastPoppedViewModel;
                 })
-                .WhereNotNull();
+                .Where(x => x != null);
 
             BackRequested.Subscribe();
         }
@@ -167,7 +167,7 @@ namespace Sextant
                         ev.Handled = true;
                     }
                 })
-                .ToSignal(),
+                .Select(_ => Unit.Default),
             Observable
                 .FromEvent<PointerEventHandler, PointerRoutedEventArgs>(
                 handler => (_, e) => handler(e),
@@ -182,7 +182,7 @@ namespace Sextant
                         args.Handled = true;
                     }
                 })
-                .ToSignal(),
+                .Select(_ => Unit.Default),
             Observable
                 .FromEvent<RoutedEventHandler, RoutedEventArgs>(
                 handler =>
@@ -199,7 +199,7 @@ namespace Sextant
                         PopPage(true);
                     }
                 })
-                .ToSignal());
+                .Select(_ => Unit.Default));
 
         /// <inheritdoc />
         public IObservable<Unit> PopModal()

--- a/src/Sextant/Sextant.cs
+++ b/src/Sextant/Sextant.cs
@@ -4,9 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Splat;
 
 namespace Sextant

--- a/src/Sextant/System/Reactive/Linq/SubscribeSafeExtensions.cs
+++ b/src/Sextant/System/Reactive/Linq/SubscribeSafeExtensions.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Splat;

--- a/src/Sextant/ViewModelFactory.cs
+++ b/src/Sextant/ViewModelFactory.cs
@@ -3,11 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
-using Sextant.Abstractions;
 using Splat;
 
 namespace Sextant

--- a/src/Sextant/ViewModelFactoryNotFoundException.cs
+++ b/src/Sextant/ViewModelFactoryNotFoundException.cs
@@ -4,11 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.Serialization;
-using System.Text;
-using Sextant.Abstractions;
-using Splat;
 
 namespace Sextant
 {

--- a/src/xunit.runner.json
+++ b/src/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "parallelizeTestCollections": false
+}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fixes issues with contracts not being passed through for ViewModel location.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Resolves #230 

**What is the new behavior?**
<!-- If this is a feature change -->

ViewModel Contracts are now passed all the way through for resolution.

**What might this PR break?**

potentially consumers registering `ViewStackService` themselves as I changed the implementation to take a dependency on the `IViewModelFactory` for testability.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

