### PR TITLE
Update copyright year and refactor code for .NET 9

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>11.1.3</AvaloniaVersion>
-    <ReactiveUIVersion>20.1.63</ReactiveUIVersion>
+    <AvaloniaVersion>11.3.5</AvaloniaVersion>
+    <ReactiveUIVersion>21.0.1</ReactiveUIVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
@@ -16,8 +16,8 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="DiffEngine" Version="16.2.3" />
     <PackageVersion Include="FluentAssertions" Version="8.6.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -30,6 +30,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <NoWarn>$(NoWarn);CA1510;IDE0130</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/Sextant.Avalonia/Navigation.cs
+++ b/src/Sextant.Avalonia/Navigation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -16,93 +16,92 @@ using DynamicData.Binding;
 
 using ReactiveUI;
 
-namespace Sextant.Avalonia
+namespace Sextant.Avalonia;
+
+/// <summary>
+/// A view used within navigation in Sextant with Avalonia.
+/// </summary>
+public sealed partial class NavigationView
 {
     /// <summary>
-    /// A view used within navigation in Sextant with Avalonia.
+    /// This class represents a single navigation layer.
     /// </summary>
-    public sealed partial class NavigationView
+    private class Navigation
     {
+        private readonly ObservableCollection<IViewFor> _navigationStack = new ObservableCollection<IViewFor>();
+        private readonly IPageTransition? _transition;
+
         /// <summary>
-        /// This class represents a single navigation layer.
+        /// Initializes a new instance of the <see cref="Navigation"/> class.
         /// </summary>
-        private class Navigation
+        public Navigation()
         {
-            private readonly ObservableCollection<IViewFor> _navigationStack = new ObservableCollection<IViewFor>();
-            private readonly IPageTransition? _transition;
+            var navigationStackObservable = _navigationStack
+                .ToObservableChangeSet()
+                .Publish()
+                .RefCount();
 
-            /// <summary>
-            /// Initializes a new instance of the <see cref="Navigation"/> class.
-            /// </summary>
-            public Navigation()
+            navigationStackObservable
+                .Select(_ => _navigationStack.LastOrDefault())
+                .Subscribe(page => Control.Content = page);
+
+            CountChanged = navigationStackObservable.Count().AsObservable();
+            _transition = Control.PageTransition;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the control is visible.
+        /// </summary>
+        public bool IsVisible => _navigationStack.Count > 1;
+
+        /// <summary>
+        /// Gets a the page count.
+        /// </summary>
+        public IObservable<int> CountChanged { get; }
+
+        /// <summary>
+        /// Gets the control responsible for rendering the current view.
+        /// </summary>
+        public TransitioningContentControl Control { get; } = new();
+
+        /// <summary>
+        /// Toggles the animations.
+        /// </summary>
+        /// <param name="enable">Returns true if we are enabling the animations.</param>
+        public void ToggleAnimations(bool enable) => Control.PageTransition = enable ? _transition : null;
+
+        /// <summary>
+        /// Adds a <see cref="IViewFor"/> to the navigation stack.
+        /// </summary>
+        /// <param name="view">The view to add to the navigation stack.</param>
+        /// <param name="resetStack">Defines if we should reset the navigation stack.</param>
+        public void Push(IViewFor view, bool resetStack = false)
+        {
+            if (resetStack)
             {
-                var navigationStackObservable = _navigationStack
-                    .ToObservableChangeSet()
-                    .Publish()
-                    .RefCount();
-
-                navigationStackObservable
-                    .Select(_ => _navigationStack.LastOrDefault())
-                    .Subscribe(page => Control.Content = page);
-
-                CountChanged = navigationStackObservable.Count().AsObservable();
-                _transition = Control.PageTransition;
-            }
-
-            /// <summary>
-            /// Gets a value indicating whether the control is visible.
-            /// </summary>
-            public bool IsVisible => _navigationStack.Count > 1;
-
-            /// <summary>
-            /// Gets a the page count.
-            /// </summary>
-            public IObservable<int> CountChanged { get; }
-
-            /// <summary>
-            /// Gets the control responsible for rendering the current view.
-            /// </summary>
-            public TransitioningContentControl Control { get; } = new();
-
-            /// <summary>
-            /// Toggles the animations.
-            /// </summary>
-            /// <param name="enable">Returns true if we are enabling the animations.</param>
-            public void ToggleAnimations(bool enable) => Control.PageTransition = enable ? _transition : null;
-
-            /// <summary>
-            /// Adds a <see cref="IViewFor"/> to the navigation stack.
-            /// </summary>
-            /// <param name="view">The view to add to the navigation stack.</param>
-            /// <param name="resetStack">Defines if we should reset the navigation stack.</param>
-            public void Push(IViewFor view, bool resetStack = false)
-            {
-                if (resetStack)
-                {
-                    _navigationStack.Clear();
-                }
-
-                _navigationStack.Add(view);
-            }
-
-            /// <summary>
-            /// Removes the last <see cref="IViewFor"/> from the navigation stack.
-            /// </summary>
-            public void Pop()
-            {
-                var indexToRemove = _navigationStack.Count - 1;
-                _navigationStack.RemoveAt(indexToRemove);
-            }
-
-            /// <summary>
-            /// Removes all pages except the first one <see cref="IViewFor"/> from the navigation stack.
-            /// </summary>
-            public void PopToRoot()
-            {
-                var view = _navigationStack[0];
                 _navigationStack.Clear();
-                _navigationStack.Add(view);
             }
+
+            _navigationStack.Add(view);
+        }
+
+        /// <summary>
+        /// Removes the last <see cref="IViewFor"/> from the navigation stack.
+        /// </summary>
+        public void Pop()
+        {
+            var indexToRemove = _navigationStack.Count - 1;
+            _navigationStack.RemoveAt(indexToRemove);
+        }
+
+        /// <summary>
+        /// Removes all pages except the first one <see cref="IViewFor"/> from the navigation stack.
+        /// </summary>
+        public void PopToRoot()
+        {
+            var view = _navigationStack[0];
+            _navigationStack.Clear();
+            _navigationStack.Add(view);
         }
     }
 }

--- a/src/Sextant.Avalonia/NavigationView.cs
+++ b/src/Sextant.Avalonia/NavigationView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -16,141 +16,140 @@ using Avalonia.Styling;
 
 using ReactiveUI;
 
-namespace Sextant.Avalonia
+namespace Sextant.Avalonia;
+
+/// <summary>
+/// The <see cref="IView"/> implementation for Avalonia.
+/// </summary>
+public sealed partial class NavigationView : ContentControl, IView
 {
+    private readonly Navigation _modalNavigation = new();
+    private readonly Navigation _pageNavigation = new();
+
     /// <summary>
-    /// The <see cref="IView"/> implementation for Avalonia.
+    /// Initializes a new instance of the <see cref="NavigationView"/> class.
     /// </summary>
-    public sealed partial class NavigationView : ContentControl, IView
+    public NavigationView()
     {
-        private readonly Navigation _modalNavigation = new();
-        private readonly Navigation _pageNavigation = new();
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NavigationView"/> class.
-        /// </summary>
-        public NavigationView()
+        MainThreadScheduler = RxApp.MainThreadScheduler;
+        ViewLocator = ReactiveUI.ViewLocator.Current;
+        Content = new Grid
         {
-            MainThreadScheduler = RxApp.MainThreadScheduler;
-            ViewLocator = ReactiveUI.ViewLocator.Current;
-            Content = new Grid
+            Children =
             {
-                Children =
+                new Grid
                 {
-                    new Grid
+                    ZIndex = 1,
+                    Children =
                     {
-                        ZIndex = 1,
-                        Children =
-                        {
-                            _pageNavigation.Control
-                        }
-                    },
-                    new Grid
-                    {
-                        ZIndex = 2,
-                        Children =
-                        {
-                            _modalNavigation.Control
-                        },
-                        [!Panel.BackgroundProperty] =
-                            _modalNavigation
-                                .CountChanged
-                                .Select(count => count > 0 ? new SolidColorBrush(Colors.Transparent) : null)
-                                .ToBinding()
+                        _pageNavigation.Control
                     }
+                },
+                new Grid
+                {
+                    ZIndex = 2,
+                    Children =
+                    {
+                        _modalNavigation.Control
+                    },
+                    [!Panel.BackgroundProperty] =
+                        _modalNavigation
+                            .CountChanged
+                            .Select(count => count > 0 ? new SolidColorBrush(Colors.Transparent) : null)
+                            .ToBinding()
                 }
-            };
-        }
-
-        /// <summary>
-        /// Gets or sets the scheduler used by the <see cref="NavigationView"/>.
-        /// </summary>
-        public IScheduler MainThreadScheduler { get; set; }
-
-        /// <summary>
-        /// Gets or sets the scheduler used by the <see cref="NavigationView"/>.
-        /// </summary>
-        public IViewLocator ViewLocator { get; set; }
-
-        /// <inheritdoc />
-        public IObservable<IViewModel> PagePopped { get; } = Observable.Never<IViewModel>();
-
-        /// <summary>
-        /// Gets the type by which the element is styled.
-        /// </summary>
-        /// <remarks>
-        /// Usually controls are styled by their own type, but there are instances where you want
-        /// an element to be styled by its base type, e.g. creating SpecialButton that
-        /// derives from Button and adds extra functionality but is still styled as a regular
-        /// Button. Override this property to change the style for a control class, returning the
-        /// type that you wish the elements to be styled as.
-        /// </remarks>
-        protected override Type StyleKeyOverride => typeof(ContentControl);
-
-        /// <inheritdoc />
-        public IObservable<Unit> PushPage(
-            IViewModel viewModel,
-            string? contract,
-            bool resetStack,
-            bool animate = true)
-        {
-            if (viewModel == null)
-            {
-                throw new ArgumentNullException(nameof(viewModel));
             }
+        };
+    }
 
-            var view = LocateView(viewModel, contract);
-            _pageNavigation.ToggleAnimations(!_modalNavigation.IsVisible);
-            _pageNavigation.Push(view, resetStack);
-            return Observable.Return(Unit.Default);
-        }
+    /// <summary>
+    /// Gets or sets the scheduler used by the <see cref="NavigationView"/>.
+    /// </summary>
+    public IScheduler MainThreadScheduler { get; set; }
 
-        /// <inheritdoc />
-        public IObservable<Unit> PopPage(bool animate = true)
+    /// <summary>
+    /// Gets or sets the scheduler used by the <see cref="NavigationView"/>.
+    /// </summary>
+    public IViewLocator ViewLocator { get; set; }
+
+    /// <inheritdoc />
+    public IObservable<IViewModel> PagePopped { get; } = Observable.Never<IViewModel>();
+
+    /// <summary>
+    /// Gets the type by which the element is styled.
+    /// </summary>
+    /// <remarks>
+    /// Usually controls are styled by their own type, but there are instances where you want
+    /// an element to be styled by its base type, e.g. creating SpecialButton that
+    /// derives from Button and adds extra functionality but is still styled as a regular
+    /// Button. Override this property to change the style for a control class, returning the
+    /// type that you wish the elements to be styled as.
+    /// </remarks>
+    protected override Type StyleKeyOverride => typeof(ContentControl);
+
+    /// <inheritdoc />
+    public IObservable<Unit> PushPage(
+        IViewModel viewModel,
+        string? contract,
+        bool resetStack,
+        bool animate = true)
+    {
+        if (viewModel == null)
         {
-            _pageNavigation.ToggleAnimations(!_modalNavigation.IsVisible);
-            _pageNavigation.Pop();
-            return Observable.Return(Unit.Default);
+            throw new ArgumentNullException(nameof(viewModel));
         }
 
-        /// <inheritdoc />
-        public IObservable<Unit> PopToRootPage(bool animate = true)
+        var view = LocateView(viewModel, contract);
+        _pageNavigation.ToggleAnimations(!_modalNavigation.IsVisible);
+        _pageNavigation.Push(view, resetStack);
+        return Observable.Return(Unit.Default);
+    }
+
+    /// <inheritdoc />
+    public IObservable<Unit> PopPage(bool animate = true)
+    {
+        _pageNavigation.ToggleAnimations(!_modalNavigation.IsVisible);
+        _pageNavigation.Pop();
+        return Observable.Return(Unit.Default);
+    }
+
+    /// <inheritdoc />
+    public IObservable<Unit> PopToRootPage(bool animate = true)
+    {
+        _pageNavigation.ToggleAnimations(!_modalNavigation.IsVisible);
+        _pageNavigation.PopToRoot();
+        return Observable.Return(Unit.Default);
+    }
+
+    /// <inheritdoc />
+    public IObservable<Unit> PushModal(
+        IViewModel modalViewModel,
+        string? contract,
+        bool withNavigationPage = true)
+    {
+        if (modalViewModel == null)
         {
-            _pageNavigation.ToggleAnimations(!_modalNavigation.IsVisible);
-            _pageNavigation.PopToRoot();
-            return Observable.Return(Unit.Default);
+            throw new ArgumentNullException(nameof(modalViewModel));
         }
 
-        /// <inheritdoc />
-        public IObservable<Unit> PushModal(
-            IViewModel modalViewModel,
-            string? contract,
-            bool withNavigationPage = true)
-        {
-            if (modalViewModel == null)
-            {
-                throw new ArgumentNullException(nameof(modalViewModel));
-            }
+        var view = LocateView(modalViewModel, contract);
+        _modalNavigation.Push(view);
+        return Observable.Return(Unit.Default);
+    }
 
-            var view = LocateView(modalViewModel, contract);
-            _modalNavigation.Push(view);
-            return Observable.Return(Unit.Default);
-        }
+    /// <inheritdoc />
+    public IObservable<Unit> PopModal()
+    {
+        _modalNavigation.Pop();
+        return Observable.Return(Unit.Default);
+    }
 
-        /// <inheritdoc />
-        public IObservable<Unit> PopModal()
-        {
-            _modalNavigation.Pop();
-            return Observable.Return(Unit.Default);
-        }
-
-        private IViewFor LocateView(IViewModel viewModel, string? contract)
-        {
-            var view = ViewLocator.ResolveView(viewModel, contract) ?? throw new InvalidOperationException(
-                    $"No view could be located for type '{viewModel.GetType().FullName}', " +
-                    $"contract '{contract}'. Be sure Splat has an appropriate registration.");
-            view.ViewModel = viewModel;
-            return view;
-        }
+    private IViewFor LocateView(IViewModel viewModel, string? contract)
+    {
+        var view = ViewLocator.ResolveView(viewModel, contract) ?? throw new InvalidOperationException(
+                $"No view could be located for type '{viewModel.GetType().FullName}', " +
+                $"contract '{contract}'. Be sure Splat has an appropriate registration.");
+        view.ViewModel = viewModel;
+        return view;
     }
 }

--- a/src/Sextant.Avalonia/Sextant.Avalonia.csproj
+++ b/src/Sextant.Avalonia/Sextant.Avalonia.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>Sextant.Avalonia</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Sextant.Maui/Behaviors/BehaviorBase.cs
+++ b/src/Sextant.Maui/Behaviors/BehaviorBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Maui/Behaviors/NavigationPageSystemPopBehavior.cs
+++ b/src/Sextant.Maui/Behaviors/NavigationPageSystemPopBehavior.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Maui/GlobalUsings.cs
+++ b/src/Sextant.Maui/GlobalUsings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Maui/Mixins/DependencyResolverMixins.cs
+++ b/src/Sextant.Maui/Mixins/DependencyResolverMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -30,7 +30,7 @@ public static class DependencyResolverMixins
             () => new NavigationView(
                 RxApp.MainThreadScheduler,
                 RxApp.TaskpoolScheduler,
-                Locator.Current.GetService<IViewLocator>() ?? throw new InvalidOperationException("IViewLocator not registered.")),
+                AppLocator.Current.GetService<IViewLocator>() ?? throw new InvalidOperationException("IViewLocator not registered.")),
             typeof(IView),
             NavigationView);
         return dependencyResolver;
@@ -49,7 +49,7 @@ public static class DependencyResolverMixins
             () => new NavigationView(
                 mainThreadScheduler,
                 backgroundScheduler,
-                Locator.Current.GetService<IViewLocator>() ?? throw new InvalidOperationException("IViewLocator not registered.")),
+                AppLocator.Current.GetService<IViewLocator>() ?? throw new InvalidOperationException("IViewLocator not registered.")),
             typeof(IView),
             NavigationView);
         return dependencyResolver;

--- a/src/Sextant.Maui/Mixins/SextantExtensions.cs
+++ b/src/Sextant.Maui/Mixins/SextantExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Maui/NavigationSource.cs
+++ b/src/Sextant.Maui/NavigationSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Maui/NavigationView.cs
+++ b/src/Sextant.Maui/NavigationView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Maui/Sextant.Maui.csproj
+++ b/src/Sextant.Maui/Sextant.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseMaui>true</UseMaui>
   </PropertyGroup>

--- a/src/Sextant.Mocks/AbstractViewModel.cs
+++ b/src/Sextant.Mocks/AbstractViewModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -7,26 +7,25 @@ using System;
 using System.Reactive;
 using System.Reactive.Linq;
 
-namespace Sextant.Mocks
+namespace Sextant.Mocks;
+
+/// <summary>
+/// Abstract view model.
+/// </summary>
+public abstract class AbstractViewModel : INavigable
 {
-    /// <summary>
-    /// Abstract view model.
-    /// </summary>
-    public abstract class AbstractViewModel : INavigable
-    {
-        /// <inheritdoc/>
-        public string Id { get; } = string.Empty;
+    /// <inheritdoc/>
+    public string Id { get; } = string.Empty;
 
-        /// <inheritdoc/>
-        public virtual IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) =>
-            Observable.Return(Unit.Default);
+    /// <inheritdoc/>
+    public virtual IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) =>
+        Observable.Return(Unit.Default);
 
-        /// <inheritdoc/>
-        public IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) =>
-            Observable.Return(Unit.Default);
+    /// <inheritdoc/>
+    public IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) =>
+        Observable.Return(Unit.Default);
 
-        /// <inheritdoc/>
-        public IObservable<Unit> WhenNavigatingTo(INavigationParameter parameter) =>
-            Observable.Return(Unit.Default);
-    }
+    /// <inheritdoc/>
+    public IObservable<Unit> WhenNavigatingTo(INavigationParameter parameter) =>
+        Observable.Return(Unit.Default);
 }

--- a/src/Sextant.Mocks/IDestructibleMock.cs
+++ b/src/Sextant.Mocks/IDestructibleMock.cs
@@ -1,14 +1,11 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Sextant.Mocks
-{
-    /// <summary>
-    /// Interface representing a destructible view model.
-    /// </summary>
-    public interface IDestructibleMock : IViewModel, IDestructible
-    {
-    }
-}
+namespace Sextant.Mocks;
+
+/// <summary>
+/// Interface representing a destructible view model.
+/// </summary>
+public interface IDestructibleMock : IViewModel, IDestructible;

--- a/src/Sextant.Mocks/IEverything.cs
+++ b/src/Sextant.Mocks/IEverything.cs
@@ -1,14 +1,11 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Sextant.Mocks
-{
-    /// <summary>
-    /// Interface representing everything.
-    /// </summary>
-    public interface IEverything : INavigable, IDestructible
-    {
-    }
-}
+namespace Sextant.Mocks;
+
+/// <summary>
+/// Interface representing everything.
+/// </summary>
+public interface IEverything : INavigable, IDestructible;

--- a/src/Sextant.Mocks/NavigableViewModelMock.cs
+++ b/src/Sextant.Mocks/NavigableViewModelMock.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -8,52 +8,43 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
-namespace Sextant.Mocks
+namespace Sextant.Mocks;
+
+/// <summary>
+/// A mock of a page view model.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="NavigableViewModelMock"/> class.
+/// </remarks>
+/// <param name="id">The id of the page.</param>
+public class NavigableViewModelMock(string? id = null) : INavigable
 {
+    private readonly ISubject<Unit> _navigatedTo = new Subject<Unit>();
+    private readonly ISubject<Unit> _navigatingTo = new Subject<Unit>();
+    private readonly ISubject<Unit> _navigatedFrom = new Subject<Unit>();
+
     /// <summary>
-    /// A mock of a page view model.
+    /// Initializes a new instance of the <see cref="NavigableViewModelMock"/> class.
     /// </summary>
-    public class NavigableViewModelMock : INavigable
+    public NavigableViewModelMock()
+        : this(string.Empty)
     {
-        private readonly ISubject<Unit> _navigatedTo;
-        private readonly ISubject<Unit> _navigatingTo;
-        private readonly ISubject<Unit> _navigatedFrom;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NavigableViewModelMock"/> class.
-        /// </summary>
-        /// <param name="id">The id of the page.</param>
-        public NavigableViewModelMock(string? id = null)
-        {
-            Id = id ?? string.Empty;
-            _navigatedTo = new Subject<Unit>();
-            _navigatedFrom = new Subject<Unit>();
-            _navigatingTo = new Subject<Unit>();
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NavigableViewModelMock"/> class.
-        /// </summary>
-        public NavigableViewModelMock()
-            : this(string.Empty)
-        {
-        }
-
-        /// <summary>
-        /// Gets the ID of the page.
-        /// </summary>
-        public string Id { get; }
-
-        /// <inheritdoc/>
-        public virtual IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) =>
-            Observable.Return(Unit.Default).Do(_ => _navigatedTo.OnNext(Unit.Default));
-
-        /// <inheritdoc/>
-        public virtual IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) =>
-            Observable.Return(Unit.Default).Do(_ => _navigatedFrom.OnNext(Unit.Default));
-
-        /// <inheritdoc/>
-        public virtual IObservable<Unit> WhenNavigatingTo(INavigationParameter parameter) =>
-            Observable.Return(Unit.Default).Do(_ => _navigatingTo.OnNext(Unit.Default));
     }
+
+    /// <summary>
+    /// Gets the ID of the page.
+    /// </summary>
+    public string Id { get; } = id ?? string.Empty;
+
+    /// <inheritdoc/>
+    public virtual IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) =>
+        Observable.Return(Unit.Default).Do(_ => _navigatedTo.OnNext(Unit.Default));
+
+    /// <inheritdoc/>
+    public virtual IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) =>
+        Observable.Return(Unit.Default).Do(_ => _navigatedFrom.OnNext(Unit.Default));
+
+    /// <inheritdoc/>
+    public virtual IObservable<Unit> WhenNavigatingTo(INavigationParameter parameter) =>
+        Observable.Return(Unit.Default).Do(_ => _navigatingTo.OnNext(Unit.Default));
 }

--- a/src/Sextant.Mocks/NavigatedMock.cs
+++ b/src/Sextant.Mocks/NavigatedMock.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -7,12 +7,11 @@ using System;
 using System.Reactive;
 using System.Reactive.Linq;
 
-namespace Sextant.Mocks
-{
-    internal class NavigatedMock : INavigated
-    {
-        public IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) => Observable.Return(Unit.Default);
+namespace Sextant.Mocks;
 
-        public IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) => Observable.Return(Unit.Default);
-    }
+internal class NavigatedMock : INavigated
+{
+    public IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) => Observable.Return(Unit.Default);
+
+    public IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) => Observable.Return(Unit.Default);
 }

--- a/src/Sextant.Mocks/NavigationViewMock.cs
+++ b/src/Sextant.Mocks/NavigationViewMock.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -10,65 +10,64 @@ using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
-namespace Sextant.Mocks
+namespace Sextant.Mocks;
+
+/// <summary>
+/// Mock <see cref="IView"/> implementation.
+/// </summary>
+public class NavigationViewMock : IView, IDisposable
 {
+    private readonly Subject<IViewModel> _pagePoppedSubject = new();
+    private readonly Stack<IViewModel> _pageStack = new();
+
     /// <summary>
-    /// Mock <see cref="IView"/> implementation.
+    /// Initializes a new instance of the <see cref="NavigationViewMock"/> class.
     /// </summary>
-    public class NavigationViewMock : IView, IDisposable
+    public NavigationViewMock() => PagePopped = _pagePoppedSubject.AsObservable();
+
+    /// <inheritdoc/>
+    public IScheduler MainThreadScheduler { get; } = CurrentThreadScheduler.Instance;
+
+    /// <inheritdoc/>
+    public IObservable<IViewModel?> PagePopped { get; }
+
+    /// <inheritdoc/>
+    public IObservable<Unit> PopModal() => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public IObservable<Unit> PopPage(bool animate = true) =>
+        Observable
+            .Return(Unit.Default)
+            .Do(_ => _pagePoppedSubject.OnNext(_pageStack.Pop()));
+
+    /// <inheritdoc/>
+    public IObservable<Unit> PopToRootPage(bool animate = true) => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public IObservable<Unit> PushModal(IViewModel modalViewModel, string? contract, bool withNavigationPage = true) => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public IObservable<Unit> PushPage(IViewModel viewModel, string? contract, bool resetStack, bool animate = true) =>
+        Observable
+            .Return(Unit.Default)
+            .Do(_ => _pageStack.Push(viewModel));
+
+    /// <inheritdoc/>
+    public void Dispose()
     {
-        private readonly Subject<IViewModel> _pagePoppedSubject = new();
-        private readonly Stack<IViewModel> _pageStack = new();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NavigationViewMock"/> class.
-        /// </summary>
-        public NavigationViewMock() => PagePopped = _pagePoppedSubject.AsObservable();
-
-        /// <inheritdoc/>
-        public IScheduler MainThreadScheduler { get; } = CurrentThreadScheduler.Instance;
-
-        /// <inheritdoc/>
-        public IObservable<IViewModel?> PagePopped { get; }
-
-        /// <inheritdoc/>
-        public IObservable<Unit> PopModal() => throw new NotImplementedException();
-
-        /// <inheritdoc/>
-        public IObservable<Unit> PopPage(bool animate = true) =>
-            Observable
-                .Return(Unit.Default)
-                .Do(_ => _pagePoppedSubject.OnNext(_pageStack.Pop()));
-
-        /// <inheritdoc/>
-        public IObservable<Unit> PopToRootPage(bool animate = true) => throw new NotImplementedException();
-
-        /// <inheritdoc/>
-        public IObservable<Unit> PushModal(IViewModel modalViewModel, string? contract, bool withNavigationPage = true) => throw new NotImplementedException();
-
-        /// <inheritdoc/>
-        public IObservable<Unit> PushPage(IViewModel viewModel, string? contract, bool resetStack, bool animate = true) =>
-            Observable
-                .Return(Unit.Default)
-                .Do(_ => _pageStack.Push(viewModel));
-
-        /// <inheritdoc/>
-        public void Dispose()
+    /// <summary>
+    /// Releases unmanaged and - optionally - managed resources.
+    /// </summary>
+    /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Releases unmanaged and - optionally - managed resources.
-        /// </summary>
-        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _pagePoppedSubject.Dispose();
-            }
+            _pagePoppedSubject.Dispose();
         }
     }
 }

--- a/src/Sextant.Mocks/NullViewModelMock.cs
+++ b/src/Sextant.Mocks/NullViewModelMock.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -8,42 +8,73 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
-namespace Sextant.Mocks
+namespace Sextant.Mocks;
+
+/// <summary>
+/// Null view model.
+/// </summary>
+public class NullViewModelMock : INavigable, IDisposable
 {
+    private readonly Subject<Unit> _navigatedTo;
+    private readonly Subject<Unit> _navigatingTo;
+    private readonly Subject<Unit> _navigatedFrom;
+    private bool _disposedValue;
+
     /// <summary>
-    /// Null view model.
+    /// Initializes a new instance of the <see cref="NullViewModelMock"/> class.
     /// </summary>
-    public class NullViewModelMock : INavigable
+    public NullViewModelMock()
     {
-        private readonly ISubject<Unit> _navigatedTo;
-        private readonly ISubject<Unit> _navigatingTo;
-        private readonly ISubject<Unit> _navigatedFrom;
+        _navigatedTo = new Subject<Unit>();
+        _navigatedFrom = new Subject<Unit>();
+        _navigatingTo = new Subject<Unit>();
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NullViewModelMock"/> class.
-        /// </summary>
-        public NullViewModelMock()
+    /// <summary>
+    /// Gets the ID of the page.
+    /// </summary>
+    public string Id => nameof(NullViewModelMock);
+
+    /// <inheritdoc/>
+    public IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) =>
+        Observable.Return(Unit.Default).Do(_ => _navigatedTo.OnNext(Unit.Default));
+
+    /// <inheritdoc/>
+    public IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) =>
+        Observable.Return(Unit.Default).Do(_ => _navigatedFrom.OnNext(Unit.Default));
+
+    /// <inheritdoc/>
+    public IObservable<Unit> WhenNavigatingTo(INavigationParameter parameter) =>
+        Observable.Return(Unit.Default).Do(_ => _navigatingTo.OnNext(Unit.Default));
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases unmanaged and - optionally - managed resources.
+    /// </summary>
+    /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
         {
-            _navigatedTo = new Subject<Unit>();
-            _navigatedFrom = new Subject<Unit>();
-            _navigatingTo = new Subject<Unit>();
+            if (disposing)
+            {
+                _navigatedFrom?.Dispose();
+                _navigatedTo?.Dispose();
+                _navigatingTo?.Dispose();
+            }
+
+            // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+            // TODO: set large fields to null
+            _disposedValue = true;
         }
-
-        /// <summary>
-        /// Gets the ID of the page.
-        /// </summary>
-        public string Id => nameof(NullViewModelMock);
-
-        /// <inheritdoc/>
-        public IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) =>
-            Observable.Return(Unit.Default).Do(_ => _navigatedTo.OnNext(Unit.Default));
-
-        /// <inheritdoc/>
-        public IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) =>
-            Observable.Return(Unit.Default).Do(_ => _navigatedFrom.OnNext(Unit.Default));
-
-        /// <inheritdoc/>
-        public IObservable<Unit> WhenNavigatingTo(INavigationParameter parameter) =>
-            Observable.Return(Unit.Default).Do(_ => _navigatingTo.OnNext(Unit.Default));
     }
 }

--- a/src/Sextant.Mocks/PageView.cs
+++ b/src/Sextant.Mocks/PageView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -8,28 +8,27 @@ using ReactiveUI;
 
 [assembly: InternalsVisibleTo("Sextant.Tests")]
 
-namespace Sextant.Mocks
+namespace Sextant.Mocks;
+
+/// <summary>
+/// A mock of a page view.
+/// </summary>
+/// <seealso cref="ReactiveUI.IViewFor{PageViewModelMock}" />
+public class PageView : IViewFor<NavigableViewModelMock>
 {
     /// <summary>
-    /// A mock of a page view.
+    /// Gets or sets the ViewModel corresponding to this specific View. This should be
+    /// a DependencyProperty if you're using XAML.
     /// </summary>
-    /// <seealso cref="ReactiveUI.IViewFor{PageViewModelMock}" />
-    public class PageView : IViewFor<NavigableViewModelMock>
+    object? IViewFor.ViewModel
     {
-        /// <summary>
-        /// Gets or sets the ViewModel corresponding to this specific View. This should be
-        /// a DependencyProperty if you're using XAML.
-        /// </summary>
-        object? IViewFor.ViewModel
-        {
-            get => ViewModel;
-            set => ViewModel = (NavigableViewModelMock?)value;
-        }
-
-        /// <summary>
-        /// Gets or sets the ViewModel corresponding to this specific View. This should be
-        /// a DependencyProperty if you're using XAML.
-        /// </summary>
-        public NavigableViewModelMock? ViewModel { get; set; }
+        get => ViewModel;
+        set => ViewModel = (NavigableViewModelMock?)value;
     }
+
+    /// <summary>
+    /// Gets or sets the ViewModel corresponding to this specific View. This should be
+    /// a DependencyProperty if you're using XAML.
+    /// </summary>
+    public NavigableViewModelMock? ViewModel { get; set; }
 }

--- a/src/Sextant.Mocks/ParameterViewModel.cs
+++ b/src/Sextant.Mocks/ParameterViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -9,52 +9,51 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using ReactiveUI;
 
-namespace Sextant.Mocks
+namespace Sextant.Mocks;
+
+/// <summary>
+/// View model to test passing parameters.
+/// </summary>
+/// <seealso cref="IViewModel" />
+public class ParameterViewModel : ReactiveObject, INavigable, IDestructible
 {
+    private string? _text;
+    private int _meaning;
+
+    /// <inheritdoc />
+    public string Id { get; } = nameof(ParameterViewModel);
+
     /// <summary>
-    /// View model to test passing parameters.
+    /// Gets or sets the text.
     /// </summary>
-    /// <seealso cref="IViewModel" />
-    public class ParameterViewModel : ReactiveObject, INavigable, IDestructible
+    public string? Text { get => _text; set => this.RaiseAndSetIfChanged(ref _text, value); }
+
+    /// <summary>
+    /// Gets or sets the meaning.
+    /// </summary>
+    public int Meaning { get => _meaning; set => this.RaiseAndSetIfChanged(ref _meaning, value); }
+
+    /// <summary>
+    /// Gets the disposable.
+    /// </summary>
+    public CompositeDisposable Disposable { get; } = new();
+
+    /// <inheritdoc />
+    public IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) => Observable.Return(Unit.Default).Do(_ => Unwrap(parameter));
+
+    /// <inheritdoc />
+    public IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) => Observable.Return(Unit.Default).Do(_ => Unwrap(parameter));
+
+    /// <inheritdoc />
+    public IObservable<Unit> WhenNavigatingTo(INavigationParameter parameter) => Observable.Return(Unit.Default).Do(_ => Unwrap(parameter));
+
+    /// <inheritdoc/>
+    public void Destroy() => Disposable.Dispose();
+
+    private void Unwrap(INavigationParameter parameter)
     {
-        private string? _text;
-        private int _meaning;
-
-        /// <inheritdoc />
-        public string Id { get; } = nameof(ParameterViewModel);
-
-        /// <summary>
-        /// Gets or sets the text.
-        /// </summary>
-        public string? Text { get => _text; set => this.RaiseAndSetIfChanged(ref _text, value); }
-
-        /// <summary>
-        /// Gets or sets the meaning.
-        /// </summary>
-        public int Meaning { get => _meaning; set => this.RaiseAndSetIfChanged(ref _meaning, value); }
-
-        /// <summary>
-        /// Gets the disposable.
-        /// </summary>
-        public CompositeDisposable Disposable { get; } = new();
-
-        /// <inheritdoc />
-        public IObservable<Unit> WhenNavigatedTo(INavigationParameter parameter) => Observable.Return(Unit.Default).Do(_ => Unwrap(parameter));
-
-        /// <inheritdoc />
-        public IObservable<Unit> WhenNavigatedFrom(INavigationParameter parameter) => Observable.Return(Unit.Default).Do(_ => Unwrap(parameter));
-
-        /// <inheritdoc />
-        public IObservable<Unit> WhenNavigatingTo(INavigationParameter parameter) => Observable.Return(Unit.Default).Do(_ => Unwrap(parameter));
-
-        /// <inheritdoc/>
-        public void Destroy() => Disposable.Dispose();
-
-        private void Unwrap(INavigationParameter parameter)
-        {
-            // Note: normally you should check parameter.ContainsKey() before accessing the dictionary.
-            Text = (string)parameter["hello"];
-            Meaning = (int)parameter["life"];
-        }
+        // Note: normally you should check parameter.ContainsKey() before accessing the dictionary.
+        Text = (string)parameter["hello"];
+        Meaning = (int)parameter["life"];
     }
 }

--- a/src/Sextant.Mocks/Sextant.Mocks.csproj
+++ b/src/Sextant.Mocks/Sextant.Mocks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Sextant.Plugins.Popup/IPopupViewStackService.cs
+++ b/src/Sextant.Plugins.Popup/IPopupViewStackService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Plugins.Popup/PopupNavigationEvent.cs
+++ b/src/Sextant.Plugins.Popup/PopupNavigationEvent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Plugins.Popup/PopupViewStackService.cs
+++ b/src/Sextant.Plugins.Popup/PopupViewStackService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Plugins.Popup/PopupViewStackServiceBase.cs
+++ b/src/Sextant.Plugins.Popup/PopupViewStackServiceBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Plugins.Popup/Sextant.Plugins.Popup.csproj
+++ b/src/Sextant.Plugins.Popup/Sextant.Plugins.Popup.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
     <UseMaui>true</UseMaui>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Sextant.Plugins.Popup/SextantPopupPage.cs
+++ b/src/Sextant.Plugins.Popup/SextantPopupPage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Plugins.Popup/SextantPopupPage{TViewModel}.cs
+++ b/src/Sextant.Plugins.Popup/SextantPopupPage{TViewModel}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Tests/API/ApiApprovalTests.Sextant.DotNet9_0.verified.txt
+++ b/src/Sextant.Tests/API/ApiApprovalTests.Sextant.DotNet9_0.verified.txt
@@ -1,0 +1,197 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
+namespace Sextant
+{
+    public class DefaultViewModelFactory : Sextant.IViewModelFactory
+    {
+        public DefaultViewModelFactory() { }
+        public TViewModel Create<TViewModel>(string? contract = null)
+            where TViewModel : Sextant.IViewModel { }
+    }
+    public static class DependencyResolverMixins
+    {
+        public static string NavigationView { get; }
+        public static Splat.IMutableDependencyResolver RegisterParameterViewStackService(this Splat.IMutableDependencyResolver dependencyResolver) { }
+        [System.Obsolete("Use RegisterViewForNavigation")]
+        public static Splat.IMutableDependencyResolver RegisterView<TView, TViewModel>(this Splat.IMutableDependencyResolver dependencyResolver, string? contract = null)
+            where TView : ReactiveUI.IViewFor<TViewModel>, new ()
+            where TViewModel :  class, Sextant.IViewModel { }
+        [System.Obsolete("Use RegisterViewForNavigation")]
+        public static Splat.IMutableDependencyResolver RegisterView<TView, TViewModel>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<TView> viewFactory, string? contract = null)
+            where TView :  class, ReactiveUI.IViewFor
+            where TViewModel :  class, Sextant.IViewModel { }
+        public static Splat.IMutableDependencyResolver RegisterViewForNavigation<TView, TViewModel>(this Splat.IMutableDependencyResolver resolver)
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>, new ()
+            where TViewModel :  class, Sextant.IViewModel, new () { }
+        public static Splat.IMutableDependencyResolver RegisterViewForNavigation<TView, TViewModel>(this Splat.IMutableDependencyResolver resolver, System.Func<TView> viewFactory, System.Func<TViewModel> viewModelFactory)
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, Sextant.IViewModel { }
+        public static Splat.IMutableDependencyResolver RegisterViewForNavigation<TView, TViewModel>(this Splat.IMutableDependencyResolver resolver, TView view, TViewModel viewModel)
+            where TView :  class, ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, Sextant.IViewModel { }
+        [System.Obsolete("Use of new makes this method undesirable.")]
+        public static Splat.IMutableDependencyResolver RegisterViewModel<TViewModel>(this Splat.IMutableDependencyResolver dependencyResolver, string? contract = null)
+            where TViewModel : Sextant.IViewModel, new () { }
+        public static Splat.IMutableDependencyResolver RegisterViewModel<TViewModel>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<TViewModel> viewModelFactory, string? contract = null)
+            where TViewModel :  class, Sextant.IViewModel { }
+        public static Splat.IMutableDependencyResolver RegisterViewModel<TViewModel>(this Splat.IMutableDependencyResolver dependencyResolver, TViewModel viewModel, string? contract = null)
+            where TViewModel :  class, Sextant.IViewModel { }
+        public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver) { }
+        public static Splat.IMutableDependencyResolver RegisterViewModelFactory(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IViewModelFactory> factory) { }
+        public static Splat.IMutableDependencyResolver RegisterViewStackService(this Splat.IMutableDependencyResolver dependencyResolver) { }
+        [System.Obsolete("Use the Func<IView, IViewModelFactory, T> variant.")]
+        public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, T> factory)
+            where T : Sextant.IViewStackService { }
+        public static Splat.IMutableDependencyResolver RegisterViewStackService<T>(this Splat.IMutableDependencyResolver dependencyResolver, System.Func<Sextant.IView, Sextant.IViewModelFactory, T> factory)
+            where T : Sextant.IViewStackService { }
+    }
+    public interface IDestructible
+    {
+        void Destroy();
+    }
+    public interface INavigable : Sextant.INavigated, Sextant.INavigating, Sextant.IViewModel { }
+    public interface INavigated
+    {
+        System.IObservable<System.Reactive.Unit> WhenNavigatedFrom(Sextant.INavigationParameter parameter);
+        System.IObservable<System.Reactive.Unit> WhenNavigatedTo(Sextant.INavigationParameter parameter);
+    }
+    public interface INavigating
+    {
+        System.IObservable<System.Reactive.Unit> WhenNavigatingTo(Sextant.INavigationParameter parameter);
+    }
+    public interface INavigationParameter : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    {
+        T GetValue<T>(string key);
+        bool TryGetValue<T>(string key, out T value);
+    }
+    public interface IParameterViewStackService : Sextant.IViewStackService
+    {
+        System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = true);
+        System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable navigableModal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true);
+        System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
+            where TViewModel : Sextant.INavigable;
+        System.IObservable<System.Reactive.Unit> PushPage(Sextant.INavigable navigableViewModel, Sextant.INavigationParameter parameter, string? contract = null, bool resetStack = false, bool animate = true);
+        System.IObservable<System.Reactive.Unit> PushPage<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool resetStack = false, bool animate = true)
+            where TViewModel : Sextant.INavigable;
+    }
+    public interface IView
+    {
+        System.Reactive.Concurrency.IScheduler MainThreadScheduler { get; }
+        System.IObservable<Sextant.IViewModel?> PagePopped { get; }
+        System.IObservable<System.Reactive.Unit> PopModal();
+        System.IObservable<System.Reactive.Unit> PopPage(bool animate = true);
+        System.IObservable<System.Reactive.Unit> PopToRootPage(bool animate = true);
+        System.IObservable<System.Reactive.Unit> PushModal(Sextant.IViewModel modalViewModel, string? contract, bool withNavigationPage = true);
+        System.IObservable<System.Reactive.Unit> PushPage(Sextant.IViewModel viewModel, string? contract, bool resetStack, bool animate = true);
+    }
+    public interface IViewModel
+    {
+        string? Id { get; }
+    }
+    public interface IViewModelFactory
+    {
+        TViewModel Create<TViewModel>(string? contract = null)
+            where TViewModel : Sextant.IViewModel;
+    }
+    public interface IViewStackService
+    {
+        System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }
+        System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> PageStack { get; }
+        Sextant.IView View { get; }
+        System.IObservable<System.Reactive.Unit> PopModal(bool animate = true);
+        System.IObservable<System.Reactive.Unit> PopPage(bool animate = true);
+        System.IObservable<System.Reactive.Unit> PopToRootPage(bool animate = true);
+        System.IObservable<System.Reactive.Unit> PushModal(Sextant.IViewModel modal, string? contract = null, bool withNavigationPage = true);
+        System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(string? contract = null, bool withNavigationPage = true)
+            where TViewModel : Sextant.IViewModel;
+        System.IObservable<System.Reactive.Unit> PushPage(Sextant.INavigable page, string? contract = null, bool resetStack = false, bool animate = true);
+        System.IObservable<System.Reactive.Unit> PushPage(Sextant.IViewModel page, string? contract = null, bool resetStack = false, bool animate = true);
+        System.IObservable<System.Reactive.Unit> PushPage<TViewModel>(string? contract = null, bool resetStack = false, bool animate = true)
+            where TViewModel : Sextant.IViewModel;
+        System.IObservable<Sextant.IViewModel> TopModal();
+        System.IObservable<Sextant.IViewModel> TopPage();
+    }
+    public class NavigationParameter : System.Collections.Generic.Dictionary<string, object>, Sextant.INavigationParameter, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    {
+        public NavigationParameter() { }
+        public T GetValue<T>(string key) { }
+        public bool TryGetValue<T>(string key, out T value) { }
+    }
+    public sealed class ParameterViewStackService : Sextant.ParameterViewStackServiceBase
+    {
+        public ParameterViewStackService(Sextant.IView view) { }
+        public ParameterViewStackService(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
+    }
+    public abstract class ParameterViewStackServiceBase : Sextant.ViewStackServiceBase, Sextant.IParameterViewStackService, Sextant.IViewStackService
+    {
+        protected ParameterViewStackServiceBase(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
+        public System.IObservable<System.Reactive.Unit> PopPage(Sextant.INavigationParameter parameter, bool animate = true) { }
+        public System.IObservable<System.Reactive.Unit> PushModal(Sextant.INavigable navigableModal, Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true) { }
+        public System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool withNavigationPage = true)
+            where TViewModel : Sextant.INavigable { }
+        public System.IObservable<System.Reactive.Unit> PushPage(Sextant.INavigable navigableViewModel, Sextant.INavigationParameter parameter, string? contract = null, bool resetStack = false, bool animate = true) { }
+        public System.IObservable<System.Reactive.Unit> PushPage<TViewModel>(Sextant.INavigationParameter parameter, string? contract = null, bool resetStack = false, bool animate = true)
+            where TViewModel : Sextant.INavigable { }
+    }
+    public class Sextant
+    {
+        public Sextant() { }
+        public Splat.IMutableDependencyResolver MutableLocator { get; }
+        public static Sextant.Sextant Instance { get; }
+    }
+    public static class SextantExtensions
+    {
+        public static void Initialize(this Sextant.Sextant sextant) { }
+    }
+    public static class ViewModelActionExtensions
+    {
+        public static object InvokeViewModelAction<T>(this object viewModel, System.Action<T> action)
+            where T :  class { }
+    }
+    public static class ViewModelFactory
+    {
+        public static Sextant.IViewModelFactory Current { get; }
+    }
+    [System.Serializable]
+    public class ViewModelFactoryNotFoundException : System.Exception
+    {
+        public ViewModelFactoryNotFoundException() { }
+        public ViewModelFactoryNotFoundException(string message) { }
+        [System.Obsolete(DiagnosticId="SYSLIB0051")]
+        protected ViewModelFactoryNotFoundException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
+        public ViewModelFactoryNotFoundException(string message, System.Exception innerException) { }
+    }
+    public sealed class ViewStackService : Sextant.ViewStackServiceBase
+    {
+        public ViewStackService(Sextant.IView view) { }
+        public ViewStackService(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
+    }
+    public abstract class ViewStackServiceBase : Sextant.IViewStackService, Splat.IEnableLogger, System.IDisposable
+    {
+        protected ViewStackServiceBase(Sextant.IView view, Sextant.IViewModelFactory viewModelFactory) { }
+        protected Sextant.IViewModelFactory Factory { get; }
+        protected Splat.IFullLogger Logger { get; }
+        public System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalStack { get; }
+        protected System.Reactive.Subjects.BehaviorSubject<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> ModalSubject { get; }
+        protected System.Reactive.Disposables.CompositeDisposable NavigationDisposables { get; }
+        public System.IObservable<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> PageStack { get; }
+        protected System.Reactive.Subjects.BehaviorSubject<System.Collections.Immutable.IImmutableList<Sextant.IViewModel>> PageSubject { get; }
+        public Sextant.IView View { get; }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public System.IObservable<System.Reactive.Unit> PopModal(bool animate = true) { }
+        public System.IObservable<System.Reactive.Unit> PopPage(bool animate = true) { }
+        public System.IObservable<System.Reactive.Unit> PopToRootPage(bool animate = true) { }
+        public System.IObservable<System.Reactive.Unit> PushModal(Sextant.IViewModel modal, string? contract = null, bool withNavigationPage = true) { }
+        public System.IObservable<System.Reactive.Unit> PushModal<TViewModel>(string? contract = null, bool withNavigationPage = true)
+            where TViewModel : Sextant.IViewModel { }
+        public System.IObservable<System.Reactive.Unit> PushPage(Sextant.INavigable viewModel, string? contract = null, bool resetStack = false, bool animate = true) { }
+        public System.IObservable<System.Reactive.Unit> PushPage(Sextant.IViewModel viewModel, string? contract = null, bool resetStack = false, bool animate = true) { }
+        public System.IObservable<System.Reactive.Unit> PushPage<TViewModel>(string? contract = null, bool resetStack = false, bool animate = true)
+            where TViewModel : Sextant.IViewModel { }
+        public System.IObservable<Sextant.IViewModel> TopModal() { }
+        public System.IObservable<Sextant.IViewModel> TopPage() { }
+        protected static void AddToStackAndTick<T>(System.Reactive.Subjects.BehaviorSubject<System.Collections.Immutable.IImmutableList<T>> stackSubject, T item, bool reset) { }
+        protected static void PopRootAndTick<T>(System.Reactive.Subjects.BehaviorSubject<System.Collections.Immutable.IImmutableList<T>> stackSubject, System.Reactive.Disposables.CompositeDisposable disposable) { }
+        protected static T PopStackAndTick<T>(System.Reactive.Subjects.BehaviorSubject<System.Collections.Immutable.IImmutableList<T>> stackSubject) { }
+    }
+}

--- a/src/Sextant.Tests/API/ApiApprovalTests.cs
+++ b/src/Sextant.Tests/API/ApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -8,19 +8,18 @@ using System.Threading.Tasks;
 using Sextant.APITests;
 using Xunit;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Tests to make sure that the API matches the approved ones.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ApiApprovalTests
 {
     /// <summary>
-    /// Tests to make sure that the API matches the approved ones.
+    /// Tests to make sure the splat project is approved.
     /// </summary>
-    [ExcludeFromCodeCoverage]
-    public class ApiApprovalTests
-    {
-        /// <summary>
-        /// Tests to make sure the splat project is approved.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public Task Sextant() => typeof(IViewStackService).Assembly.CheckApproval(["Sextant"]);
-    }
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public Task Sextant() => typeof(IViewStackService).Assembly.CheckApproval(["Sextant"]);
 }

--- a/src/Sextant.Tests/API/ApiExtensions.cs
+++ b/src/Sextant.Tests/API/ApiExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant.Tests/DependencyResolverMixinTests.cs
+++ b/src/Sextant.Tests/DependencyResolverMixinTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -9,159 +9,158 @@ using Sextant.Mocks;
 using Splat;
 using Xunit;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Tests the IMutableDependencyResolver extension class.
+/// </summary>
+public sealed class DependencyResolverMixinTests
 {
     /// <summary>
-    /// Tests the IMutableDependencyResolver extension class.
+    /// Tests the register view model factory method.
     /// </summary>
-    public sealed class DependencyResolverMixinTests
+    public sealed class TheRegisterViewModelFactoryMethod
     {
         /// <summary>
-        /// Tests the register view model factory method.
+        /// Should register the view model factory.
         /// </summary>
-        public sealed class TheRegisterViewModelFactoryMethod
+        [Fact]
+        public void Should_Register_View_Model_Factory()
         {
-            /// <summary>
-            /// Should register the view model factory.
-            /// </summary>
-            [Fact]
-            public void Should_Register_View_Model_Factory()
-            {
-                // Given
-                Locator.CurrentMutable.RegisterViewModelFactory();
+            // Given
+            Locator.CurrentMutable.RegisterViewModelFactory();
 
-                // When
-                var result = ViewModelFactory.Current;
+            // When
+            var result = ViewModelFactory.Current;
 
-                // Then
-                result.Should().BeOfType<DefaultViewModelFactory>();
-            }
-
-            /// <summary>
-            /// Should register the view model factory.
-            /// </summary>
-            [Fact]
-            public void Should_Register_View_Model_Factory_With_Factory()
-            {
-                // Given
-                var viewModelFactory = new DefaultViewModelFactory();
-                Locator.CurrentMutable.RegisterViewModelFactory(() => viewModelFactory);
-
-                // When
-                var result = ViewModelFactory.Current;
-
-                // Then
-                result.Should().Be(viewModelFactory);
-            }
+            // Then
+            result.Should().BeOfType<DefaultViewModelFactory>();
         }
 
         /// <summary>
-        /// Tests the register view method.
+        /// Should register the view model factory.
         /// </summary>
-        public sealed class TheRegisterViewMethod
+        [Fact]
+        public void Should_Register_View_Model_Factory_With_Factory()
         {
-            /// <summary>
-            /// Should register the view stack service.
-            /// </summary>
-            [Fact]
-            public void Should_Register_View()
-            {
-                // Given
-                Locator.CurrentMutable.RegisterViewForNavigation<PageView, NavigableViewModelMock>();
+            // Given
+            var viewModelFactory = new DefaultViewModelFactory();
+            Locator.CurrentMutable.RegisterViewModelFactory(() => viewModelFactory);
 
-                // When
-                var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
+            // When
+            var result = ViewModelFactory.Current;
 
-                // Then
-                result.Should().BeOfType<PageView>();
-            }
+            // Then
+            result.Should().Be(viewModelFactory);
+        }
+    }
 
-            /// <summary>
-            /// Should register the view stack service factory.
-            /// </summary>
-            [Fact]
-            public void Should_Register_View_Factory()
-            {
-                // Given
-                Locator.CurrentMutable.RegisterViewForNavigation(() => new PageView(), () => new NavigableViewModelMock());
-                ////Locator.CurrentMutable.RegisterView<PageView, NavigableViewModelMock>(() => new PageView());
+    /// <summary>
+    /// Tests the register view method.
+    /// </summary>
+    public sealed class TheRegisterViewMethod
+    {
+        /// <summary>
+        /// Should register the view stack service.
+        /// </summary>
+        [Fact]
+        public void Should_Register_View()
+        {
+            // Given
+            Locator.CurrentMutable.RegisterViewForNavigation<PageView, NavigableViewModelMock>();
 
-                // When
-                var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
+            // When
+            var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
 
-                // Then
-                result.Should().BeOfType<PageView>();
-            }
+            // Then
+            result.Should().BeOfType<PageView>();
         }
 
         /// <summary>
-        /// Tests the register view for navigation method.
+        /// Should register the view stack service factory.
         /// </summary>
-        public sealed class TheRegisterViewForNavigationMethod
+        [Fact]
+        public void Should_Register_View_Factory()
         {
-            /// <summary>
-            /// Should register the view for navigation.
-            /// </summary>
-            [Fact]
-            public void Should_Register_View_Factory_For_Navigation()
-            {
-                // Given
-                Locator.CurrentMutable.RegisterViewForNavigation(() => new PageView(), () => new NavigableViewModelMock());
+            // Given
+            Locator.CurrentMutable.RegisterViewForNavigation(() => new PageView(), () => new NavigableViewModelMock());
+            ////Locator.CurrentMutable.RegisterView<PageView, NavigableViewModelMock>(() => new PageView());
 
-                // When
-                var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
+            // When
+            var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
 
-                // Then
-                result.Should().BeOfType<PageView>();
-            }
+            // Then
+            result.Should().BeOfType<PageView>();
+        }
+    }
 
-            /// <summary>
-            /// Should register the view for navigation.
-            /// </summary>
-            [Fact]
-            public void Should_Register_ViewModel_Factory_For_Navigation()
-            {
-                // Given
-                Locator.CurrentMutable.RegisterViewForNavigation(() => new PageView(), () => new NavigableViewModelMock());
+    /// <summary>
+    /// Tests the register view for navigation method.
+    /// </summary>
+    public sealed class TheRegisterViewForNavigationMethod
+    {
+        /// <summary>
+        /// Should register the view for navigation.
+        /// </summary>
+        [Fact]
+        public void Should_Register_View_Factory_For_Navigation()
+        {
+            // Given
+            Locator.CurrentMutable.RegisterViewForNavigation(() => new PageView(), () => new NavigableViewModelMock());
 
-                // When
-                var result = Locator.Current.GetService<NavigableViewModelMock>();
+            // When
+            var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
 
-                // Then
-                result.Should().NotBeNull();
-            }
+            // Then
+            result.Should().BeOfType<PageView>();
+        }
 
-            /// <summary>
-            /// Should register the view for navigation.
-            /// </summary>
-            [Fact]
-            public void Should_Register_View_For_Navigation()
-            {
-                // Given
-                Locator.CurrentMutable.RegisterViewForNavigation(new PageView(), new NavigableViewModelMock());
+        /// <summary>
+        /// Should register the view for navigation.
+        /// </summary>
+        [Fact]
+        public void Should_Register_ViewModel_Factory_For_Navigation()
+        {
+            // Given
+            Locator.CurrentMutable.RegisterViewForNavigation(() => new PageView(), () => new NavigableViewModelMock());
 
-                // When
-                var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
+            // When
+            var result = Locator.Current.GetService<NavigableViewModelMock>();
 
-                // Then
-                result.Should().BeOfType<PageView>();
-            }
+            // Then
+            result.Should().NotBeNull();
+        }
 
-            /// <summary>
-            /// Should register the view for navigation.
-            /// </summary>
-            [Fact]
-            public void Should_Register_ViewModel_For_Navigation()
-            {
-                // Given
-                Locator.CurrentMutable.RegisterViewForNavigation(() => new PageView(), () => new NavigableViewModelMock());
+        /// <summary>
+        /// Should register the view for navigation.
+        /// </summary>
+        [Fact]
+        public void Should_Register_View_For_Navigation()
+        {
+            // Given
+            Locator.CurrentMutable.RegisterViewForNavigation(new PageView(), new NavigableViewModelMock());
 
-                // When
-                var result = Locator.Current.GetService<NavigableViewModelMock>();
+            // When
+            var result = Locator.Current.GetService<IViewFor<NavigableViewModelMock>>();
 
-                // Then
-                result.Should().NotBeNull();
-            }
+            // Then
+            result.Should().BeOfType<PageView>();
+        }
+
+        /// <summary>
+        /// Should register the view for navigation.
+        /// </summary>
+        [Fact]
+        public void Should_Register_ViewModel_For_Navigation()
+        {
+            // Given
+            Locator.CurrentMutable.RegisterViewForNavigation(() => new PageView(), () => new NavigableViewModelMock());
+
+            // When
+            var result = Locator.Current.GetService<NavigableViewModelMock>();
+
+            // Then
+            result.Should().NotBeNull();
         }
     }
 }

--- a/src/Sextant.Tests/Navigation/DestructibleTests.cs
+++ b/src/Sextant.Tests/Navigation/DestructibleTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -7,58 +7,62 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
+using ReactiveUI;
 using Sextant.Mocks;
+using Splat;
 using Xunit;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Test a <see cref="IDestructible"/> implementation.
+/// </summary>
+public sealed class DestructibleTests
 {
     /// <summary>
-    /// Test a <see cref="IDestructible"/> implementation.
+    /// Tests the destroy method.
     /// </summary>
-    public sealed class DestructibleTests
+    public class TheDestroyMethod
     {
         /// <summary>
-        /// Tests the destroy method.
+        /// Should unwrap the parameters.
         /// </summary>
-        public class TheDestroyMethod
+        [Fact]
+        public void Should_Destroy()
         {
-            /// <summary>
-            /// Should unwrap the parameters.
-            /// </summary>
-            [Fact]
-            public void Should_Destroy()
-            {
-                // Given
-                ParameterViewModel sut = new();
+            // Given
+            ParameterViewModel sut = new();
 
-                // When
-                sut.Disposable.IsDisposed.Should().BeFalse();
-                sut.Destroy();
+            // When
+            sut.Disposable.IsDisposed.Should().BeFalse();
+            sut.Destroy();
 
-                // Then
-                sut.Disposable.IsDisposed.Should().BeTrue();
-            }
+            // Then
+            sut.Disposable.IsDisposed.Should().BeTrue();
+        }
 
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_When_Page_Popped()
-            {
-                // Given
-                var viewModel1 = Substitute.For<IDestructibleMock>();
-                var viewModel2 = Substitute.For<IDestructibleMock>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_When_Page_Popped()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
 
-                // When
-                await sut.PushPage(viewModel1);
-                await sut.PushPage(viewModel2);
-                await sut.PopPage();
+            // Given
+            var viewModel1 = Substitute.For<IDestructibleMock>();
+            var viewModel2 = Substitute.For<IDestructibleMock>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
 
-                // Then
-                viewModel2.Received(1).Destroy();
-            }
+            // When
+            await sut.PushPage(viewModel1);
+            await sut.PushPage(viewModel2);
+            await sut.PopPage();
+
+            // Then
+            viewModel2.Received(1).Destroy();
         }
     }
 }

--- a/src/Sextant.Tests/Navigation/NavigatedTests.cs
+++ b/src/Sextant.Tests/Navigation/NavigatedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -9,105 +9,104 @@ using FluentAssertions;
 using Sextant.Mocks;
 using Xunit;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Test a <see cref="INavigated"/> implementation.
+/// </summary>
+public sealed class NavigatedTests
 {
     /// <summary>
-    /// Test a <see cref="INavigated"/> implementation.
+    /// Tests the WhenNavigatedTo method.
     /// </summary>
-    public sealed class NavigatedTests
+    public sealed class TheWhenNavigatedToMethod
     {
         /// <summary>
-        /// Tests the WhenNavigatedTo method.
+        /// Should unwrap the parameters.
         /// </summary>
-        public sealed class TheWhenNavigatedToMethod
+        [Fact]
+        public void Should_Unwrap_Parameters()
         {
-            /// <summary>
-            /// Should unwrap the parameters.
-            /// </summary>
-            [Fact]
-            public void Should_Unwrap_Parameters()
-            {
-                // Given
-                ParameterViewModel sut = new();
+            // Given
+            ParameterViewModel sut = new();
 
-                // When
-                sut.WhenNavigatedTo(new NavigationParameter { { "hello", "world" }, { "life", 42 } }).Subscribe();
+            // When
+            sut.WhenNavigatedTo(new NavigationParameter { { "hello", "world" }, { "life", 42 } }).Subscribe();
 
-                // Then
-                sut.Text.Should().Be("world");
-                sut.Meaning.Should().Be(42);
-            }
-
-            /// <summary>
-            /// Should return null if no values are provided for the parameter.
-            /// </summary>
-            [Fact]
-            public void Should_Return_Null_If_No_Values_Provided()
-            {
-                // Given
-                ParameterViewModel sut = new();
-
-                // When
-                sut.WhenNavigatedTo(new NavigationParameter());
-
-                // Then
-                sut.Text.Should().BeNull();
-            }
-
-            /// <summary>
-            /// Should not throw if key not found.
-            /// </summary>
-            [Fact]
-            public void Should_Throw_If_Key_Not_Found()
-            {
-                // Given
-                ParameterViewModel sut = new();
-
-                // When
-                var result = Record.Exception(() => sut.WhenNavigatedTo(new NavigationParameter { { "hello", "world" } }).Subscribe());
-
-                // Then
-                result.Should().BeOfType<KeyNotFoundException>();
-            }
+            // Then
+            sut.Text.Should().Be("world");
+            sut.Meaning.Should().Be(42);
         }
 
         /// <summary>
-        /// Tests the WhenNavigatedTo method.
+        /// Should return null if no values are provided for the parameter.
         /// </summary>
-        public sealed class TheWhenNavigatedFromMethod
+        [Fact]
+        public void Should_Return_Null_If_No_Values_Provided()
         {
-            /// <summary>
-            /// Should unwrap the parameters.
-            /// </summary>
-            [Fact]
-            public void Should_Unwrap_Parameters()
-            {
-                // Given
-                ParameterViewModel sut = new();
+            // Given
+            ParameterViewModel sut = new();
 
-                // When
-                sut.WhenNavigatedFrom(new NavigationParameter { { "hello", "world" }, { "life", 42 } }).Subscribe();
+            // When
+            sut.WhenNavigatedTo(new NavigationParameter());
 
-                // Then
-                sut.Text.Should().Be("world");
-                sut.Meaning.Should().Be(42);
-            }
+            // Then
+            sut.Text.Should().BeNull();
+        }
 
-            /// <summary>
-            /// Should not throw if key not found.
-            /// </summary>
-            [Fact]
-            public void Should_Throw_If_Key_Not_Found()
-            {
-                // Given
-                ParameterViewModel sut = new();
+        /// <summary>
+        /// Should not throw if key not found.
+        /// </summary>
+        [Fact]
+        public void Should_Throw_If_Key_Not_Found()
+        {
+            // Given
+            ParameterViewModel sut = new();
 
-                // When
-                var result = Record.Exception(() => sut.WhenNavigatedFrom(new NavigationParameter { { "hello", "world" } }).Subscribe());
+            // When
+            var result = Record.Exception(() => sut.WhenNavigatedTo(new NavigationParameter { { "hello", "world" } }).Subscribe());
 
-                // Then
-                result.Should().BeOfType<KeyNotFoundException>();
-            }
+            // Then
+            result.Should().BeOfType<KeyNotFoundException>();
+        }
+    }
+
+    /// <summary>
+    /// Tests the WhenNavigatedTo method.
+    /// </summary>
+    public sealed class TheWhenNavigatedFromMethod
+    {
+        /// <summary>
+        /// Should unwrap the parameters.
+        /// </summary>
+        [Fact]
+        public void Should_Unwrap_Parameters()
+        {
+            // Given
+            ParameterViewModel sut = new();
+
+            // When
+            sut.WhenNavigatedFrom(new NavigationParameter { { "hello", "world" }, { "life", 42 } }).Subscribe();
+
+            // Then
+            sut.Text.Should().Be("world");
+            sut.Meaning.Should().Be(42);
+        }
+
+        /// <summary>
+        /// Should not throw if key not found.
+        /// </summary>
+        [Fact]
+        public void Should_Throw_If_Key_Not_Found()
+        {
+            // Given
+            ParameterViewModel sut = new();
+
+            // When
+            var result = Record.Exception(() => sut.WhenNavigatedFrom(new NavigationParameter { { "hello", "world" } }).Subscribe());
+
+            // Then
+            result.Should().BeOfType<KeyNotFoundException>();
         }
     }
 }

--- a/src/Sextant.Tests/Navigation/NavigatingTests.cs
+++ b/src/Sextant.Tests/Navigation/NavigatingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -9,50 +9,49 @@ using FluentAssertions;
 using Sextant.Mocks;
 using Xunit;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Test a <see cref="INavigating"/> implementation.
+/// </summary>
+public sealed class NavigatingTests
 {
     /// <summary>
-    /// Test a <see cref="INavigating"/> implementation.
+    /// Tests the WhenNavigatingTo method.
     /// </summary>
-    public sealed class NavigatingTests
+    public sealed class TheWhenNavigatingToMethod
     {
         /// <summary>
-        /// Tests the WhenNavigatingTo method.
+        /// Should unwrap the parameters.
         /// </summary>
-        public sealed class TheWhenNavigatingToMethod
+        [Fact]
+        public void Should_Unwrap_Parameters()
         {
-            /// <summary>
-            /// Should unwrap the parameters.
-            /// </summary>
-            [Fact]
-            public void Should_Unwrap_Parameters()
-            {
-                // Given
-                ParameterViewModel sut = new();
+            // Given
+            ParameterViewModel sut = new();
 
-                // When
-                sut.WhenNavigatingTo(new NavigationParameter { { "hello", "world" }, { "life", 42 } }).Subscribe();
+            // When
+            sut.WhenNavigatingTo(new NavigationParameter { { "hello", "world" }, { "life", 42 } }).Subscribe();
 
-                // Then
-                sut.Text.Should().Be("world");
-                sut.Meaning.Should().Be(42);
-            }
+            // Then
+            sut.Text.Should().Be("world");
+            sut.Meaning.Should().Be(42);
+        }
 
-            /// <summary>
-            /// Should not throw if key not found.
-            /// </summary>
-            [Fact]
-            public void Should_Throw_If_Key_Not_Found()
-            {
-                // Given
-                ParameterViewModel sut = new();
+        /// <summary>
+        /// Should not throw if key not found.
+        /// </summary>
+        [Fact]
+        public void Should_Throw_If_Key_Not_Found()
+        {
+            // Given
+            ParameterViewModel sut = new();
 
-                // When
-                var result = Record.Exception(() => sut.WhenNavigatingTo(new NavigationParameter { { "hello", "world" } }).Subscribe());
+            // When
+            var result = Record.Exception(() => sut.WhenNavigatingTo(new NavigationParameter { { "hello", "world" } }).Subscribe());
 
-                // Then
-                result.Should().BeOfType<KeyNotFoundException>();
-            }
+            // Then
+            result.Should().BeOfType<KeyNotFoundException>();
         }
     }
 }

--- a/src/Sextant.Tests/Navigation/NavigationParameterTests.cs
+++ b/src/Sextant.Tests/Navigation/NavigationParameterTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -7,97 +7,96 @@ using System;
 using FluentAssertions;
 using Xunit;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Tests <see cref="NavigationParameter"/> and extensions.
+/// </summary>
+public static class NavigationParameterTests
 {
     /// <summary>
-    /// Tests <see cref="NavigationParameter"/> and extensions.
+    /// Tests the get value method.
     /// </summary>
-    public static class NavigationParameterTests
+    public sealed class TheGetValueMethod
     {
         /// <summary>
-        /// Tests the get value method.
+        /// Tests the method gets a value.
         /// </summary>
-        public sealed class TheGetValueMethod
+        [Fact]
+        public void Should_Get_Value()
         {
-            /// <summary>
-            /// Tests the method gets a value.
-            /// </summary>
-            [Fact]
-            public void Should_Get_Value()
-            {
-                // Given
-                NavigationParameter sut = new();
-                sut.Add("key", TimeSpan.Zero);
+            // Given
+            NavigationParameter sut = new();
+            sut.Add("key", TimeSpan.Zero);
 
-                // When
-                var result = sut.GetValue<TimeSpan>("key");
+            // When
+            var result = sut.GetValue<TimeSpan>("key");
 
-                // Then
-                result
-                    .Should()
-                    .Be(TimeSpan.Zero);
-            }
-
-            /// <summary>
-            /// Tests the method gets a value.
-            /// </summary>
-            [Fact]
-            public void Should_Get_Default_Value()
-            {
-                // Given
-                NavigationParameter sut = new();
-
-                // When
-                var result = sut.GetValue<TimeSpan>("key");
-
-                // Then
-                result
-                    .Should()
-                    .Be(TimeSpan.Zero);
-            }
+            // Then
+            result
+                .Should()
+                .Be(TimeSpan.Zero);
         }
 
         /// <summary>
-        /// Test the try get value method.
+        /// Tests the method gets a value.
         /// </summary>
-        public sealed class TheTryGetValueMethod
+        [Fact]
+        public void Should_Get_Default_Value()
         {
-            /// <summary>
-            /// Tests the method tries to gets a value.
-            /// </summary>
-            [Fact]
-            public void Should_Try_Get_Value()
-            {
-                // Given
-                NavigationParameter sut = new();
-                sut.Add("key", TimeSpan.Zero);
+            // Given
+            NavigationParameter sut = new();
 
-                // When
-                var result = sut.TryGetValue<TimeSpan>("key", out var value);
+            // When
+            var result = sut.GetValue<TimeSpan>("key");
 
-                // Then
-                result
-                    .Should()
-                    .BeTrue();
-            }
+            // Then
+            result
+                .Should()
+                .Be(TimeSpan.Zero);
+        }
+    }
 
-            /// <summary>
-            /// Tests the method tries to gets a value.
-            /// </summary>
-            [Fact]
-            public void Should_Not_Try_Get_Value()
-            {
-                // Given
-                NavigationParameter sut = new();
+    /// <summary>
+    /// Test the try get value method.
+    /// </summary>
+    public sealed class TheTryGetValueMethod
+    {
+        /// <summary>
+        /// Tests the method tries to gets a value.
+        /// </summary>
+        [Fact]
+        public void Should_Try_Get_Value()
+        {
+            // Given
+            NavigationParameter sut = new();
+            sut.Add("key", TimeSpan.Zero);
 
-                // When
-                var result = sut.TryGetValue<TimeSpan>("key", out var value);
+            // When
+            var result = sut.TryGetValue<TimeSpan>("key", out var value);
 
-                // Then
-                result
-                    .Should()
-                    .BeFalse();
-            }
+            // Then
+            result
+                .Should()
+                .BeTrue();
+        }
+
+        /// <summary>
+        /// Tests the method tries to gets a value.
+        /// </summary>
+        [Fact]
+        public void Should_Not_Try_Get_Value()
+        {
+            // Given
+            NavigationParameter sut = new();
+
+            // When
+            var result = sut.TryGetValue<TimeSpan>("key", out var value);
+
+            // Then
+            result
+                .Should()
+                .BeFalse();
         }
     }
 }

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceFixture.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -10,53 +10,52 @@ using NSubstitute;
 using ReactiveUI.Testing;
 using Sextant.Mocks;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// A fixture for the view stack.
+/// </summary>
+internal class ParameterViewStackServiceFixture : IBuilder
 {
+    private IView _view;
+    private IViewModelFactory _viewModelFactory;
+
     /// <summary>
-    /// A fixture for the view stack.
+    /// Initializes a new instance of the <see cref="ParameterViewStackServiceFixture"/> class.
     /// </summary>
-    internal class ParameterViewStackServiceFixture : IBuilder
+    public ParameterViewStackServiceFixture()
     {
-        private IView _view;
-        private IViewModelFactory _viewModelFactory;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ParameterViewStackServiceFixture"/> class.
-        /// </summary>
-        public ParameterViewStackServiceFixture()
-        {
-            _view = Substitute.For<IView>();
-            _view.PushPage(Arg.Any<INavigable>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
-                .Returns(Observable.Return(Unit.Default));
-            _view.PopPage().Returns(Observable.Return(Unit.Default));
-            _viewModelFactory = Substitute.For<IViewModelFactory>();
-            _viewModelFactory.Create<NavigableViewModelMock>(Arg.Any<string>()).Returns(new NavigableViewModelMock());
-        }
-
-        public static implicit operator ParameterViewStackService(ParameterViewStackServiceFixture fixture) =>
-            fixture.Build();
-
-        public ParameterViewStackServiceFixture WithView(IView view) => this.With(out _view, view);
-
-        public ParameterViewStackService WithPushed<TViewModel>(TViewModel viewModel)
-            where TViewModel : INavigable
-        {
-            var stack = Build();
-            stack.PushPage(viewModel).Subscribe();
-            return stack;
-        }
-
-        public ParameterViewStackService WithModal<TViewModel>(TViewModel viewModel)
-            where TViewModel : INavigable
-        {
-            var stack = Build();
-            stack.PushModal(viewModel).Subscribe();
-            return stack;
-        }
-
-        public ParameterViewStackService WithFactory(IViewModelFactory viewModelFactory) =>
-            this.With(out _viewModelFactory, viewModelFactory);
-
-        private ParameterViewStackService Build() => new(_view, _viewModelFactory);
+        _view = Substitute.For<IView>();
+        _view.PushPage(Arg.Any<INavigable>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+            .Returns(Observable.Return(Unit.Default));
+        _view.PopPage().Returns(Observable.Return(Unit.Default));
+        _viewModelFactory = Substitute.For<IViewModelFactory>();
+        _viewModelFactory.Create<NavigableViewModelMock>(Arg.Any<string>()).Returns(new NavigableViewModelMock());
     }
+
+    public static implicit operator ParameterViewStackService(ParameterViewStackServiceFixture fixture) =>
+        fixture.Build();
+
+    public ParameterViewStackServiceFixture WithView(IView view) => this.With(out _view, view);
+
+    public ParameterViewStackService WithPushed<TViewModel>(TViewModel viewModel)
+        where TViewModel : INavigable
+    {
+        var stack = Build();
+        stack.PushPage(viewModel).Subscribe();
+        return stack;
+    }
+
+    public ParameterViewStackService WithModal<TViewModel>(TViewModel viewModel)
+        where TViewModel : INavigable
+    {
+        var stack = Build();
+        stack.PushModal(viewModel).Subscribe();
+        return stack;
+    }
+
+    public ParameterViewStackService WithFactory(IViewModelFactory viewModelFactory) =>
+        this.With(out _viewModelFactory, viewModelFactory);
+
+    private ParameterViewStackService Build() => new(_view, _viewModelFactory);
 }

--- a/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ParameterViewStackServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -9,731 +9,767 @@ using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
+using ReactiveUI;
 using Sextant.Mocks;
 using Splat;
 using Xunit;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Tests the <see cref="ParameterViewStackService"/>.
+/// </summary>
+public sealed class ParameterViewStackServiceTests
 {
     /// <summary>
-    /// Tests the <see cref="ParameterViewStackService"/>.
+    /// Tests the construction of the object.
     /// </summary>
-    public sealed class ParameterViewStackServiceTests
+    public class TheConstructor
     {
         /// <summary>
-        /// Tests the construction of the object.
+        /// Initializes a new instance of the <see cref="TheConstructor"/> class.
         /// </summary>
-        public class TheConstructor
+        public TheConstructor()
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="TheConstructor"/> class.
-            /// </summary>
-            public TheConstructor() => Locator.GetLocator().UnregisterAll<IViewModelFactory>();
-
-            /// <summary>
-            /// Test that the object constructed uses a new instance of ViewModelFactory.
-            /// </summary>
-            [Fact]
-            public void Should_Not_Throw_If_View_Model_Factory_Current_Null()
-            {
-                // Given, When
-                var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null!));
-
-                // Then
-                result.Should().BeNull();
-            }
-
-            /// <summary>
-            /// Test that the object constructed uses the static instance of ViewModelFactory.
-            /// </summary>
-            [Fact]
-            public void Should_Resolve_View_Model_Factory()
-            {
-                // Given
-                Locator.CurrentMutable.RegisterViewModelFactory();
-
-                // When
-                var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null!));
-
-                // Then
-                result.Should().BeNull();
-            }
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
+            Locator.GetLocator().UnregisterAll<IViewModelFactory>();
         }
 
         /// <summary>
-        /// Tests the push page method that passes parameters.
+        /// Test that the object constructed uses a new instance of ViewModelFactory.
         /// </summary>
-        public class ThePushPageWithParameterMethod
+        [Fact]
+        public void Should_Not_Throw_If_View_Model_Factory_Current_Null()
         {
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_View_Model_Null()
-            {
-                // Given
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+            // Given, When
+            var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null!));
 
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushPage(null!, navigationParameter))
-                        .ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("navigableViewModel");
-            }
-
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_Parameter_Null()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushPage(viewModel, null!))
-                        .ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_When_Navigating_To()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                await sut.PushPage(viewModel, navigationParameter);
-
-                // Then
-                await viewModel.Received().WhenNavigatingTo(navigationParameter);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_When_Navigated_To()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                await sut.PushPage(viewModel, navigationParameter);
-
-                // Then
-                await viewModel.Received().WhenNavigatedTo(navigationParameter);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Not_Call_When_Navigated_From()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                await sut.PushPage(viewModel, navigationParameter);
-
-                // Then
-                await viewModel.DidNotReceive().WhenNavigatedFrom(navigationParameter);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a navigation methods in the correct order.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_In_Order()
-            {
-                // Given
-                var view = Substitute.For<IView>();
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-
-                // When
-                await sut.PushPage(viewModel, navigationParameter);
-
-                // Then
-                Received.InOrder(() =>
-                {
-                    viewModel.WhenNavigatingTo(Arg.Any<INavigationParameter>());
-                    view.PushPage(Arg.Any<IViewModel>(), null, Arg.Any<bool>(), Arg.Any<bool>());
-                    viewModel.WhenNavigatedTo(Arg.Any<INavigationParameter>());
-                });
-            }
-
-            /// <summary>Tests to make sure we receive a push page notification.</summary>
-            /// <param name="contract">The contract.</param>
-            /// <param name="reset">Reset the stack.</param>
-            /// <param name="animate">Animate the navigation.</param>
-            /// <returns>A completion notification.</returns>
-            [Theory]
-            [InlineData(null, false, true)]
-            [InlineData(null, true, false)]
-            [InlineData("hello", true, true)]
-            [InlineData("hello", true, false)]
-            [InlineData("hello", false, true)]
-            [InlineData("hello", false, false)]
-            public async Task Should_Call_View(string? contract, bool reset, bool animate)
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var view = Substitute.For<IView>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-
-                // When
-                await sut.PushPage(viewModel, navigationParameter, contract, reset, animate);
-
-                // Then
-                await view.Received().PushPage(viewModel, contract, reset, animate);
-            }
+            // Then
+            result.Should().BeNull();
         }
 
         /// <summary>
-        /// Tests the push page generic method that passes parameters.
+        /// Test that the object constructed uses the static instance of ViewModelFactory.
         /// </summary>
-        public class ThePushPageGenericWithParameterMethod
+        [Fact]
+        public void Should_Resolve_View_Model_Factory()
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ThePushPageGenericWithParameterMethod"/> class.
-            /// </summary>
-            public ThePushPageGenericWithParameterMethod()
-            {
-                Locator.CurrentMutable.UnregisterAll<NavigableViewModelMock>();
-                Locator.CurrentMutable.Register(() => new NavigableViewModelMock());
-            }
+            // Given
+            Locator.CurrentMutable.RegisterViewModelFactory();
 
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_View_Model_Null()
-            {
-                // Given
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+            // When
+            var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null!));
 
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushPage<NullViewModelMock>(navigationParameter))
-                        .ConfigureAwait(true);
+            // Then
+            result.Should().BeNull();
+        }
+    }
 
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("navigableViewModel");
-            }
-
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_Parameter_Null()
-            {
-                // Given
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushPage<NavigableViewModelMock>(null!))
-                        .ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <param name="contract">The contract.</param>
-            /// <param name="reset">Reset the stack.</param>
-            /// <param name="animate">Animate the navigation.</param>
-            /// <returns>A completion notification.</returns>
-            [Theory]
-            [InlineData(null, false, true)]
-            [InlineData(null, true, false)]
-            [InlineData("hello", true, true)]
-            [InlineData("hello", true, false)]
-            [InlineData("hello", false, true)]
-            [InlineData("hello", false, false)]
-            public async Task Should_Call_View(string? contract, bool reset, bool animate)
-            {
-                // Given
-                var view = Substitute.For<IView>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-
-                // When
-                await sut.PushPage<NavigableViewModelMock>(navigationParameter, contract, reset, animate);
-
-                // Then
-                await view.Received().PushPage(Arg.Any<NavigableViewModelMock>(), contract, reset, animate);
-            }
-
-            /// <summary>
-            /// Tests the view model factory is called.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_ViewModel_Factory()
-            {
-                // Given
-                var factory = Substitute.For<IViewModelFactory>();
-                factory.Create<NavigableViewModelMock>().Returns(new NavigableViewModelMock());
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                var sut = new ParameterViewStackServiceFixture().WithFactory(factory);
-
-                // When
-                await sut.PushPage<NavigableViewModelMock>(navigationParameter);
-
-                // Then
-                factory.Received().Create<NavigableViewModelMock>();
-            }
+    /// <summary>
+    /// Tests the push page method that passes parameters.
+    /// </summary>
+    public class ThePushPageWithParameterMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThePushPageWithParameterMethod"/> class.
+        /// </summary>
+        public ThePushPageWithParameterMethod()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
         }
 
         /// <summary>
-        /// Tests the push modal method that passes parameters.
+        /// Should the throw if view model null.
         /// </summary>
-        public class ThePushModalWithParameterMethod
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_View_Model_Null()
         {
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_View_Model_Null()
-            {
-                // Given
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+            // Given
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
 
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushModal(null!, navigationParameter))
-                        .ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("navigableModal");
-            }
-
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_Parameter_Null()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushModal(viewModel, null!))
-                        .ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <param name="contract">The contract.</param>
-            /// <param name="withNavigation">Wrap model in navigation page.</param>
-            /// <returns>A completion notification.</returns>
-            [Theory]
-            [InlineData(null, false)]
-            [InlineData(null, true)]
-            [InlineData("hello", true)]
-            [InlineData("hello", false)]
-            public async Task Should_Call_View(string? contract, bool withNavigation)
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                var view = Substitute.For<IView>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-
-                // When
-                await sut.PushModal(viewModel, navigationParameter, contract, withNavigation);
-
-                // Then
-                await view.Received().PushModal(viewModel, contract, withNavigation);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_When_Navigating_To()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                await sut.PushModal(viewModel, navigationParameter);
-
-                // Then
-                await viewModel.Received().WhenNavigatingTo(navigationParameter);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_When_Navigated_To()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                await sut.PushModal(viewModel, navigationParameter);
-
-                // Then
-                await viewModel.Received().WhenNavigatedTo(navigationParameter);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Not_Call_When_Navigated_From()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                await sut.PushModal(viewModel, navigationParameter);
-
-                // Then
-                await viewModel.DidNotReceive().WhenNavigatedFrom(navigationParameter);
-            }
-        }
-
-        /// <summary>
-        /// Tests the push modal page method that passes parameters.
-        /// </summary>
-        public class ThePushModalGenericWithParameterMethod
-        {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ThePushModalGenericWithParameterMethod"/> class.
-            /// </summary>
-            public ThePushModalGenericWithParameterMethod()
-            {
-                Locator.CurrentMutable.UnregisterAll<NavigableViewModelMock>();
-                Locator.CurrentMutable.UnregisterAll<IViewModelFactory>();
-                Locator.CurrentMutable.Register(() => new DefaultViewModelFactory(), typeof(IViewModelFactory));
-                Locator.CurrentMutable.Register(() => new NavigableViewModelMock());
-                Locator.CurrentMutable.UnregisterAll<NullViewModelMock>();
-            }
-
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_View_Model_Null()
-            {
-                // Given
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushModal<NullViewModelMock>(navigationParameter))
-                        .ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("navigableModal");
-            }
-
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_Parameter_Null()
-            {
-                // Given
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushModal<NavigableViewModelMock>(null!))
-                        .ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <param name="contract">The contract.</param>
-            /// <param name="withNavigation">Wrap model in navigation page.</param>
-            /// <returns>A completion notification.</returns>
-            [Theory]
-            [InlineData(null, false)]
-            [InlineData(null, true)]
-            [InlineData("hello", true)]
-            [InlineData("hello", false)]
-            public async Task Should_Call_View(string? contract, bool withNavigation)
-            {
-                // Given
-                var view = Substitute.For<IView>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-
-                // When
-                await sut.PushModal<NavigableViewModelMock>(navigationParameter, contract, withNavigation);
-
-                // Then
-                await view.Received().PushModal(Arg.Any<NavigableViewModelMock>(), contract, withNavigation);
-            }
-
-            /// <summary>
-            /// Tests the view model factory is called.
-            /// </summary>
-            /// <param name="contract">The contract.</param>
-            /// <returns>A completion notification.</returns>
-            [Theory]
-            [InlineData("")]
-            [InlineData(null)]
-            [InlineData("contract")]
-            public async Task Should_Call_ViewModel_Factory(string? contract)
-            {
-                // Given
-                var factory = Substitute.For<IViewModelFactory>();
-                factory.Create<NavigableViewModelMock>(Arg.Any<string?>()).Returns(new NavigableViewModelMock());
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                var sut = new ParameterViewStackServiceFixture().WithFactory(factory);
-
-                // When
-                await sut.PushModal<NavigableViewModelMock>(navigationParameter, contract);
-
-                // Then
-                factory.Received().Create<NavigableViewModelMock>(contract);
-            }
-        }
-
-        /// <summary>
-        /// Tests the pop page method that passes parameters.
-        /// </summary>
-        public class ThePopPageWithParameterMethod
-        {
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_Parameter_Null()
-            {
-                // Given
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
-
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PopPage(null!))
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushPage(null!, navigationParameter))
                     .ConfigureAwait(true);
 
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
-            }
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("navigableViewModel");
+        }
 
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_View()
+        /// <summary>
+        /// Should the throw if view model null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_Parameter_Null()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushPage(viewModel, null!))
+                    .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_When_Navigating_To()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            await sut.PushPage(viewModel, navigationParameter);
+
+            // Then
+            await viewModel.Received().WhenNavigatingTo(navigationParameter);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_When_Navigated_To()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            await sut.PushPage(viewModel, navigationParameter);
+
+            // Then
+            await viewModel.Received().WhenNavigatedTo(navigationParameter);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Not_Call_When_Navigated_From()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            await sut.PushPage(viewModel, navigationParameter);
+
+            // Then
+            await viewModel.DidNotReceive().WhenNavigatedFrom(navigationParameter);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a navigation methods in the correct order.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_In_Order()
+        {
+            // Given
+            var view = Substitute.For<IView>();
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+
+            // When
+            await sut.PushPage(viewModel, navigationParameter);
+
+            // Then
+            Received.InOrder(() =>
             {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                var view = Substitute.For<IView>();
-                var sut = new ParameterViewStackServiceFixture().WithView(view).WithPushed(viewModel);
+                viewModel.WhenNavigatingTo(Arg.Any<INavigationParameter>());
+                view.PushPage(Arg.Any<IViewModel>(), null, Arg.Any<bool>(), Arg.Any<bool>());
+                viewModel.WhenNavigatedTo(Arg.Any<INavigationParameter>());
+            });
+        }
 
-                // When
-                await sut.PopPage(navigationParameter);
+        /// <summary>Tests to make sure we receive a push page notification.</summary>
+        /// <param name="contract">The contract.</param>
+        /// <param name="reset">Reset the stack.</param>
+        /// <param name="animate">Animate the navigation.</param>
+        /// <returns>A completion notification.</returns>
+        [Theory]
+        [InlineData(null, false, true)]
+        [InlineData(null, true, false)]
+        [InlineData("hello", true, true)]
+        [InlineData("hello", true, false)]
+        [InlineData("hello", false, true)]
+        [InlineData("hello", false, false)]
+        public async Task Should_Call_View(string? contract, bool reset, bool animate)
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var view = Substitute.For<IView>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
 
-                // Then
-                await view.Received().PopPage(Arg.Any<bool>());
-            }
+            // When
+            await sut.PushPage(viewModel, navigationParameter, contract, reset, animate);
 
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_Destroy()
+            // Then
+            await view.Received().PushPage(viewModel, contract, reset, animate);
+        }
+    }
+
+    /// <summary>
+    /// Tests the push page generic method that passes parameters.
+    /// </summary>
+    public class ThePushPageGenericWithParameterMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThePushPageGenericWithParameterMethod"/> class.
+        /// </summary>
+        public ThePushPageGenericWithParameterMethod()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
+            Locator.CurrentMutable.UnregisterAll<NavigableViewModelMock>();
+            Locator.CurrentMutable.Register(() => new NavigableViewModelMock());
+        }
+
+        /// <summary>
+        /// Should the throw if view model null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_View_Model_Null()
+        {
+            // Given
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushPage<NullViewModelMock>(navigationParameter))
+                    .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("navigableViewModel");
+        }
+
+        /// <summary>
+        /// Should the throw if view model null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_Parameter_Null()
+        {
+            // Given
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushPage<NavigableViewModelMock>(null!))
+                    .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <param name="contract">The contract.</param>
+        /// <param name="reset">Reset the stack.</param>
+        /// <param name="animate">Animate the navigation.</param>
+        /// <returns>A completion notification.</returns>
+        [Theory]
+        [InlineData(null, false, true)]
+        [InlineData(null, true, false)]
+        [InlineData("hello", true, true)]
+        [InlineData("hello", true, false)]
+        [InlineData("hello", false, true)]
+        [InlineData("hello", false, false)]
+        public async Task Should_Call_View(string? contract, bool reset, bool animate)
+        {
+            // Given
+            var view = Substitute.For<IView>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+
+            // When
+            await sut.PushPage<NavigableViewModelMock>(navigationParameter, contract, reset, animate);
+
+            // Then
+            await view.Received().PushPage(Arg.Any<NavigableViewModelMock>(), contract, reset, animate);
+        }
+
+        /// <summary>
+        /// Tests the view model factory is called.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_ViewModel_Factory()
+        {
+            // Given
+            var factory = Substitute.For<IViewModelFactory>();
+            factory.Create<NavigableViewModelMock>().Returns(new NavigableViewModelMock());
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            var sut = new ParameterViewStackServiceFixture().WithFactory(factory);
+
+            // When
+            await sut.PushPage<NavigableViewModelMock>(navigationParameter);
+
+            // Then
+            factory.Received().Create<NavigableViewModelMock>();
+        }
+    }
+
+    /// <summary>
+    /// Tests the push modal method that passes parameters.
+    /// </summary>
+    public class ThePushModalWithParameterMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThePushModalWithParameterMethod"/> class.
+        /// </summary>
+        public ThePushModalWithParameterMethod()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
+        }
+
+        /// <summary>
+        /// Should the throw if view model null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_View_Model_Null()
+        {
+            // Given
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushModal(null!, navigationParameter))
+                    .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("navigableModal");
+        }
+
+        /// <summary>
+        /// Should the throw if view model null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_Parameter_Null()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushModal(viewModel, null!))
+                    .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <param name="contract">The contract.</param>
+        /// <param name="withNavigation">Wrap model in navigation page.</param>
+        /// <returns>A completion notification.</returns>
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(null, true)]
+        [InlineData("hello", true)]
+        [InlineData("hello", false)]
+        public async Task Should_Call_View(string? contract, bool withNavigation)
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            var view = Substitute.For<IView>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+
+            // When
+            await sut.PushModal(viewModel, navigationParameter, contract, withNavigation);
+
+            // Then
+            await view.Received().PushModal(viewModel, contract, withNavigation);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_When_Navigating_To()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            await sut.PushModal(viewModel, navigationParameter);
+
+            // Then
+            await viewModel.Received().WhenNavigatingTo(navigationParameter);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_When_Navigated_To()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            await sut.PushModal(viewModel, navigationParameter);
+
+            // Then
+            await viewModel.Received().WhenNavigatedTo(navigationParameter);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Not_Call_When_Navigated_From()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            await sut.PushModal(viewModel, navigationParameter);
+
+            // Then
+            await viewModel.DidNotReceive().WhenNavigatedFrom(navigationParameter);
+        }
+    }
+
+    /// <summary>
+    /// Tests the push modal page method that passes parameters.
+    /// </summary>
+    public class ThePushModalGenericWithParameterMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThePushModalGenericWithParameterMethod"/> class.
+        /// </summary>
+        public ThePushModalGenericWithParameterMethod()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
+            Locator.CurrentMutable.UnregisterAll<NavigableViewModelMock>();
+            Locator.CurrentMutable.UnregisterAll<IViewModelFactory>();
+            Locator.CurrentMutable.Register(() => new DefaultViewModelFactory(), typeof(IViewModelFactory));
+            Locator.CurrentMutable.Register(() => new NavigableViewModelMock());
+            Locator.CurrentMutable.UnregisterAll<NullViewModelMock>();
+        }
+
+        /// <summary>
+        /// Should the throw if view model null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_View_Model_Null()
+        {
+            // Given
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushModal<NullViewModelMock>(navigationParameter))
+                    .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("navigableModal");
+        }
+
+        /// <summary>
+        /// Should the throw if view model null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_Parameter_Null()
+        {
+            // Given
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushModal<NavigableViewModelMock>(null!))
+                    .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <param name="contract">The contract.</param>
+        /// <param name="withNavigation">Wrap model in navigation page.</param>
+        /// <returns>A completion notification.</returns>
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData(null, true)]
+        [InlineData("hello", true)]
+        [InlineData("hello", false)]
+        public async Task Should_Call_View(string? contract, bool withNavigation)
+        {
+            // Given
+            var view = Substitute.For<IView>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+
+            // When
+            await sut.PushModal<NavigableViewModelMock>(navigationParameter, contract, withNavigation);
+
+            // Then
+            await view.Received().PushModal(Arg.Any<NavigableViewModelMock>(), contract, withNavigation);
+        }
+
+        /// <summary>
+        /// Tests the view model factory is called.
+        /// </summary>
+        /// <param name="contract">The contract.</param>
+        /// <returns>A completion notification.</returns>
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("contract")]
+        public async Task Should_Call_ViewModel_Factory(string? contract)
+        {
+            // Given
+            var factory = Substitute.For<IViewModelFactory>();
+            factory.Create<NavigableViewModelMock>(Arg.Any<string?>()).Returns(new NavigableViewModelMock());
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            var sut = new ParameterViewStackServiceFixture().WithFactory(factory);
+
+            // When
+            await sut.PushModal<NavigableViewModelMock>(navigationParameter, contract);
+
+            // Then
+            factory.Received().Create<NavigableViewModelMock>(contract);
+        }
+    }
+
+    /// <summary>
+    /// Tests the pop page method that passes parameters.
+    /// </summary>
+    public class ThePopPageWithParameterMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThePopPageWithParameterMethod"/> class.
+        /// </summary>
+        public ThePopPageWithParameterMethod()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
+        }
+
+        /// <summary>
+        /// Should the throw if view model null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_Parameter_Null()
+        {
+            // Given
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PopPage(null!))
+                .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("parameter");
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_View()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            var view = Substitute.For<IView>();
+            var sut = new ParameterViewStackServiceFixture().WithView(view).WithPushed(viewModel);
+
+            // When
+            await sut.PopPage(navigationParameter);
+
+            // Then
+            await view.Received().PopPage(Arg.Any<bool>());
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_Destroy()
+        {
+            // Given
+            var viewModel = Substitute.For<IEverything>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
+            await sut.PushPage(viewModel);
+            await sut.PushPage(viewModel);
+
+            // When
+            await sut.PopPage(navigationParameter);
+
+            // Then
+            viewModel.Received(1).Destroy();
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Not_Call_When_Navigated_To()
+        {
+            // Given
+            var firstViewModel = Substitute.For<INavigable>();
+            var secondViewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
+
+            // When
+            await sut.PushPage(firstViewModel);
+            await sut.PushPage(secondViewModel);
+            await sut.PopPage(navigationParameter);
+
+            // Then
+            await secondViewModel.DidNotReceive().WhenNavigatedTo(navigationParameter);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_When_Navigated_To()
+        {
+            // Given
+            var firstViewModel = Substitute.For<INavigable>();
+            var secondViewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
+
+            // When
+            await sut.PushPage(firstViewModel, navigationParameter);
+            await sut.PushPage(secondViewModel);
+            await sut.PopPage(navigationParameter);
+
+            // Then
+            await firstViewModel.Received(2).WhenNavigatedTo(Arg.Any<INavigationParameter>());
+            await secondViewModel.Received().WhenNavigatedFrom(navigationParameter);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_When_Navigated_From()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            var sut = new ParameterViewStackServiceFixture().WithPushed(viewModel);
+
+            // When
+            await sut.PopPage(navigationParameter);
+
+            // Then
+            await viewModel.Received().WhenNavigatedFrom(navigationParameter);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Not_Call_When_Navigating_To()
+        {
+            // Given
+            var viewModel = Substitute.For<INavigable>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            var sut = new ParameterViewStackServiceFixture().WithPushed(viewModel);
+
+            // When
+            await sut.PopPage(navigationParameter);
+
+            // Then
+            await viewModel.DidNotReceive().WhenNavigatingTo(navigationParameter);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_In_Order()
+        {
+            // Given
+            var viewModel1 = Substitute.For<IEverything>();
+            var viewModel2 = Substitute.For<IEverything>();
+            var subject = new Subject<IViewModel>();
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            var view = Substitute.For<IView>();
+
+            view.When(x => x.PopPage())
+                .Do(_ => subject.OnNext(viewModel2));
+            view
+                .PagePopped
+                .Returns(subject.AsObservable());
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+            await sut.PushPage(viewModel1);
+            await sut.PushPage(viewModel2);
+
+            // When
+            await sut.PopPage(navigationParameter);
+
+            // Then
+            Received.InOrder(() =>
             {
-                // Given
-                var viewModel = Substitute.For<IEverything>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
-                await sut.PushPage(viewModel);
-                await sut.PushPage(viewModel);
-
-                // When
-                await sut.PopPage(navigationParameter);
-
-                // Then
-                viewModel.Received(1).Destroy();
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Not_Call_When_Navigated_To()
-            {
-                // Given
-                var firstViewModel = Substitute.For<INavigable>();
-                var secondViewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
-
-                // When
-                await sut.PushPage(firstViewModel);
-                await sut.PushPage(secondViewModel);
-                await sut.PopPage(navigationParameter);
-
-                // Then
-                await secondViewModel.DidNotReceive().WhenNavigatedTo(navigationParameter);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_When_Navigated_To()
-            {
-                // Given
-                var firstViewModel = Substitute.For<INavigable>();
-                var secondViewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(new NavigationViewMock());
-
-                // When
-                await sut.PushPage(firstViewModel, navigationParameter);
-                await sut.PushPage(secondViewModel);
-                await sut.PopPage(navigationParameter);
-
-                // Then
-                await firstViewModel.Received(2).WhenNavigatedTo(Arg.Any<INavigationParameter>());
-                await secondViewModel.Received().WhenNavigatedFrom(navigationParameter);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_When_Navigated_From()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                var sut = new ParameterViewStackServiceFixture().WithPushed(viewModel);
-
-                // When
-                await sut.PopPage(navigationParameter);
-
-                // Then
-                await viewModel.Received().WhenNavigatedFrom(navigationParameter);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Not_Call_When_Navigating_To()
-            {
-                // Given
-                var viewModel = Substitute.For<INavigable>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                var sut = new ParameterViewStackServiceFixture().WithPushed(viewModel);
-
-                // When
-                await sut.PopPage(navigationParameter);
-
-                // Then
-                await viewModel.DidNotReceive().WhenNavigatingTo(navigationParameter);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_In_Order()
-            {
-                // Given
-                var viewModel1 = Substitute.For<IEverything>();
-                var viewModel2 = Substitute.For<IEverything>();
-                var subject = new Subject<IViewModel>();
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                var view = Substitute.For<IView>();
-
-                view.When(x => x.PopPage())
-                    .Do(_ => subject.OnNext(viewModel2));
-                view
-                    .PagePopped
-                    .Returns(subject.AsObservable());
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-                await sut.PushPage(viewModel1);
-                await sut.PushPage(viewModel2);
-
-                // When
-                await sut.PopPage(navigationParameter);
-
-                // Then
-                Received.InOrder(() =>
-                {
-                    view.PopPage(Arg.Any<bool>());
-                    viewModel2.WhenNavigatedFrom(Arg.Any<INavigationParameter>());
-                    viewModel2.Destroy();
-                });
-            }
+                view.PopPage(Arg.Any<bool>());
+                viewModel2.WhenNavigatedFrom(Arg.Any<INavigationParameter>());
+                viewModel2.Destroy();
+            });
         }
     }
 }

--- a/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceFixture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -9,34 +9,33 @@ using NSubstitute;
 using ReactiveUI.Testing;
 using Sextant.Mocks;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// A fixture for the view stack.
+/// </summary>
+internal sealed class ViewStackServiceFixture : IBuilder
 {
+    private IView _view;
+    private IViewModelFactory _viewModelFactory;
+
     /// <summary>
-    /// A fixture for the view stack.
+    /// Initializes a new instance of the <see cref="ViewStackServiceFixture"/> class.
     /// </summary>
-    internal sealed class ViewStackServiceFixture : IBuilder
+    public ViewStackServiceFixture()
     {
-        private IView _view;
-        private IViewModelFactory _viewModelFactory;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ViewStackServiceFixture"/> class.
-        /// </summary>
-        public ViewStackServiceFixture()
-        {
-            _view = Substitute.For<IView>();
-            _view.PushPage(Arg.Any<IViewModel>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>()).Returns(Observable.Return(Unit.Default));
-            _viewModelFactory = Substitute.For<IViewModelFactory>();
-            _viewModelFactory.Create<NavigableViewModelMock>(Arg.Any<string>()).Returns(new NavigableViewModelMock());
-        }
-
-        public static implicit operator ViewStackService(ViewStackServiceFixture fixture) => fixture.Build();
-
-        public ViewStackServiceFixture WithView(IView view) => this.With(out _view, view);
-
-        public ViewStackServiceFixture WithFactory(IViewModelFactory viewModelFactory) =>
-            this.With(out _viewModelFactory, viewModelFactory);
-
-        private ViewStackService Build() => new(_view, _viewModelFactory);
+        _view = Substitute.For<IView>();
+        _view.PushPage(Arg.Any<IViewModel>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>()).Returns(Observable.Return(Unit.Default));
+        _viewModelFactory = Substitute.For<IViewModelFactory>();
+        _viewModelFactory.Create<NavigableViewModelMock>(Arg.Any<string>()).Returns(new NavigableViewModelMock());
     }
+
+    public static implicit operator ViewStackService(ViewStackServiceFixture fixture) => fixture.Build();
+
+    public ViewStackServiceFixture WithView(IView view) => this.With(out _view, view);
+
+    public ViewStackServiceFixture WithFactory(IViewModelFactory viewModelFactory) =>
+        this.With(out _viewModelFactory, viewModelFactory);
+
+    private ViewStackService Build() => new(_view, _viewModelFactory);
 }

--- a/src/Sextant.Tests/Navigation/ViewStackServiceFixtureExtensions.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceFixtureExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -7,51 +7,50 @@ using System;
 using System.Reactive;
 using System.Reactive.Linq;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Extension methods to help us with the ViewStackService.
+/// </summary>
+internal static class ViewStackServiceFixtureExtensions
 {
-    /// <summary>
-    /// Extension methods to help us with the ViewStackService.
-    /// </summary>
-    internal static class ViewStackServiceFixtureExtensions
+    public static IObservable<Unit> PopModal(this ViewStackService viewStackService, int pages = 1)
     {
-        public static IObservable<Unit> PopModal(this ViewStackService viewStackService, int pages = 1)
+        for (var i = 0; i < pages; i++)
         {
-            for (var i = 0; i < pages; i++)
-            {
-                viewStackService.PopModal().Subscribe();
-            }
-
-            return Observable.Return(Unit.Default);
+            viewStackService.PopModal().Subscribe();
         }
 
-        public static IObservable<Unit> PopPage(this ViewStackService viewStackService, int pages = 1)
-        {
-            for (var i = 0; i < pages; i++)
-            {
-                viewStackService.PopPage().Subscribe();
-            }
+        return Observable.Return(Unit.Default);
+    }
 
-            return Observable.Return(Unit.Default);
+    public static IObservable<Unit> PopPage(this ViewStackService viewStackService, int pages = 1)
+    {
+        for (var i = 0; i < pages; i++)
+        {
+            viewStackService.PopPage().Subscribe();
         }
 
-        public static IObservable<Unit> PushModal(this ViewStackService viewStackService, IViewModel viewModel, string? contract = null, int pages = 1)
-        {
-            for (var i = 0; i < pages; i++)
-            {
-                viewStackService.PushModal(viewModel, contract).Subscribe();
-            }
+        return Observable.Return(Unit.Default);
+    }
 
-            return Observable.Return(Unit.Default);
+    public static IObservable<Unit> PushModal(this ViewStackService viewStackService, IViewModel viewModel, string? contract = null, int pages = 1)
+    {
+        for (var i = 0; i < pages; i++)
+        {
+            viewStackService.PushModal(viewModel, contract).Subscribe();
         }
 
-        public static IObservable<Unit> PushPage(this ViewStackService viewStackService, INavigable viewModel, string? contract = null, int pages = 1)
-        {
-            for (var i = 0; i < pages; i++)
-            {
-                viewStackService.PushPage(viewModel, contract).Subscribe();
-            }
+        return Observable.Return(Unit.Default);
+    }
 
-            return Observable.Return(Unit.Default);
+    public static IObservable<Unit> PushPage(this ViewStackService viewStackService, INavigable viewModel, string? contract = null, int pages = 1)
+    {
+        for (var i = 0; i < pages; i++)
+        {
+            viewStackService.PushPage(viewModel, contract).Subscribe();
         }
+
+        return Observable.Return(Unit.Default);
     }
 }

--- a/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
+++ b/src/Sextant.Tests/Navigation/ViewStackServiceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -11,966 +11,995 @@ using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
+using ReactiveUI;
 using Sextant.Mocks;
 using Splat;
 using Xunit;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Tests that check to make sure that the view stack works correctly.
+/// </summary>
+public sealed class ViewStackServiceTests
 {
     /// <summary>
-    /// Tests that check to make sure that the view stack works correctly.
+    /// Tests the construction of the object.
     /// </summary>
-    public sealed class ViewStackServiceTests
+    public class TheConstructor
     {
         /// <summary>
-        /// Tests the construction of the object.
+        /// Initializes a new instance of the <see cref="TheConstructor"/> class.
         /// </summary>
-        public class TheConstructor
+        public TheConstructor() => Locator.GetLocator().UnregisterAll<IViewModelFactory>();
+
+        /// <summary>
+        /// Test that the object constructed uses a new instance of ViewModelFactory.
+        /// </summary>
+        [Fact]
+        public void Should_Not_Throw_If_View_Model_Factory_Current_Null()
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="TheConstructor"/> class.
-            /// </summary>
-            public TheConstructor() => Locator.GetLocator().UnregisterAll<IViewModelFactory>();
+            // Given, When
+            var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null!));
 
-            /// <summary>
-            /// Test that the object constructed uses a new instance of ViewModelFactory.
-            /// </summary>
-            [Fact]
-            public void Should_Not_Throw_If_View_Model_Factory_Current_Null()
-            {
-                // Given, When
-                var result = Record.Exception(() => new ParameterViewStackServiceFixture().WithFactory(null!));
-
-                // Then
-                result.Should().BeNull();
-            }
-
-            /// <summary>
-            /// Test that the object constructed uses the static instance of ViewModelFactory.
-            /// </summary>
-            [Fact]
-            public void Should_Resolve_View_Model_Factory()
-            {
-                // Given
-                Locator.CurrentMutable.RegisterViewModelFactory();
-
-                // When
-                var result = Record.Exception(() => (ViewStackService)new ViewStackServiceFixture().WithFactory(null!));
-
-                // Then
-                result.Should().BeNull();
-            }
+            // Then
+            result.Should().BeNull();
         }
 
         /// <summary>
-        /// Tests associated with the page stack property.
+        /// Test that the object constructed uses the static instance of ViewModelFactory.
         /// </summary>
-        public class ThePageStackProperty
+        [Fact]
+        public void Should_Resolve_View_Model_Factory()
         {
-            /// <summary>
-            /// Tests to verify the return value is an observable type.
-            /// </summary>
-            [Fact]
-            public void Should_Return_Observable()
-            {
-                // Given, When
-                ViewStackService sut = new ViewStackServiceFixture();
+            // Given
+            Locator.CurrentMutable.RegisterViewModelFactory();
 
-                // Then
-                sut.PageStack.Should().NotBeOfType<BehaviorSubject<IImmutableList<IViewModel>>>();
-            }
+            // When
+            var result = Record.Exception(() => (ViewStackService)new ViewStackServiceFixture().WithFactory(null!));
 
-            /// <summary>
-            /// Tests to verify the return value is not a subject type.
-            /// </summary>
-            [Fact]
-            public void Should_Not_Return_Behavior()
-            {
-                // Given, When
-                ViewStackService sut = new ViewStackServiceFixture();
+            // Then
+            result.Should().BeNull();
+        }
+    }
 
-                // Then
-                sut.PageStack.Should().NotBeOfType<BehaviorSubject<IImmutableList<IViewModel>>>();
-            }
+    /// <summary>
+    /// Tests associated with the page stack property.
+    /// </summary>
+    public class ThePageStackProperty
+    {
+        /// <summary>
+        /// Tests to verify the return value is an observable type.
+        /// </summary>
+        [Fact]
+        public void Should_Return_Observable()
+        {
+            // Given, When
+            ViewStackService sut = new ViewStackServiceFixture();
+
+            // Then
+            sut.PageStack.Should().NotBeOfType<BehaviorSubject<IImmutableList<IViewModel>>>();
         }
 
         /// <summary>
-        /// Tests associated with the modal stack property.
+        /// Tests to verify the return value is not a subject type.
         /// </summary>
-        public class TheModalStackProperty
+        [Fact]
+        public void Should_Not_Return_Behavior()
         {
-            /// <summary>
-            /// Tests to verify the return value is an observable type.
-            /// </summary>
-            [Fact]
-            public void Should_Return_Observable()
-            {
-                // Given, When
-                ViewStackService sut = new ViewStackServiceFixture();
+            // Given, When
+            ViewStackService sut = new ViewStackServiceFixture();
 
-                // Then
-                sut.ModalStack.Should().NotBeOfType<BehaviorSubject<IImmutableList<IViewModel>>>();
-            }
+            // Then
+            sut.PageStack.Should().NotBeOfType<BehaviorSubject<IImmutableList<IViewModel>>>();
+        }
+    }
 
-            /// <summary>
-            /// Tests to verify the return value is not a subject type.
-            /// </summary>
-            [Fact]
-            public void Should_Not_Return_Behavior()
-            {
-                // Given, When
-                ViewStackService sut = new ViewStackServiceFixture();
+    /// <summary>
+    /// Tests associated with the modal stack property.
+    /// </summary>
+    public class TheModalStackProperty
+    {
+        /// <summary>
+        /// Tests to verify the return value is an observable type.
+        /// </summary>
+        [Fact]
+        public void Should_Return_Observable()
+        {
+            // Given, When
+            ViewStackService sut = new ViewStackServiceFixture();
 
-                // Then
-                sut.ModalStack.Should().NotBeOfType<BehaviorSubject<IImmutableList<IViewModel>>>();
-            }
+            // Then
+            sut.ModalStack.Should().NotBeOfType<BehaviorSubject<IImmutableList<IViewModel>>>();
         }
 
         /// <summary>
-        /// Tests associated with the pop model methods.
+        /// Tests to verify the return value is not a subject type.
         /// </summary>
-        public class ThePopModalMethod
+        [Fact]
+        public void Should_Not_Return_Behavior()
         {
-            /// <summary>
-            /// Checks to make sure that the pop modal method works correctly.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Pop_Modal()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushModal(new NavigableViewModelMock());
+            // Given, When
+            ViewStackService sut = new ViewStackServiceFixture();
 
-                // When
-                var item = await sut.ModalStack.FirstAsync();
-                item.Count.Should().Be(1);
-                await sut.PopModal();
+            // Then
+            sut.ModalStack.Should().NotBeOfType<BehaviorSubject<IImmutableList<IViewModel>>>();
+        }
+    }
 
-                // Then
-                item = await sut.ModalStack.FirstAsync();
-                item.Should().BeEmpty();
-            }
+    /// <summary>
+    /// Tests associated with the pop model methods.
+    /// </summary>
+    public class ThePopModalMethod
+    {
+        /// <summary>
+        /// Checks to make sure that the pop modal method works correctly.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Pop_Modal()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushModal(new NavigableViewModelMock());
 
-            /// <summary>
-            /// Checks to make sure that the pop modal observables are received.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Receive_Pop_Modal()
-            {
-                // Given, When
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushModal(new NavigableViewModelMock());
+            // When
+            var item = await sut.ModalStack.FirstAsync();
+            item.Count.Should().Be(1);
+            await sut.PopModal();
 
-                // When
-                await sut.PopModal();
-
-                // Then
-                await sut.View.Received().PopModal();
-            }
-
-            /// <summary>
-            /// Checks to make sure that the pop returns a <see cref="Unit"/>.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Return_Unit()
-            {
-                // Given, When
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushModal(new NavigableViewModelMock());
-
-                // When
-                var result = await sut.PopModal();
-
-                // Then
-                result.Should().BeOfType<Unit>();
-            }
-
-            /// <summary>
-            /// Checks to make sure that there is a exception thrown if the stack happens to be empty.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_Stack_Empty()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-
-                // When
-                var result = await Record.ExceptionAsync(async () => await sut.PopModal()).ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<InvalidOperationException>();
-                result?.Message.Should().Be("Stack is empty.");
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_Destroy()
-            {
-                // Given
-                var viewModel = Substitute.For<IEverything>();
-                var view = Substitute.For<IView>();
-                var sut = new ParameterViewStackServiceFixture().WithView(view).WithModal(viewModel);
-
-                // When
-                await sut.PopModal();
-
-                // Then
-                viewModel.Received(1).Destroy();
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_In_Order()
-            {
-                // Given
-                var viewModel1 = Substitute.For<IEverything>();
-                var viewModel2 = Substitute.For<IEverything>();
-                var subject = new Subject<IViewModel>();
-                var view = Substitute.For<IView>();
-
-                view.When(x => x.PopPage())
-                    .Do(_ => subject.OnNext(viewModel2));
-                view
-                    .PagePopped
-                    .Returns(subject.AsObservable());
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-                await sut.PushModal(viewModel1);
-                await sut.PushModal(viewModel2);
-
-                // When
-                await sut.PopModal();
-
-                // Then
-                Received.InOrder(() =>
-                {
-                    view.PopModal();
-                    viewModel2.Destroy();
-                });
-            }
+            // Then
+            item = await sut.ModalStack.FirstAsync();
+            item.Should().BeEmpty();
         }
 
         /// <summary>
-        /// Tests associated with the pop page methods.
+        /// Checks to make sure that the pop modal observables are received.
         /// </summary>
-        public class ThePopPageMethod
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Receive_Pop_Modal()
         {
-            /// <summary>
-            /// Checks to make sure that the pop page works.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Pop_Page()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture().WithView(new NavigationViewMock());
-                await sut.PushPage(new NavigableViewModelMock());
+            // Given, When
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushModal(new NavigableViewModelMock());
 
-                // When
-                await sut.PopPage();
-                var result = await sut.PageStack.FirstAsync();
+            // When
+            await sut.PopModal();
 
-                // Then
-                result.Should().BeEmpty();
-            }
-
-            /// <summary>
-            /// Checks to make sure that the pop page observables are received.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Receive_Pop_Page()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushPage(new NavigableViewModelMock());
-
-                // When
-                await sut.PopPage();
-
-                // Then
-                await sut.View.Received().PopPage();
-            }
-
-            /// <summary>
-            /// Checks to make sure that the pop returns a <see cref="Unit"/>.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Return_Unit()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushPage(new NavigableViewModelMock());
-
-                // When
-                var result = await sut.PopPage();
-
-                // Then
-                result.Should().BeOfType<Unit>();
-            }
-
-            /// <summary>
-            /// Tests to make sure we destroy the view model.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_Destroy()
-            {
-                // Given
-                var viewModel1 = Substitute.For<IEverything>();
-                var viewModel2 = Substitute.For<IEverything>();
-                var view = new NavigationViewMock();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-                await sut.PushPage(viewModel1);
-                await sut.PushPage(viewModel2);
-
-                // When
-                await sut.PopPage();
-
-                // Then
-                viewModel2.Received(1).Destroy();
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a event notifications in order.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_In_Order()
-            {
-                // Given
-                var viewModel1 = Substitute.For<IEverything>();
-                var viewModel2 = Substitute.For<IEverything>();
-                var subject = new Subject<IViewModel>();
-                var view = Substitute.For<IView>();
-
-                view.When(x => x.PopPage())
-                    .Do(_ => subject.OnNext(viewModel2));
-                view
-                    .PagePopped
-                    .Returns(subject.AsObservable());
-
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-                await sut.PushPage(viewModel1);
-                await sut.PushPage(viewModel2);
-
-                // When
-                await sut.PopPage();
-
-                // Then
-                Received.InOrder(() =>
-                {
-                    view.PopPage();
-                    viewModel2.Destroy();
-                });
-            }
+            // Then
+            await sut.View.Received().PopModal();
         }
 
         /// <summary>
-        /// Tests for the pop to root method.
+        /// Checks to make sure that the pop returns a <see cref="Unit"/>.
         /// </summary>
-        public class ThePopToRootPageMethod
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Return_Unit()
         {
-            /// <summary>
-            /// Tests to verify that no exception is thrown if the stack happens to be empty.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_Stack_Empty()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
+            // Given, When
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushModal(new NavigableViewModelMock());
 
-                // When
-                var result = await Record.ExceptionAsync(async () => await sut.PopToRootPage()).ConfigureAwait(true);
+            // When
+            var result = await sut.PopModal();
 
-                // Then
-                result.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("Stack is empty.");
-            }
-
-            /// <summary>
-            /// Tests to verify the navigation stack is cleared.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Clear_Navigation_Stack()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushPage(new NavigableViewModelMock(), pages: 3);
-
-                // When
-                await sut.PopToRootPage();
-                var result = await sut.PageStack.FirstOrDefaultAsync();
-
-                // Then
-                result.Should().ContainSingle();
-            }
-
-            /// <summary>
-            /// Tests to verify the navigation stack is cleared.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Return_Single_Notification()
-            {
-                // Given
-                var count = 0;
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushPage(new NavigableViewModelMock(), pages: 3);
-
-                sut.View.PagePopped.Subscribe(_ => count++);
-
-                // When
-                await sut.PopToRootPage();
-
-                // Then
-                count.Should().Be(1);
-            }
-
-            /// <summary>
-            /// Tests to verify the navigation stack has an element left.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Have_One_Item_On_Stack()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushPage(new NavigableViewModelMock(), pages: 3);
-                await sut.PopToRootPage();
-
-                // When
-                var result = await sut.PageStack.FirstOrDefaultAsync();
-
-                // Then
-                result.Should().ContainSingle();
-            }
-
-            /// <summary>
-            /// Tests to make sure we destroy the view model.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_Destroy()
-            {
-                // Given
-                var viewModel1 = Substitute.For<IEverything>();
-                var viewModel2 = Substitute.For<IEverything>();
-                var viewModel3 = Substitute.For<IEverything>();
-                var view = Substitute.For<IView>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-                await sut.PushPage(viewModel1);
-                await sut.PushPage(viewModel2);
-                await sut.PushPage(viewModel3);
-
-                // When
-                await sut.PopToRootPage();
-
-                // Then
-                Received.InOrder(() =>
-                {
-                    viewModel3.Destroy();
-                    viewModel2.Destroy();
-                });
-            }
+            // Then
+            result.Should().BeOfType<Unit>();
         }
 
         /// <summary>
-        /// Tests for the push modal method.
+        /// Checks to make sure that there is a exception thrown if the stack happens to be empty.
         /// </summary>
-        public class ThePushModalMethod
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_Stack_Empty()
         {
-            /// <summary>
-            /// Makes sure that the push and pop methods work correctly.
-            /// </summary>
-            /// <param name="amount">The number of pages.</param>
-            /// <returns>A completion notification.</returns>
-            [Theory]
-            [InlineData(1)]
-            [InlineData(3)]
-            [InlineData(5)]
-            public async Task Should_Push_And_Pop(int amount)
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushModal(new NavigableViewModelMock(), "modal", amount);
-                sut.ModalStack.FirstAsync().Wait().Count.Should().Be(amount);
-                await sut.PopModal(amount);
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
 
-                // When
-                var result = await sut.ModalStack.FirstAsync();
+            // When
+            var result = await Record.ExceptionAsync(async () => await sut.PopModal()).ConfigureAwait(true);
 
-                // Then
-                result.Should().BeEmpty();
-            }
-
-            /// <summary>
-            /// Tests to make sure that the push modal works.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Push_Modal()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushModal(new NavigableViewModelMock());
-
-                // When
-                var result = await sut.TopModal();
-
-                // Then
-                result.Should().NotBeNull();
-                result.Should().BeOfType<NavigableViewModelMock>();
-            }
-
-            /// <summary>
-            /// Tests to make sure that the push modal respects navigation.
-            /// </summary>
-            /// <param name="withNavigationPage">Whether to use a navigation page.</param>
-            /// <returns>A completion notification.</returns>
-            [Theory]
-            [InlineData(true)]
-            [InlineData(false)]
-            public async Task Should_Push_Modal_Navigation_Page(bool withNavigationPage)
-            {
-                // Given
-                var view = Substitute.For<IView>();
-                ViewStackService sut = new ViewStackServiceFixture().WithView(view);
-
-                // When
-                await sut.PushModal(new NavigableViewModelMock(), withNavigationPage: withNavigationPage);
-
-                // Then
-                await view.Received().PushModal(Arg.Any<INavigable>(), Arg.Any<string>(), withNavigationPage);
-            }
-
-            /// <summary>
-            /// Tests to make sure we can push a page onto the stack.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Push_Page_On_Stack()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-
-                // When
-                await sut.PushModal(new NavigableViewModelMock(), "modal");
-                var result = await sut.ModalStack.FirstAsync();
-
-                // Then
-                result.Should().NotBeEmpty();
-                result.Count.Should().Be(1);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive an push modal notifications.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Receive_Push_Modal()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
-
-                // When
-                await sut.PushModal(new NavigableViewModelMock(), "modal");
-
-                // Then
-                await sut.View.Received().PushModal(Arg.Any<IViewModel>(), "modal");
-            }
-
-            /// <summary>
-            /// Tests to make sure that we get an exception throw if we pass in a null view model.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_View_Model_Null()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-
-                // When
-                var result = await Record.ExceptionAsync(async () => await sut.PushModal(null!)).ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>();
-            }
+            // Then
+            result.Should().BeOfType<InvalidOperationException>();
+            result?.Message.Should().Be("Stack is empty.");
         }
 
         /// <summary>
-        /// Tests the push modal page method that passes parameters.
+        /// Tests to make sure we receive a push page notification.
         /// </summary>
-        public class ThePushModalGenericMethod
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_Destroy()
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ThePushModalGenericMethod"/> class.
-            /// </summary>
-            public ThePushModalGenericMethod()
-            {
-                Locator.CurrentMutable.Register(() => new DefaultViewModelFactory(), typeof(IViewModelFactory));
-                Locator.CurrentMutable.Register(() => new NavigableViewModelMock());
-                Locator.CurrentMutable.UnregisterAll<NullViewModelMock>();
-            }
+            // Given
+            var viewModel = Substitute.For<IEverything>();
+            var view = Substitute.For<IView>();
+            var sut = new ParameterViewStackServiceFixture().WithView(view).WithModal(viewModel);
 
-            /// <summary>
-            /// Should the throw if view model null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_View_Model_Null()
-            {
-                // Given
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+            // When
+            await sut.PopModal();
 
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushModal<NullViewModelMock>())
-                        .ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("modal");
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_View()
-            {
-                // Given
-                var view = Substitute.For<IView>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-
-                // When
-                await sut.PushModal<NavigableViewModelMock>();
-
-                // Then
-                await view.Received().PushModal(Arg.Any<NavigableViewModelMock>(), Arg.Any<string>(), Arg.Any<bool>());
-            }
-
-            /// <summary>
-            /// Tests that the ViewModelFactory is called.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_ViewModel_Factory()
-            {
-                // Given
-                var factory = Substitute.For<IViewModelFactory>();
-                factory.Create<NavigableViewModelMock>(Arg.Any<string?>()).Returns(new NavigableViewModelMock());
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                var sut = new ParameterViewStackServiceFixture().WithFactory(factory);
-
-                // When
-                await sut.PushModal<NavigableViewModelMock>(navigationParameter);
-
-                // Then
-                factory.Received().Create<NavigableViewModelMock>();
-            }
+            // Then
+            viewModel.Received(1).Destroy();
         }
 
         /// <summary>
-        /// Tests associated with the push page method.
+        /// Tests to make sure we receive a push page notification.
         /// </summary>
-        public class ThePushPageMethod
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_In_Order()
         {
-            /// <summary>
-            /// Tests to make sure that we get an exception throw if we pass in a null view model.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_View_Model_Null()
+            // Given
+            var viewModel1 = Substitute.For<IEverything>();
+            var viewModel2 = Substitute.For<IEverything>();
+            var subject = new Subject<IViewModel>();
+            var view = Substitute.For<IView>();
+
+            view.When(x => x.PopPage())
+                .Do(_ => subject.OnNext(viewModel2));
+            view
+                .PagePopped
+                .Returns(subject.AsObservable());
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+            await sut.PushModal(viewModel1);
+            await sut.PushModal(viewModel2);
+
+            // When
+            await sut.PopModal();
+
+            // Then
+            Received.InOrder(() =>
             {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
+                view.PopModal();
+                viewModel2.Destroy();
+            });
+        }
+    }
 
-                // When
-                var result = await Record.ExceptionAsync(async () => await sut.PushPage(null!)).ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("viewModel");
-            }
-
-            /// <summary>
-            /// Tests to make sure that the push page works.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Push_Page()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-
-                // When
-                await sut.PushPage(new NavigableViewModelMock());
-                var result = await sut.TopPage();
-
-                // Then
-                result.Should().NotBeNull();
-                result.Should().BeOfType<NavigableViewModelMock>();
-            }
-
-            /// <summary>
-            /// Tests to make sure we can push a page onto the stack.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Push_Page_On_Stack()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-
-                // When
-                await sut.PushPage(new NavigableViewModelMock());
-                var result = await sut.PageStack.FirstAsync();
-
-                // Then
-                result.Should().NotBeEmpty();
-                result.Count.Should().Be(1);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive an push page notifications.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Receive_Push_Page()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
-
-                // When
-                await sut.PushPage(new NavigableViewModelMock());
-
-                // Then
-                await sut.View.Received().PushPage(Arg.Any<IViewModel>(), null, false);
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive an push page notifications.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Clear_Navigation_Stack_If_Reset()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
-
-                // When
-                await sut.PushPage(new NavigableViewModelMock(), pages: 3);
-                await sut.PushPage(new NavigableViewModelMock(), resetStack: true);
-                var result = await sut.PageStack.FirstOrDefaultAsync();
-
-                // Then
-                result.Should().ContainSingle();
-            }
+    /// <summary>
+    /// Tests associated with the pop page methods.
+    /// </summary>
+    public class ThePopPageMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThePopPageMethod"/> class.
+        /// </summary>
+        public ThePopPageMethod()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
         }
 
         /// <summary>
-        /// Tests the push page generic method that passes parameters.
+        /// Checks to make sure that the pop page works.
         /// </summary>
-        public class ThePushPageGenericWithParameterMethod
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Pop_Page()
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ThePushPageGenericWithParameterMethod"/> class.
-            /// </summary>
-            public ThePushPageGenericWithParameterMethod()
-            {
-                Locator.CurrentMutable.Register(() => new DefaultViewModelFactory(), typeof(IViewModelFactory));
-                Locator.CurrentMutable.Register(() => new NavigableViewModelMock());
-            }
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture().WithView(new NavigationViewMock());
+            await sut.PushPage(new NavigableViewModelMock());
 
-            /// <summary>
-            /// Should the throw if view model is null.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_View_Model_Null()
-            {
-                // Given
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+            // When
+            await sut.PopPage();
+            var result = await sut.PageStack.FirstAsync();
 
-                // When
-                var result =
-                    await Record.ExceptionAsync(async () => await sut.PushPage<NullViewModelMock>())
-                        .ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("viewModel");
-            }
-
-            /// <summary>
-            /// Tests to make sure we receive a push page notification.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_View()
-            {
-                // Given
-                var view = Substitute.For<IView>();
-                ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
-
-                // When
-                await sut.PushPage<NavigableViewModelMock>();
-
-                // Then
-                await view.Received().PushPage(Arg.Any<NavigableViewModelMock>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>());
-            }
-
-            /// <summary>
-            /// Tests the view model factory is called.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Call_ViewModel_Factory()
-            {
-                // Given
-                var factory = Substitute.For<IViewModelFactory>();
-                factory.Create<NavigableViewModelMock>(Arg.Any<string?>()).Returns(new NavigableViewModelMock());
-                var navigationParameter = Substitute.For<INavigationParameter>();
-                var sut = new ParameterViewStackServiceFixture().WithFactory(factory);
-
-                // When
-                await sut.PushPage<NavigableViewModelMock>(navigationParameter);
-
-                // Then
-                factory.Received().Create<NavigableViewModelMock>();
-            }
+            // Then
+            result.Should().BeEmpty();
         }
 
         /// <summary>
-        /// Tests for the TopModal method.
+        /// Checks to make sure that the pop page observables are received.
         /// </summary>
-        public class TheTopModalMethod
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Receive_Pop_Page()
         {
-            /// <summary>
-            /// Tests to make sure that it does not pop the stack.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Not_Pop()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
-                await sut.PushModal(new NavigableViewModelMock());
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushPage(new NavigableViewModelMock());
 
-                // When
-                await sut.TopModal();
+            // When
+            await sut.PopPage();
 
-                // Then
-                await sut.View.DidNotReceive().PopModal();
-            }
-
-            /// <summary>
-            /// Tests to make sure that it returns the last element only.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Return_Last_Element()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushModal(new NavigableViewModelMock("1"));
-                await sut.PushModal(new NavigableViewModelMock("2"));
-
-                // When
-                var result = await sut.TopModal();
-
-                // Then
-                result.Should().BeOfType<NavigableViewModelMock>();
-                result.Id.Should().Be("2");
-            }
-
-            /// <summary>
-            /// Tests to make sure it throws an exception if the stack is empty.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_Stack_Empty()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-
-                // When
-                var result = await Record.ExceptionAsync(async () => await sut.TopModal()).ConfigureAwait(true);
-
-                // Then
-                result.Should().BeOfType<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("index");
-            }
+            // Then
+            await sut.View.Received().PopPage();
         }
 
         /// <summary>
-        /// Tests for the TopPage method.
+        /// Checks to make sure that the pop returns a <see cref="Unit"/>.
         /// </summary>
-        public class TheTopPageMethod
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Return_Unit()
         {
-            /// <summary>
-            /// Tests to make sure that it does not pop the stack.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Not_Pop()
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushPage(new NavigableViewModelMock());
+
+            // When
+            var result = await sut.PopPage();
+
+            // Then
+            result.Should().BeOfType<Unit>();
+        }
+
+        /// <summary>
+        /// Tests to make sure we destroy the view model.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_Destroy()
+        {
+            // Given
+            var viewModel1 = Substitute.For<IEverything>();
+            var viewModel2 = Substitute.For<IEverything>();
+            var view = new NavigationViewMock();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+            await sut.PushPage(viewModel1);
+            await sut.PushPage(viewModel2);
+
+            // When
+            await sut.PopPage();
+
+            // Then
+            viewModel2.Received(1).Destroy();
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a event notifications in order.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_In_Order()
+        {
+            // Given
+            var viewModel1 = Substitute.For<IEverything>();
+            var viewModel2 = Substitute.For<IEverything>();
+            var subject = new Subject<IViewModel>();
+            var view = Substitute.For<IView>();
+
+            view.When(x => x.PopPage())
+                .Do(_ => subject.OnNext(viewModel2));
+            view
+                .PagePopped
+                .Returns(subject.AsObservable());
+
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+            await sut.PushPage(viewModel1);
+            await sut.PushPage(viewModel2);
+
+            // When
+            await sut.PopPage();
+
+            // Then
+            Received.InOrder(() =>
             {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
-                await sut.PushPage(new NavigableViewModelMock());
+                view.PopPage();
+                viewModel2.Destroy();
+            });
+        }
+    }
 
-                // When
-                await sut.TopPage();
+    /// <summary>
+    /// Tests for the pop to root method.
+    /// </summary>
+    public class ThePopToRootPageMethod
+    {
+        /// <summary>
+        /// Tests to verify that no exception is thrown if the stack happens to be empty.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_Stack_Empty()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
 
-                // Then
-                await sut.View.DidNotReceive().PopPage();
-            }
+            // When
+            var result = await Record.ExceptionAsync(async () => await sut.PopToRootPage()).ConfigureAwait(true);
 
-            /// <summary>
-            /// Tests to make sure that it returns the last element only.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Return_Last_Element()
+            // Then
+            result.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("Stack is empty.");
+        }
+
+        /// <summary>
+        /// Tests to verify the navigation stack is cleared.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Clear_Navigation_Stack()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushPage(new NavigableViewModelMock(), pages: 3);
+
+            // When
+            await sut.PopToRootPage();
+            var result = await sut.PageStack.FirstOrDefaultAsync();
+
+            // Then
+            result.Should().ContainSingle();
+        }
+
+        /// <summary>
+        /// Tests to verify the navigation stack is cleared.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Return_Single_Notification()
+        {
+            // Given
+            var count = 0;
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushPage(new NavigableViewModelMock(), pages: 3);
+
+            sut.View.PagePopped.Subscribe(_ => count++);
+
+            // When
+            await sut.PopToRootPage();
+
+            // Then
+            count.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Tests to verify the navigation stack has an element left.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Have_One_Item_On_Stack()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushPage(new NavigableViewModelMock(), pages: 3);
+            await sut.PopToRootPage();
+
+            // When
+            var result = await sut.PageStack.FirstOrDefaultAsync();
+
+            // Then
+            result.Should().ContainSingle();
+        }
+
+        /// <summary>
+        /// Tests to make sure we destroy the view model.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_Destroy()
+        {
+            // Given
+            var viewModel1 = Substitute.For<IEverything>();
+            var viewModel2 = Substitute.For<IEverything>();
+            var viewModel3 = Substitute.For<IEverything>();
+            var view = Substitute.For<IView>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+            await sut.PushPage(viewModel1);
+            await sut.PushPage(viewModel2);
+            await sut.PushPage(viewModel3);
+
+            // When
+            await sut.PopToRootPage();
+
+            // Then
+            Received.InOrder(() =>
             {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
-                await sut.PushPage(new NavigableViewModelMock("1"));
-                await sut.PushPage(new NavigableViewModelMock("2"));
+                viewModel3.Destroy();
+                viewModel2.Destroy();
+            });
+        }
+    }
 
-                // When
-                var result = await sut.TopPage();
+    /// <summary>
+    /// Tests for the push modal method.
+    /// </summary>
+    public class ThePushModalMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThePushModalMethod"/> class.
+        /// </summary>
+        public ThePushModalMethod()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
+        }
 
-                // Then
-                result.Should().BeOfType<NavigableViewModelMock>();
-                result.Id.Should().Be("2");
-            }
+        /// <summary>
+        /// Makes sure that the push and pop methods work correctly.
+        /// </summary>
+        /// <param name="amount">The number of pages.</param>
+        /// <returns>A completion notification.</returns>
+        [Theory]
+        [InlineData(1)]
+        [InlineData(3)]
+        [InlineData(5)]
+        public async Task Should_Push_And_Pop(int amount)
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushModal(new NavigableViewModelMock(), "modal", amount);
+            sut.ModalStack.FirstAsync().Wait().Count.Should().Be(amount);
+            await sut.PopModal(amount);
 
-            /// <summary>
-            /// Tests to make sure it throws an exception if the stack is empty.
-            /// </summary>
-            /// <returns>A completion notification.</returns>
-            [Fact]
-            public async Task Should_Throw_If_Stack_Empty()
-            {
-                // Given
-                ViewStackService sut = new ViewStackServiceFixture();
+            // When
+            var result = await sut.ModalStack.FirstAsync();
 
-                // When
-                var result = await Record.ExceptionAsync(async () => await sut.TopPage()).ConfigureAwait(true);
+            // Then
+            result.Should().BeEmpty();
+        }
 
-                // Then
-                result.Should().BeOfType<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("index");
-            }
+        /// <summary>
+        /// Tests to make sure that the push modal works.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Push_Modal()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushModal(new NavigableViewModelMock());
+
+            // When
+            var result = await sut.TopModal();
+
+            // Then
+            result.Should().NotBeNull();
+            result.Should().BeOfType<NavigableViewModelMock>();
+        }
+
+        /// <summary>
+        /// Tests to make sure that the push modal respects navigation.
+        /// </summary>
+        /// <param name="withNavigationPage">Whether to use a navigation page.</param>
+        /// <returns>A completion notification.</returns>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Should_Push_Modal_Navigation_Page(bool withNavigationPage)
+        {
+            // Given
+            var view = Substitute.For<IView>();
+            ViewStackService sut = new ViewStackServiceFixture().WithView(view);
+
+            // When
+            await sut.PushModal(new NavigableViewModelMock(), withNavigationPage: withNavigationPage);
+
+            // Then
+            await view.Received().PushModal(Arg.Any<INavigable>(), Arg.Any<string>(), withNavigationPage);
+        }
+
+        /// <summary>
+        /// Tests to make sure we can push a page onto the stack.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Push_Page_On_Stack()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+
+            // When
+            await sut.PushModal(new NavigableViewModelMock(), "modal");
+            var result = await sut.ModalStack.FirstAsync();
+
+            // Then
+            result.Should().NotBeEmpty();
+            result.Count.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive an push modal notifications.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Receive_Push_Modal()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
+
+            // When
+            await sut.PushModal(new NavigableViewModelMock(), "modal");
+
+            // Then
+            await sut.View.Received().PushModal(Arg.Any<IViewModel>(), "modal");
+        }
+
+        /// <summary>
+        /// Tests to make sure that we get an exception throw if we pass in a null view model.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_View_Model_Null()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+
+            // When
+            var result = await Record.ExceptionAsync(async () => await sut.PushModal(null!)).ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>();
+        }
+    }
+
+    /// <summary>
+    /// Tests the push modal page method that passes parameters.
+    /// </summary>
+    public class ThePushModalGenericMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThePushModalGenericMethod"/> class.
+        /// </summary>
+        public ThePushModalGenericMethod()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
+            Locator.CurrentMutable.Register(() => new DefaultViewModelFactory(), typeof(IViewModelFactory));
+            Locator.CurrentMutable.Register(() => new NavigableViewModelMock());
+            Locator.CurrentMutable.UnregisterAll<NullViewModelMock>();
+        }
+
+        /// <summary>
+        /// Should the throw if view model null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_View_Model_Null()
+        {
+            // Given
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushModal<NullViewModelMock>())
+                    .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("modal");
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_View()
+        {
+            // Given
+            var view = Substitute.For<IView>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+
+            // When
+            await sut.PushModal<NavigableViewModelMock>();
+
+            // Then
+            await view.Received().PushModal(Arg.Any<NavigableViewModelMock>(), Arg.Any<string>(), Arg.Any<bool>());
+        }
+
+        /// <summary>
+        /// Tests that the ViewModelFactory is called.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_ViewModel_Factory()
+        {
+            // Given
+            var factory = Substitute.For<IViewModelFactory>();
+            factory.Create<NavigableViewModelMock>(Arg.Any<string?>()).Returns(new NavigableViewModelMock());
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            var sut = new ParameterViewStackServiceFixture().WithFactory(factory);
+
+            // When
+            await sut.PushModal<NavigableViewModelMock>(navigationParameter);
+
+            // Then
+            factory.Received().Create<NavigableViewModelMock>();
+        }
+    }
+
+    /// <summary>
+    /// Tests associated with the push page method.
+    /// </summary>
+    public class ThePushPageMethod
+    {
+        /// <summary>
+        /// Tests to make sure that we get an exception throw if we pass in a null view model.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_View_Model_Null()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+
+            // When
+            var result = await Record.ExceptionAsync(async () => await sut.PushPage(null!)).ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("viewModel");
+        }
+
+        /// <summary>
+        /// Tests to make sure that the push page works.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Push_Page()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+
+            // When
+            await sut.PushPage(new NavigableViewModelMock());
+            var result = await sut.TopPage();
+
+            // Then
+            result.Should().NotBeNull();
+            result.Should().BeOfType<NavigableViewModelMock>();
+        }
+
+        /// <summary>
+        /// Tests to make sure we can push a page onto the stack.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Push_Page_On_Stack()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+
+            // When
+            await sut.PushPage(new NavigableViewModelMock());
+            var result = await sut.PageStack.FirstAsync();
+
+            // Then
+            result.Should().NotBeEmpty();
+            result.Count.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive an push page notifications.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Receive_Push_Page()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
+
+            // When
+            await sut.PushPage(new NavigableViewModelMock());
+
+            // Then
+            await sut.View.Received().PushPage(Arg.Any<IViewModel>(), null, false);
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive an push page notifications.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Clear_Navigation_Stack_If_Reset()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
+
+            // When
+            await sut.PushPage(new NavigableViewModelMock(), pages: 3);
+            await sut.PushPage(new NavigableViewModelMock(), resetStack: true);
+            var result = await sut.PageStack.FirstOrDefaultAsync();
+
+            // Then
+            result.Should().ContainSingle();
+        }
+    }
+
+    /// <summary>
+    /// Tests the push page generic method that passes parameters.
+    /// </summary>
+    public class ThePushPageGenericWithParameterMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThePushPageGenericWithParameterMethod"/> class.
+        /// </summary>
+        public ThePushPageGenericWithParameterMethod()
+        {
+            Locator.CurrentMutable.Register(() => new DefaultViewModelFactory(), typeof(IViewModelFactory));
+            Locator.CurrentMutable.Register(() => new NavigableViewModelMock());
+        }
+
+        /// <summary>
+        /// Should the throw if view model is null.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_View_Model_Null()
+        {
+            // Given
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture();
+
+            // When
+            var result =
+                await Record.ExceptionAsync(async () => await sut.PushPage<NullViewModelMock>())
+                    .ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentNullException>().Which.ParamName.Should().Be("viewModel");
+        }
+
+        /// <summary>
+        /// Tests to make sure we receive a push page notification.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_View()
+        {
+            // Given
+            var view = Substitute.For<IView>();
+            ParameterViewStackService sut = new ParameterViewStackServiceFixture().WithView(view);
+
+            // When
+            await sut.PushPage<NavigableViewModelMock>();
+
+            // Then
+            await view.Received().PushPage(Arg.Any<NavigableViewModelMock>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>());
+        }
+
+        /// <summary>
+        /// Tests the view model factory is called.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Call_ViewModel_Factory()
+        {
+            // Given
+            var factory = Substitute.For<IViewModelFactory>();
+            factory.Create<NavigableViewModelMock>(Arg.Any<string?>()).Returns(new NavigableViewModelMock());
+            var navigationParameter = Substitute.For<INavigationParameter>();
+            var sut = new ParameterViewStackServiceFixture().WithFactory(factory);
+
+            // When
+            await sut.PushPage<NavigableViewModelMock>(navigationParameter);
+
+            // Then
+            factory.Received().Create<NavigableViewModelMock>();
+        }
+    }
+
+    /// <summary>
+    /// Tests for the TopModal method.
+    /// </summary>
+    public class TheTopModalMethod
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TheTopModalMethod"/> class.
+        /// </summary>
+        public TheTopModalMethod()
+        {
+            Locator.CurrentMutable.InitializeSplat();
+            Locator.CurrentMutable.InitializeReactiveUI();
+        }
+
+        /// <summary>
+        /// Tests to make sure that it does not pop the stack.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Not_Pop()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
+            await sut.PushModal(new NavigableViewModelMock());
+
+            // When
+            await sut.TopModal();
+
+            // Then
+            await sut.View.DidNotReceive().PopModal();
+        }
+
+        /// <summary>
+        /// Tests to make sure that it returns the last element only.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Return_Last_Element()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushModal(new NavigableViewModelMock("1"));
+            await sut.PushModal(new NavigableViewModelMock("2"));
+
+            // When
+            var result = await sut.TopModal();
+
+            // Then
+            result.Should().BeOfType<NavigableViewModelMock>();
+            result.Id.Should().Be("2");
+        }
+
+        /// <summary>
+        /// Tests to make sure it throws an exception if the stack is empty.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_Stack_Empty()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+
+            // When
+            var result = await Record.ExceptionAsync(async () => await sut.TopModal()).ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("index");
+        }
+    }
+
+    /// <summary>
+    /// Tests for the TopPage method.
+    /// </summary>
+    public class TheTopPageMethod
+    {
+        /// <summary>
+        /// Tests to make sure that it does not pop the stack.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Not_Pop()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture().WithView(Substitute.For<IView>());
+            await sut.PushPage(new NavigableViewModelMock());
+
+            // When
+            await sut.TopPage();
+
+            // Then
+            await sut.View.DidNotReceive().PopPage();
+        }
+
+        /// <summary>
+        /// Tests to make sure that it returns the last element only.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Return_Last_Element()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+            await sut.PushPage(new NavigableViewModelMock("1"));
+            await sut.PushPage(new NavigableViewModelMock("2"));
+
+            // When
+            var result = await sut.TopPage();
+
+            // Then
+            result.Should().BeOfType<NavigableViewModelMock>();
+            result.Id.Should().Be("2");
+        }
+
+        /// <summary>
+        /// Tests to make sure it throws an exception if the stack is empty.
+        /// </summary>
+        /// <returns>A completion notification.</returns>
+        [Fact]
+        public async Task Should_Throw_If_Stack_Empty()
+        {
+            // Given
+            ViewStackService sut = new ViewStackServiceFixture();
+
+            // When
+            var result = await Record.ExceptionAsync(async () => await sut.TopPage()).ConfigureAwait(true);
+
+            // Then
+            result.Should().BeOfType<ArgumentOutOfRangeException>().Which.ParamName.Should().Be("index");
         }
     }
 }

--- a/src/Sextant.Tests/Sextant.Tests.csproj
+++ b/src/Sextant.Tests/Sextant.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>    
     <Nullable>enable</Nullable>    

--- a/src/Sextant.Tests/ViewModelFactoryTests.cs
+++ b/src/Sextant.Tests/ViewModelFactoryTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -7,50 +7,49 @@ using FluentAssertions;
 using Splat;
 using Xunit;
 
-namespace Sextant.Tests
+namespace Sextant.Tests;
+
+/// <summary>
+/// Tests the <see cref="ViewModelFactory"/>.
+/// </summary>
+public sealed class ViewModelFactoryTests
 {
     /// <summary>
-    /// Tests the <see cref="ViewModelFactory"/>.
+    /// Tests the currently registered view model factory parameter.
     /// </summary>
-    public sealed class ViewModelFactoryTests
+    public class CurrentPropertyTests
     {
         /// <summary>
-        /// Tests the currently registered view model factory parameter.
+        /// Initializes a new instance of the <see cref="CurrentPropertyTests"/> class.
         /// </summary>
-        public class CurrentPropertyTests
+        public CurrentPropertyTests() => Locator.CurrentMutable.UnregisterAll<IViewModelFactory>();
+
+        /// <summary>
+        /// Should throw if the IViewFactory is not registered.
+        /// </summary>
+        [Fact]
+        public void Should_Throw_If_Not_Registered()
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="CurrentPropertyTests"/> class.
-            /// </summary>
-            public CurrentPropertyTests() => Locator.CurrentMutable.UnregisterAll<IViewModelFactory>();
+            // Given, When
+            var result = Record.Exception(() => ViewModelFactory.Current);
 
-            /// <summary>
-            /// Should throw if the IViewFactory is not registered.
-            /// </summary>
-            [Fact]
-            public void Should_Throw_If_Not_Registered()
-            {
-                // Given, When
-                var result = Record.Exception(() => ViewModelFactory.Current);
+            // Then
+            result.Should().BeOfType<ViewModelFactoryNotFoundException>().Which.Message.Should().Be("Could not find a default ViewModelFactory. This should never happen, your dependency resolver is broken");
+        }
 
-                // Then
-                result.Should().BeOfType<ViewModelFactoryNotFoundException>().Which.Message.Should().Be("Could not find a default ViewModelFactory. This should never happen, your dependency resolver is broken");
-            }
+        /// <summary>
+        /// Should return the default view model factory.
+        /// </summary>
+        [Fact]
+        public void Should_Return_View_Model_Factory()
+        {
+            // Given, When
+            Locator.CurrentMutable.Register(() => new DefaultViewModelFactory(), typeof(IViewModelFactory));
+            var viewModelFactory = ViewModelFactory.Current;
 
-            /// <summary>
-            /// Should return the default view model factory.
-            /// </summary>
-            [Fact]
-            public void Should_Return_View_Model_Factory()
-            {
-                // Given, When
-                Locator.CurrentMutable.Register(() => new DefaultViewModelFactory(), typeof(IViewModelFactory));
-                var viewModelFactory = ViewModelFactory.Current;
-
-                // Then
-                viewModelFactory.Should().BeAssignableTo<IViewModelFactory>();
-                viewModelFactory.Should().BeOfType<DefaultViewModelFactory>();
-            }
+            // Then
+            viewModelFactory.Should().BeAssignableTo<IViewModelFactory>();
+            viewModelFactory.Should().BeOfType<DefaultViewModelFactory>();
         }
     }
 }

--- a/src/Sextant/Abstractions/IDestructible.cs
+++ b/src/Sextant/Abstractions/IDestructible.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Abstractions/INavigable.cs
+++ b/src/Sextant/Abstractions/INavigable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Abstractions/INavigated.cs
+++ b/src/Sextant/Abstractions/INavigated.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Abstractions/INavigating.cs
+++ b/src/Sextant/Abstractions/INavigating.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Abstractions/INavigationParameter.cs
+++ b/src/Sextant/Abstractions/INavigationParameter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Abstractions/IParameterViewStackService.cs
+++ b/src/Sextant/Abstractions/IParameterViewStackService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Abstractions/IView.cs
+++ b/src/Sextant/Abstractions/IView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Abstractions/IViewModel.cs
+++ b/src/Sextant/Abstractions/IViewModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Abstractions/IViewModelFactory.cs
+++ b/src/Sextant/Abstractions/IViewModelFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Abstractions/IViewStackService.cs
+++ b/src/Sextant/Abstractions/IViewStackService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/DefaultViewModelFactory.cs
+++ b/src/Sextant/DefaultViewModelFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -17,7 +17,7 @@ public class DefaultViewModelFactory : IViewModelFactory
     public TViewModel Create<TViewModel>(string? contract = null)
         where TViewModel : IViewModel
     {
-        var viewModel = Locator.Current.GetService<TViewModel>(contract);
+        var viewModel = AppLocator.Current.GetService<TViewModel>(contract);
         return viewModel switch
         {
             null => throw new InvalidOperationException($"ViewModel of type {typeof(TViewModel).Name} {contract} not registered."),

--- a/src/Sextant/DependencyResolverMixins.cs
+++ b/src/Sextant/DependencyResolverMixins.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -34,8 +34,8 @@ public static class DependencyResolverMixins
 
         dependencyResolver.RegisterLazySingleton<IViewStackService>(
             () => new ParameterViewStackService(
-                Locator.Current.GetService<IView>(NavigationView) ?? throw new InvalidOperationException("IView not registered."),
-                Locator.Current.GetService<IViewModelFactory>() ?? new DefaultViewModelFactory()));
+                AppLocator.Current.GetService<IView>(NavigationView) ?? throw new InvalidOperationException("IView not registered."),
+                AppLocator.Current.GetService<IViewModelFactory>() ?? new DefaultViewModelFactory()));
         return dependencyResolver;
     }
 
@@ -53,8 +53,8 @@ public static class DependencyResolverMixins
 
         dependencyResolver.RegisterLazySingleton<IParameterViewStackService>(
             () => new ParameterViewStackService(
-                Locator.Current.GetService<IView>(NavigationView) ?? throw new InvalidOperationException("IView not registered."),
-                Locator.Current.GetService<IViewModelFactory>() ?? new DefaultViewModelFactory()));
+                AppLocator.Current.GetService<IView>(NavigationView) ?? throw new InvalidOperationException("IView not registered."),
+                AppLocator.Current.GetService<IViewModelFactory>() ?? new DefaultViewModelFactory()));
         return dependencyResolver;
     }
 
@@ -80,7 +80,7 @@ public static class DependencyResolverMixins
         }
 
         dependencyResolver.RegisterLazySingleton(() => factory(
-            Locator.Current.GetService<IView>(NavigationView) ?? throw new InvalidOperationException("IView not registered.")));
+            AppLocator.Current.GetService<IView>(NavigationView) ?? throw new InvalidOperationException("IView not registered.")));
         return dependencyResolver;
     }
 
@@ -105,8 +105,8 @@ public static class DependencyResolverMixins
         }
 
         dependencyResolver.RegisterLazySingleton(() => factory(
-            Locator.Current.GetService<IView>(NavigationView) ?? throw new InvalidOperationException("IView not registered."),
-            Locator.Current.GetService<IViewModelFactory>() ?? new DefaultViewModelFactory()));
+            AppLocator.Current.GetService<IView>(NavigationView) ?? throw new InvalidOperationException("IView not registered."),
+            AppLocator.Current.GetService<IViewModelFactory>() ?? new DefaultViewModelFactory()));
         return dependencyResolver;
     }
 

--- a/src/Sextant/Navigation/NavigationParameter.cs
+++ b/src/Sextant/Navigation/NavigationParameter.cs
@@ -1,11 +1,10 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Sextant;
 

--- a/src/Sextant/Navigation/ParameterViewStackService.cs
+++ b/src/Sextant/Navigation/ParameterViewStackService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Navigation/ParameterViewStackServiceBase.cs
+++ b/src/Sextant/Navigation/ParameterViewStackServiceBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Navigation/ViewModelActionExtensions.cs
+++ b/src/Sextant/Navigation/ViewModelActionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Navigation/ViewStackService.cs
+++ b/src/Sextant/Navigation/ViewStackService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Navigation/ViewStackServiceBase.cs
+++ b/src/Sextant/Navigation/ViewStackServiceBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Platforms/android/SextantExtensions.cs
+++ b/src/Sextant/Platforms/android/SextantExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Platforms/mac/SextantExtensions.cs
+++ b/src/Sextant/Platforms/mac/SextantExtensions.cs
@@ -1,13 +1,9 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Reactive.Concurrency;
-using System.Text;
-using Splat;
 
 namespace Sextant;
 

--- a/src/Sextant/Platforms/net/SextantExtensions.cs
+++ b/src/Sextant/Platforms/net/SextantExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Platforms/net4/SextantExtensions.cs
+++ b/src/Sextant/Platforms/net4/SextantExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Platforms/netstandard2.0/SextantExtensions.cs
+++ b/src/Sextant/Platforms/netstandard2.0/SextantExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Platforms/uikit-common/NavigationViewController.cs
+++ b/src/Sextant/Platforms/uikit-common/NavigationViewController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Platforms/uikit-common/SextantExtensions.cs
+++ b/src/Sextant/Platforms/uikit-common/SextantExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/Sextant.cs
+++ b/src/Sextant/Sextant.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -18,9 +18,9 @@ public class Sextant
     private static readonly Lazy<Sextant> _sextant = new();
 
     static Sextant() =>
-        Locator.RegisterResolverCallbackChanged(() =>
+        AppLocator.RegisterResolverCallbackChanged(() =>
         {
-            if (Locator.CurrentMutable is null)
+            if (AppLocator.CurrentMutable is null)
             {
                 return;
             }
@@ -37,5 +37,5 @@ public class Sextant
     /// Gets the mutable dependency resolver.
     /// </summary>
     [SuppressMessage("Design", "CA1822: Implement statically", Justification = "Existing API.")]
-    public IMutableDependencyResolver MutableLocator => Locator.CurrentMutable;
+    public IMutableDependencyResolver MutableLocator => AppLocator.CurrentMutable;
 }

--- a/src/Sextant/Sextant.csproj
+++ b/src/Sextant/Sextant.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net8.0-android;net8.0-ios;net8.0-tvos;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;net6.0-windows10.0.17763.0;net8.0-windows10.0.17763.0;net6.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net9.0-android;net9.0-ios;net9.0-tvos;net9.0-macos;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0;net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</TargetFrameworks>
     <RootNamespace>Sextant</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -44,7 +44,7 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard2.0')) ">
     <Compile Include="Platforms\netstandard2.0\**\*.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net8.0' or $(TargetFramework.EndsWith('-windows10.0.17763.0')) or $(TargetFramework.EndsWith('-windows10.0.19041.0'))  ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or $(TargetFramework.EndsWith('-windows10.0.17763.0')) or $(TargetFramework.EndsWith('-windows10.0.19041.0'))  ">
     <Compile Include="Platforms\net\**\*.cs" />
   </ItemGroup>
 </Project>

--- a/src/Sextant/System/Reactive/Linq/SubscribeSafeExtensions.cs
+++ b/src/Sextant/System/Reactive/Linq/SubscribeSafeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -34,7 +34,7 @@ public static class SubscribeSafeExtensions
                 _ => { },
                 ex =>
                 {
-                    var logger = new DefaultLogManager().GetLogger(typeof(SubscribeSafeExtensions));
+                    var logger = new DefaultLogManager(AppLocator.Current).GetLogger(typeof(SubscribeSafeExtensions));
                     logger.Error(ex, "An exception went unhandled. Caller member name: '{0}', caller file path: '{1}', caller line number: {2}.", callerMemberName, callerFilePath, callerLineNumber);
 
                     Debugger.Break();

--- a/src/Sextant/System/Reactive/Linq/ToSignalExtension.cs
+++ b/src/Sextant/System/Reactive/Linq/ToSignalExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/System/Reactive/Linq/WhereNotNullExtension.cs
+++ b/src/Sextant/System/Reactive/Linq/WhereNotNullExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Sextant/ViewModelFactory.cs
+++ b/src/Sextant/ViewModelFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
@@ -25,7 +25,7 @@ public static class ViewModelFactory
     {
         get
         {
-            var locator = Locator.Current.GetService<IViewModelFactory>();
+            var locator = AppLocator.Current.GetService<IViewModelFactory>();
             return locator switch
             {
                 null => throw new ViewModelFactoryNotFoundException("Could not find a default ViewModelFactory. This should never happen, your dependency resolver is broken"),

--- a/src/Sextant/ViewModelFactoryNotFoundException.cs
+++ b/src/Sextant/ViewModelFactoryNotFoundException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -13,7 +13,7 @@
             "documentPrivateFields": false,
             "documentationCulture": "en-US",
             "companyName": ".NET Foundation and Contributors",
-            "copyrightText": "Copyright (c) 2021 {companyName}. All rights reserved.\nLicensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
+            "copyrightText": "Copyright (c) 2025 {companyName}. All rights reserved.\nLicensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
             "variables": {
                 "licenseName": "MIT",
                 "licenseFile": "LICENSE"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0",
+  "version": "4.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main", // we release out of master
     "^refs/heads/rel/\\d+\\.\\d+\\.\\d+" // we also release branches starting with rel/N.N.N


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

Updated copyright headers to 2025 across all source files. Refactored code to use file-scoped namespaces and modern C# syntax. Changed target frameworks to net9.0 in Sextant.Avalonia and Sextant.Maui projects. Updated package versions in Directory.Packages.props and added new compiler warnings suppression. Improved code consistency and formatting in mocks and Avalonia navigation classes.

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

