### PR TITLE
Fix version conflicts caused by PR#448

### DIFF
--- a/Sample/SextantSample.Android/SextantSample.Android.csproj
+++ b/Sample/SextantSample.Android/SextantSample.Android.csproj
@@ -68,8 +68,8 @@
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="5.0.*" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.3.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.0" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.2.0.7" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />
     <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.8" />
     <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.4" />

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -33,7 +33,7 @@
     <PackageReference Include="ReactiveUI.Testing" Version="14.*" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bbuild(deps): bump coverlet.msbuild from 3.0.3 to 3.1.0 in /Sample. [(PR#448)](https://github.com/reactiveui/Sextant/pull/448).
Hope this fix can help you.

Best regards,
sucrose