### PR TITLE
housekeeping: Remove more shouldly references

### DIFF
--- a/src/Sextant.iOS.Runner/NavigationViewControllerTests.cs
+++ b/src/Sextant.iOS.Runner/NavigationViewControllerTests.cs
@@ -4,7 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 
 namespace Sextant.IOS.Runner
@@ -29,7 +29,7 @@ namespace Sextant.IOS.Runner
             sut.PopPage();
 
             // Then
-            actual.ShouldBeTrue();
+            actual.Should().BeTrue();
         }
     }
 }

--- a/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
+++ b/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
@@ -139,7 +139,6 @@
     <PackageReference Include="xunit.runner.devices">
       <Version>2.5.25</Version>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version=" 4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sextant\Sextant.csproj">

--- a/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
+++ b/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
@@ -139,7 +139,7 @@
     <PackageReference Include="xunit.runner.devices">
       <Version>2.5.25</Version>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version=" 3.0.2" />
+    <PackageReference Include="Shouldly" Version=" 4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sextant\Sextant.csproj">

--- a/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
+++ b/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
@@ -139,6 +139,7 @@
     <PackageReference Include="xunit.runner.devices">
       <Version>2.5.25</Version>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sextant\Sextant.csproj">

--- a/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
+++ b/src/Sextant.iOS.Runner/Sextant.iOS.Runner.csproj
@@ -76,6 +76,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>


### PR DESCRIPTION
We've converted most of the other projects over to using FluentAssertions, just converting the iOS tests to also use FluentAssertions.