### PR TITLE
housekeeping: Fix CodeCov Paths

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -56,22 +56,15 @@ jobs:
         no-build: true
         exclude-filter: '[${{env.productNamespacePrefix}}*Tests.*]*'
         include-filter: '[${{env.productNamespacePrefix}}*]*'
-        output-format: opencover
-        merge-with: '../../artifacts/coverage/coverage.json'
-        output: '../../artifacts/coverage/'
+        output-format: cobertura
+        output: '../../artifacts/'
         configuration: ${{ env.configuration }}
 
-    - name: Combine Coverage Reports
+    - name: Upload Code Coverage
       shell: bash
       run: |
-        dotnet tool install --global dotnet-reportgenerator-globaltool
-        reportgenerator -reports:artifacts/coverage/*.xml -targetdir:artifacts/finalcoverage  -reporttypes:Cobertura
-
-    - name: Upload Code Coverage
-      run: |
-        npm install -g codecov
-        codecov
-      working-directory: artifacts/finalcoverage
+        echo $PWD
+        bash <(curl -s https://codecov.io/bash) -X gcov -X coveragepy -t ${{ env.CODECOV_TOKEN }} -s '$PWD/artifacts' -f '*.xml'
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,21 +27,16 @@ jobs:
       with:
         dotnet-version: 3.1.x
 
-    - name: Use Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-
-    - name: NuGet restore
-      run: dotnet restore
-      working-directory: src
-
     - name: NBGV
       id: nbgv
       uses: dotnet/nbgv@master
       with:
         setAllVars: true
 
+    - name: NuGet Restore
+      run: dotnet restore
+      working-directory: src
+      
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1
 
@@ -54,7 +49,7 @@ jobs:
       with:
         project-files: '**/*Tests*.csproj'
         no-build: true
-        exclude-filter: '[${{env.productNamespacePrefix}}*Tests.*]*'
+        exclude-filter: '[${{env.productNamespacePrefix}}.*.Tests.*]*'
         include-filter: '[${{env.productNamespacePrefix}}*]*'
         output-format: cobertura
         output: '../../artifacts/'


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR should fix the broken `codecov` paths. Based on the changes introduced in https://github.com/reactiveui/ReactiveUI.Validation/pull/156

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, the paths are broken, and this results into the following error displayed in `codecov` web interface:

<img src="https://user-images.githubusercontent.com/6759207/97346044-fa1af400-189b-11eb-8ef9-a27782d23fdd.png" width="500" />

**What is the new behavior?**
<!-- If this is a feature change -->

Now, the paths should hopefully be fixed.