### PR TITLE
feature: add GetValue methods to INavigationParameter

### DIFF
--- a/src/Sextant.Tests/API/ApiApprovalTests.Sextant.net5.0.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.Sextant.net5.0.approved.txt
@@ -47,7 +47,11 @@ namespace Sextant
     {
         System.IObservable<System.Reactive.Unit> WhenNavigatingTo(Sextant.INavigationParameter parameter);
     }
-    public interface INavigationParameter : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable { }
+    public interface INavigationParameter : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    {
+        T GetValue<T>(string key);
+        bool TryGetValue<T>(string key, out T value);
+    }
     [System.Obsolete("Please use the IViewModel interface.")]
     public interface IPageViewModel : Sextant.IViewModel { }
     public interface IParameterViewStackService : Sextant.IViewStackService
@@ -100,6 +104,8 @@ namespace Sextant
     public class NavigationParameter : System.Collections.Generic.Dictionary<string, object>, Sextant.INavigationParameter, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
     {
         public NavigationParameter() { }
+        public T GetValue<T>(string key) { }
+        public bool TryGetValue<T>(string key, out T value) { }
     }
     public sealed class ParameterViewStackService : Sextant.ParameterViewStackServiceBase
     {

--- a/src/Sextant.Tests/API/ApiApprovalTests.Sextant.netcoreapp3.1.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.Sextant.netcoreapp3.1.approved.txt
@@ -47,7 +47,11 @@ namespace Sextant
     {
         System.IObservable<System.Reactive.Unit> WhenNavigatingTo(Sextant.INavigationParameter parameter);
     }
-    public interface INavigationParameter : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable { }
+    public interface INavigationParameter : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    {
+        T GetValue<T>(string key);
+        bool TryGetValue<T>(string key, out T value);
+    }
     [System.Obsolete("Please use the IViewModel interface.")]
     public interface IPageViewModel : Sextant.IViewModel { }
     public interface IParameterViewStackService : Sextant.IViewStackService
@@ -100,6 +104,8 @@ namespace Sextant
     public class NavigationParameter : System.Collections.Generic.Dictionary<string, object>, Sextant.INavigationParameter, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
     {
         public NavigationParameter() { }
+        public T GetValue<T>(string key) { }
+        public bool TryGetValue<T>(string key, out T value) { }
     }
     public sealed class ParameterViewStackService : Sextant.ParameterViewStackServiceBase
     {

--- a/src/Sextant.Tests/Navigation/NavigationParameterTests.cs
+++ b/src/Sextant.Tests/Navigation/NavigationParameterTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Sextant.Tests
+{
+    /// <summary>
+    /// Tests <see cref="NavigationParameter"/> and extensions.
+    /// </summary>
+    public class NavigationParameterTests
+    {
+        /// <summary>
+        /// Tests the method gets a value.
+        /// </summary>
+        [Fact]
+        public void Should_Get_Value()
+        {
+            // Given
+            NavigationParameter sut = new();
+            sut.Add("key", TimeSpan.Zero);
+
+            // When
+            var result = sut.GetValue<TimeSpan>("key");
+
+            // Then
+            result
+                .Should()
+                .Be(TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// Tests the method tries to gets a value.
+        /// </summary>
+        [Fact]
+        public void Should_Try_Get_Value()
+        {
+            // Given
+            NavigationParameter sut = new();
+            sut.Add("key", TimeSpan.Zero);
+
+            // When
+            var result = sut.TryGetValue<TimeSpan>("key", out var value);
+
+            // Then
+            result
+                .Should()
+                .BeTrue();
+        }
+    }
+}

--- a/src/Sextant/Abstractions/INavigationParameter.cs
+++ b/src/Sextant/Abstractions/INavigationParameter.cs
@@ -12,5 +12,21 @@ namespace Sextant
     /// </summary>
     public interface INavigationParameter : IDictionary<string, object>
     {
+        /// <summary>
+        /// Gets the value from the navigation parameter.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <typeparam name="T">The type parameter.</typeparam>
+        /// <returns>The value.</returns>
+        T GetValue<T>(string key);
+
+        /// <summary>
+        /// Gets the value from the navigation parameter with the specified key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <typeparam name="T">The type of the parameter.</typeparam>
+        /// <returns>A value indicating whether the value exists.</returns>
+        bool TryGetValue<T>(string key, out T value);
     }
 }

--- a/src/Sextant/Navigation/NavigationParameter.cs
+++ b/src/Sextant/Navigation/NavigationParameter.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Sextant
 {
@@ -17,5 +18,28 @@ namespace Sextant
     [SuppressMessage("Design", "CA2237: Mark ISerializable types with SerializableAttribute.", Justification = "Deliberate usage")]
     public class NavigationParameter : Dictionary<string, object>, INavigationParameter
     {
+        /// <inheritdoc />
+        public T GetValue<T>(string key)
+        {
+            if (TryGetValue(key, out var result))
+            {
+                return (T)result;
+            }
+
+            return default!;
+        }
+
+        /// <inheritdoc />
+        public bool TryGetValue<T>(string key, out T value)
+        {
+            if (TryGetValue(key, out var result))
+            {
+                value = (T)result;
+                return true;
+            }
+
+            value = default!;
+            return false;
+        }
     }
 }


### PR DESCRIPTION

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Adds genetic value methods for getting parameters.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

You have to cast them yourself.

**What is the new behavior?**
<!-- If this is a feature change -->

use a generic `Get` or `TryGet`

**What might this PR break?**

navigation parameters

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

