### PR TITLE
fix: ParameterViewStackService passing null on construction

### DIFF
--- a/src/Sextant.Tests/API/ApiApprovalTests.Sextant.net5.0.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.Sextant.net5.0.approved.txt
@@ -153,11 +153,11 @@ namespace Sextant
     public sealed class ViewStackService : Sextant.ViewStackServiceBase
     {
         public ViewStackService(Sextant.IView view) { }
-        public ViewStackService(Sextant.IView view, Sextant.IViewModelFactory? viewModelFactory) { }
+        public ViewStackService(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
     }
     public abstract class ViewStackServiceBase : Sextant.IViewStackService, Splat.IEnableLogger, System.IDisposable
     {
-        protected ViewStackServiceBase(Sextant.IView view, Sextant.IViewModelFactory? viewModelFactory) { }
+        protected ViewStackServiceBase(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
         protected Sextant.IViewModelFactory Factory { get; }
         protected Splat.IFullLogger Logger { get; }
         public System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }

--- a/src/Sextant.Tests/API/ApiApprovalTests.Sextant.netcoreapp3.1.approved.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.Sextant.netcoreapp3.1.approved.txt
@@ -153,11 +153,11 @@ namespace Sextant
     public sealed class ViewStackService : Sextant.ViewStackServiceBase
     {
         public ViewStackService(Sextant.IView view) { }
-        public ViewStackService(Sextant.IView view, Sextant.IViewModelFactory? viewModelFactory) { }
+        public ViewStackService(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
     }
     public abstract class ViewStackServiceBase : Sextant.IViewStackService, Splat.IEnableLogger, System.IDisposable
     {
-        protected ViewStackServiceBase(Sextant.IView view, Sextant.IViewModelFactory? viewModelFactory) { }
+        protected ViewStackServiceBase(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
         protected Sextant.IViewModelFactory Factory { get; }
         protected Splat.IFullLogger Logger { get; }
         public System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -31,16 +31,16 @@ namespace Sextant.Tests
             public TheConstructor() => Locator.GetLocator().UnregisterAll<IViewModelFactory>();
 
             /// <summary>
-            /// Test that the object constructed uses the static instance of ViewModelFactory.
+            /// Test that the object constructed uses a new instance of ViewModelFactory.
             /// </summary>
             [Fact]
-            public void Should_Throw_If_View_Model_Factory_Current_Null()
+            public void Should_Not_Throw_If_View_Model_Factory_Current_Null()
             {
                 // Given, When
                 var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null!));
 
                 // Then
-                result.Should().BeOfType<ViewModelFactoryNotFoundException>();
+                result.Should().BeNull();
             }
 
             /// <summary>

--- a/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
@@ -33,16 +33,16 @@ namespace Sextant.Tests
             public TheConstructor() => Locator.GetLocator().UnregisterAll<IViewModelFactory>();
 
             /// <summary>
-            /// Test that the object constructed uses the static instance of ViewModelFactory.
+            /// Test that the object constructed uses a new instance of ViewModelFactory.
             /// </summary>
             [Fact]
-            public void Should_Throw_If_View_Model_Factory_Current_Null()
+            public void Should_Not_Throw_If_View_Model_Factory_Current_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => (ViewStackService)new ViewStackServiceFixture().WithFactory(null!));
+                var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null!));
 
                 // Then
-                result.Should().BeOfType<ViewModelFactoryNotFoundException>();
+                result.Should().BeNull();
             }
 
             /// <summary>

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -17,7 +17,7 @@ namespace Sextant
         /// </summary>
         /// <param name="view">The view.</param>
         public ParameterViewStackService(IView view)
-            : this(view, null!)
+            : this(view, new DefaultViewModelFactory())
         {
         }
 

--- a/src/Sextant/Navigation/ViewStackService.cs
+++ b/src/Sextant/Navigation/ViewStackService.cs
@@ -17,7 +17,7 @@ namespace Sextant
         /// </summary>
         /// <param name="view">The view.</param>
         public ViewStackService(IView view)
-            : this(view, null)
+            : this(view, new DefaultViewModelFactory())
         {
         }
 
@@ -26,7 +26,7 @@ namespace Sextant
         /// </summary>
         /// <param name="view">The view.</param>
         /// <param name="viewModelFactory">The view model factory.</param>
-        public ViewStackService(IView view, IViewModelFactory? viewModelFactory)
+        public ViewStackService(IView view, IViewModelFactory viewModelFactory)
             : base(view, viewModelFactory)
         {
         }

--- a/src/Sextant/Navigation/ViewStackServiceBase.cs
+++ b/src/Sextant/Navigation/ViewStackServiceBase.cs
@@ -28,11 +28,11 @@ namespace Sextant
         /// </summary>
         /// <param name="view">The view.</param>
         /// <param name="viewModelFactory">The view model factory.</param>
-        protected ViewStackServiceBase(IView view, IViewModelFactory? viewModelFactory)
+        protected ViewStackServiceBase(IView view, IViewModelFactory viewModelFactory)
         {
             Logger = this.Log();
             View = view ?? throw new ArgumentNullException(nameof(view));
-            Factory = viewModelFactory ?? ViewModelFactory.Current;
+            Factory = viewModelFactory;
             ModalSubject = new BehaviorSubject<IImmutableList<IViewModel>>(ImmutableList<IViewModel>.Empty);
             PageSubject = new BehaviorSubject<IImmutableList<IViewModel>>(ImmutableList<IViewModel>.Empty);
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fixes: #306 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

The base implementation is passing null expecting the value to come from registration.

**What is the new behavior?**
<!-- If this is a feature change -->

The constructor provides a new instance.

**What might this PR break?**


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

